### PR TITLE
Client support for AFP 3.3 replay cache

### DIFF
--- a/include/afp.h
+++ b/include/afp.h
@@ -16,7 +16,7 @@
 #include "libafpclient.h"
 
 /* This is the maximum AFP version this library supports */
-#define AFP_MAX_SUPPORTED_VERSION 32
+#define AFP_MAX_SUPPORTED_VERSION 34
 
 typedef enum {TCPIP, AT} e_proto;
 
@@ -242,6 +242,10 @@ struct afp_server {
     unsigned short lastrequestid;
     unsigned short expectedrequestid;
     struct dsi_request *command_requests;
+
+    /* AFP 3.3+ Replay cache support */
+    unsigned int replay_cache_size;  /* Server's replay cache size */
+    unsigned char supports_replay_cache;  /* 1 if server supports replay cache */
 
 
     char loginmesg[200];

--- a/lib/dsi_protocol.h
+++ b/lib/dsi_protocol.h
@@ -15,7 +15,8 @@
 #define DSI_DSIWrite 6
 #define DSI_DSIAttention 8
 
-
+/* DSI Option types for DSIOpenSession */
+#define kServerReplayCacheSize 0x02
 
 struct dsi_header {
     uint8_t flags;


### PR DESCRIPTION
AFP 3.3 **mandates** support for the AFP Replay Cache mechanism, which ensures reliable operation across network interruptions and reconnections.

1. **Persistent Request IDs**: Request IDs are no longer reset to 0 on reconnection when the server supports replay cache. They wrap around from 65535 to 1 (avoiding 0).

2. **Server Capability Detection**: During `DSIOpenSession`, the client now parses the `kServerReplayCacheSize` option from the server's reply to detect replay cache support.

Note: No further modification to the client is required for AFP 3.4 since this only concerns the server side error handling