### PR TITLE
pull in the original GNU copyright notice from readline

### DIFF
--- a/cmdline/cmdline_afp.c
+++ b/cmdline/cmdline_afp.c
@@ -1,6 +1,27 @@
 /*
+	Copyright (C) 1987-2002 Free Software Foundation, Inc.
 	portions Copyright (C) 2007 Alex deVries
 
+	This is based on readline's fileman.c example, which is very useful.
+    The original fileman.c carries the following notice:
+
+    This file is part of the GNU Readline Library, a library for
+    reading lines of text with interactive input and history editing.
+
+    The GNU Readline Library is free software; you can redistribute it
+    and/or modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2, or
+    (at your option) any later version.
+
+    The GNU Readline Library is distributed in the hope that it will be
+    useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+    of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    The GNU General Public License is often shipped with GNU software, and
+    is generally kept in a file called COPYING or LICENSE.  If you do not
+    have a copy of the license, write to the Free Software Foundation,
+    59 Temple Place, Suite 330, Boston, MA 02111 USA.
 */
 
 #include "afp.h"

--- a/cmdline/cmdline_main.c
+++ b/cmdline/cmdline_main.c
@@ -2,8 +2,26 @@
 	Copyright (C) 1987-2002 Free Software Foundation, Inc.
 	portions Copyright (C) 2007 Alex deVries
 
-	This is based on readline's filemap.c example, which is very useful.
+	This is based on readline's fileman.c example, which is very useful.
+    The original fileman.c carries the following notice:
 
+    This file is part of the GNU Readline Library, a library for
+    reading lines of text with interactive input and history editing.
+
+    The GNU Readline Library is free software; you can redistribute it
+    and/or modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2, or
+    (at your option) any later version.
+
+    The GNU Readline Library is distributed in the hope that it will be
+    useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+    of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    The GNU General Public License is often shipped with GNU software, and
+    is generally kept in a file called COPYING or LICENSE.  If you do not
+    have a copy of the license, write to the Free Software Foundation,
+    59 Temple Place, Suite 330, Boston, MA 02111 USA.
 */
 
 #include <pthread.h>


### PR DESCRIPTION
The afpcmd source code is based on GNU readline. As per the GNU GPL v2, the original license notices should be kept intact (clause 1). This brings back the notice to both source files which have traces of the original examples/fileman.c

Using readline 5.2 as the baseline since this was contemporaneous with afpcmd getting added to revision control in commit 9fa5892 on Sep 7, 2007

ftp://ftp.gnu.org/gnu/readline/readline-5.2.tar.gz