### PR TITLE
support fuse3 in the AFP FUSE client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,8 +87,8 @@ jobs:
       - name: Uninstall
         run: sudo ninja -C build uninstall
 
-  build-ubuntu:
-    name: Ubuntu
+  build-ubuntu-fuse2:
+    name: Ubuntu (with FUSE v2)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
@@ -104,7 +104,38 @@ jobs:
             libreadline-dev \
             libncurses-dev \
             meson \
-            ninja-build
+            ninja-build \
+            pkg-config
+      - name: Setup
+        run: meson setup build --prefix=/usr
+      - name: Compile
+        run: meson compile -C build
+      - name: Install
+        run: sudo meson install -C build
+      - name: Run
+        run: afpcmd -h
+      - name: Uninstall
+        run: sudo ninja -C build uninstall
+
+  build-ubuntu-fuse3:
+    name: Ubuntu (with FUSE v3)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --assume-yes --no-install-recommends \
+            cmark-gfm \
+            gcc \
+            libgcrypt-dev \
+            libfuse3-dev \
+            libgmp-dev \
+            libreadline-dev \
+            libncurses-dev \
+            meson \
+            ninja-build \
+            pkg-config
       - name: Setup
         run: meson setup build --prefix=/usr
       - name: Compile
@@ -143,8 +174,8 @@ jobs:
       - name: Uninstall
         run: sudo ninja -C build uninstall
 
-  build-freebsd:
-    name: FreeBSD
+  build-freebsd-fuse2:
+    name: FreeBSD (with FUSE v2)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -152,13 +183,45 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
       - name: Build on VM
-        uses: vmactions/freebsd-vm@0cd283ca698d48b59cda444a9948f48a30709627 # v1.2.8
+        uses: vmactions/freebsd-vm@1885b78bae4c4c4b331b4b0461d23cc14cc72387 # v1.2.9
+        with:
+          copyback: false
+          prepare: |
+            pkg remove -y fusefs-libs3
+            pkg install -y \
+              cmark \
+              fusefs-libs \
+              gmp \
+              libedit \
+              libgcrypt \
+              libiconv \
+              meson \
+              pkgconf
+          run: |
+            set -e
+            meson setup build \
+              -Dpkg_config_path=/usr/local/libdata/pkgconfig
+            meson compile -C build
+            meson install -C build
+            afpcmd -h
+            ninja -C build uninstall
+
+  build-freebsd-fuse3:
+    name: FreeBSD (with FUSE v3)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+      - name: Build on VM
+        uses: vmactions/freebsd-vm@1885b78bae4c4c4b331b4b0461d23cc14cc72387 # v1.2.9
         with:
           copyback: false
           prepare: |
             pkg install -y \
               cmark \
-              fusefs-libs \
+              fusefs-libs3 \
               gmp \
               libedit \
               libgcrypt \

--- a/TODO
+++ b/TODO
@@ -4,7 +4,6 @@ Things to be done shortly
 * more testing of the network code, especially in high latency/unstable
   network environments
 * full support for AFP 3.3 and 3.4
-* move to FUSE3 APIs
 
 Longer term improvements
 ========================

--- a/include/afp.h
+++ b/include/afp.h
@@ -108,6 +108,7 @@ struct afp_volume {
     unsigned short dtrefnum;
     char volpassword[AFP_VOLPASS_LEN];
     unsigned int extra_flags; /* This is an afpfs-ng specific field */
+    time_t mount_time; /* Time when the volume was mounted */
 
     /* Our directory ID cache */
     struct did_cache_entry *did_cache_base;

--- a/include/midlevel.h
+++ b/include/midlevel.h
@@ -1,6 +1,9 @@
 #ifndef __MIDLEVEL_H_
 #define __MIDLEVEL_H_
 
+#include <sys/time.h>
+#include <sys/types.h>
+#include <stdint.h>
 #include <utime.h>
 #include "afp.h"
 
@@ -43,6 +46,9 @@ int ml_chown(struct afp_volume * vol, const char * path,
              uid_t uid, gid_t gid);
 
 int ml_truncate(struct afp_volume * vol, const char * path, off_t offset);
+
+int ml_setfork_size(struct afp_volume * vol, unsigned short forkid,
+                    unsigned int resource, uint64_t size);
 
 int ml_utime(struct afp_volume * vol, const char * path,
              struct utimbuf * timebuf);

--- a/lib/debug.c
+++ b/lib/debug.c
@@ -1,3 +1,4 @@
+#include <stdio.h>
 
 /* AFP function names */
 static char *afp_command_names[] = {
@@ -59,5 +60,14 @@ static char *afp_command_names[] = {
 
 char *afp_get_command_name(unsigned char code)
 {
+    static const int array_size = sizeof(afp_command_names) / sizeof(
+                                      afp_command_names[0]);
+
+    if (code >= array_size) {
+        static char unknown_buf[32];
+        snprintf(unknown_buf, sizeof(unknown_buf), "Unknown %d", code);
+        return unknown_buf;
+    }
+
     return afp_command_names[code];
 }

--- a/lib/dsi.c
+++ b/lib/dsi.c
@@ -147,15 +147,15 @@ static int dsi_remove_from_request_queue(struct afp_server *server,
         struct dsi_request *toremove)
 {
     struct dsi_request *p, *prev = NULL;
-#ifdef DEBUG_DSI
-    printf("*** removing %d, %s\n", toremove->requestid,
-           afp_get_command_name(toremove->subcommand));
-#endif
 
     if (!server_still_valid(server)) {
         return -1;
     }
 
+#ifdef DEBUG_DSI
+    printf("*** removing %d, %s\n", toremove->requestid,
+           afp_get_command_name(toremove->subcommand));
+#endif
     pthread_mutex_lock(&server->request_queue_mutex);
 
     for (p = server->command_requests; p; p = p->next) {

--- a/lib/lowlevel.h
+++ b/lib/lowlevel.h
@@ -18,6 +18,9 @@ int ll_getattr(struct afp_volume * volume, const char *path, struct stat *stbuf,
 int ll_zero_file(struct afp_volume * volume, unsigned short forkid,
                  unsigned int resource);
 
+int ll_setfork_size(struct afp_volume * volume, unsigned short forkid,
+                    unsigned int resource, uint64_t size);
+
 int ll_read(struct afp_volume * volume,
             char *buf, size_t size, off_t offset,
             struct afp_file_info *fp, int *eof);

--- a/lib/resource.h
+++ b/lib/resource.h
@@ -8,6 +8,8 @@
 #define AFP_META_COMMENT 4
 #define AFP_META_SERVER_ICON 5
 
+#include <sys/time.h>
+#include <sys/types.h>
 #include <utime.h>
 
 int appledouble_creat(struct afp_volume * volume, const char * path,

--- a/lib/status.c
+++ b/lib/status.c
@@ -159,12 +159,15 @@ int afp_status_server(struct afp_server * s, char * text, int * len)
                     s->tx_quantum, s->rx_quantum,
                     s->lastrequestid, s->stats.requests_pending);
 
+    pthread_mutex_lock(&s->request_queue_mutex);
+
     for (request = s->command_requests; request; request = request->next) {
         pos += snprintf(text + pos, *len - pos,
                         "         request %d, %s\n",
                         request->requestid, afp_get_command_name(request->subcommand));
     }
 
+    pthread_mutex_unlock(&s->request_queue_mutex);
     pos += snprintf(text + pos, *len - pos,
                     "    transfer: %" PRIu64 "(rx) %" PRIu64 "(tx)\n"
                     "    runt packets: %" PRIu64 "\n",

--- a/meson.build
+++ b/meson.build
@@ -63,7 +63,10 @@ endif
 
 gcrypt_dep = dependency('libgcrypt', version: '>=1.2.3', required: false)
 libgmp_dep = dependency('gmp', required: false)
-fuse_dep = dependency('fuse', version: '==2.9.9', required: false)
+fuse_dep = dependency('fuse3', version: '>=3.0.0', required: false)
+if not fuse_dep.found()
+    fuse_dep = dependency('fuse', version: '>=2.9.0', required: false)
+endif
 
 cmark = find_program('cmark', required: false)
 cmarkgfm = find_program('cmark-gfm', required: false)
@@ -79,10 +82,80 @@ with_fuse = get_option('enable-fuse') and fuse_dep.found()
 with_crypt = gcrypt_dep.found() and libgmp_dep.found()
 
 if with_fuse
-    cflags += [
-        '-DHAVE_LIBFUSE',
-        '-DFUSE_USE_VERSION=29',
-    ]
+    fuse_version = fuse_dep.version()
+    if fuse_version.version_compare('>=3.0.0')
+        cflags += [
+            '-DHAVE_LIBFUSE',
+            '-DFUSE_USE_VERSION=35',
+        ]
+    else
+        cflags += [
+            '-DHAVE_LIBFUSE',
+            '-DFUSE_USE_VERSION=29',
+        ]
+    endif
+
+    # Detect FUSE capability: new readdir API with fuse_readdir_flags
+    # This tests if enum fuse_readdir_flags type exists (FUSE 3.3+)
+    fuse_readdir_flags_check = cc.compiles(
+        '''
+        #define FUSE_USE_VERSION 35
+        #include <fuse.h>
+        enum fuse_readdir_flags flags;
+    ''',
+        dependencies: fuse_dep,
+        name: 'FUSE enum fuse_readdir_flags',
+    )
+
+    # Detect FUSE capability: new function signatures with struct fuse_file_info *fi parameter
+    # This tests if a function with the new signature can be defined and used
+    fuse_file_info_ops_check = cc.compiles(
+        '''
+        #define FUSE_USE_VERSION 35
+        #include <fuse.h>
+
+        int chown_func(const char *path, uid_t uid, gid_t gid,
+                       struct fuse_file_info *fi) { return 0; }
+        int chmod_func(const char *path, mode_t mode,
+                       struct fuse_file_info *fi) { return 0; }
+        int truncate_func(const char *path, off_t offset,
+                          struct fuse_file_info *fi) { return 0; }
+    ''',
+        dependencies: fuse_dep,
+        name: 'FUSE new function signatures with file_info',
+    )
+
+    # Detect FUSE capability: new rename API with flags parameter
+    fuse_rename_flags_check = cc.compiles(
+        '''
+        #define FUSE_USE_VERSION 35
+        #include <fuse.h>
+        int rename_func(const char *from, const char *to,
+                        unsigned int flags) { return 0; }
+    ''',
+        dependencies: fuse_dep,
+        name: 'FUSE rename with flags parameter',
+    )
+
+    # Detect FUSE capability: new utimens API with file_info parameter
+    fuse_utimens_fi_check = cc.compiles(
+        '''
+        #define FUSE_USE_VERSION 35
+        #include <fuse.h>
+        int utimens_func(const char *path, const struct timespec tv[2],
+                         struct fuse_file_info *fi) { return 0; }
+    ''',
+        dependencies: fuse_dep,
+        name: 'FUSE utimens with file_info parameter',
+    )
+
+    # Define FUSE_NEW_API if we have the new API capabilities
+    # We consider it "new API" if all the new signatures are supported
+    if fuse_readdir_flags_check and fuse_file_info_ops_check and fuse_rename_flags_check and fuse_utimens_fi_check
+        cflags += '-DFUSE_NEW_API=1'
+    else
+        cflags += '-DFUSE_NEW_API=0'
+    endif
 endif
 
 incdir = include_directories(['.', 'include', include_dirs])


### PR DESCRIPTION
the build system will detect fuse 3.x first, and fall back to fuse 2.9

Overhaul of the FUSE client to enable FUSE v3 while maintaining support for v2.9.9

Implements a number of additional FUSE commands

In the mid and low layers, fixes a number of bugs and fills in missing gaps in file opening, creation, truncation, etc.

Makes the integration with macFUSE much nicer, with proper support for volume label and creation date