### PR TITLE
afpcmd: improve error reporting and handling

### DIFF
--- a/cmdline/cmdline_afp.c
+++ b/cmdline/cmdline_afp.c
@@ -1039,7 +1039,7 @@ int com_copy(char * arg)
     }
 
     /* Create destination file with default permissions */
-    ret = ml_creat(vol, full_to_path, 0600);
+    ret = ml_creat(vol, full_to_path, 0660);
 
     if (ret != 0) {
         printf("Could not create destination file \"%s\" with AFP: %s\n",


### PR DESCRIPTION
- map error codes to human readable strings with strerror()
- better error handling in the cd command 
- shore up error handling in mv, put and touch commands
- make copied files group-rw for a more reasonable default