### PR TITLE
Use a per-mount afpfsd daemon process structure for all platforms

### DIFF
--- a/docs/manpages/afp_client.1.md
+++ b/docs/manpages/afp_client.1.md
@@ -22,8 +22,8 @@ The mount_afpfs(1) command is in fact a symlink to afp_client.
 When invoked with a fully formed AFP URL, it will execute a FUSE mount command.
 
 Multiple volumes can be mounted simultaneously on all supported platforms.
-Each mount request automatically starts or connects to the appropriate
-afpfsd daemon.
+Each mount request talks to a per-user manager daemon, which spawns a
+per-mount afpfsd daemon that owns that FUSE mount.
 
 # COMMANDS
 
@@ -62,6 +62,11 @@ connected server. Currently unsupported.
 > Resumes all suspended server connections. Currently unsupported. Enable
 or disable the **promiscuous** mode of the interface. If selected, all
 packets on the network will be received by the interface.
+
+**exit**
+
+> Stop all mounts owned by the current user and shut down the manager
+> daemon. Busy mounts may require a manual umount(8).
 
 # MOUNT FLAGS
 

--- a/docs/manpages/mount_afpfs.1.md
+++ b/docs/manpages/mount_afpfs.1.md
@@ -17,11 +17,9 @@ executable, which is a full implementation to mount AFP volumes using
 the FUSE infrastructure. It communicates with afpfsd, a daemon that
 manages AFP sessions.
 
-Multiple volumes can be mounted simultaneously.
-On most supported platforms,
-a single afpfsd daemon efficiently handles multiple mounts.
-On macOS, each mount uses its own daemon process
-to avoid signal handler conflicts with the macFUSE library.
+In order to mount multiple AFP volumes simultaneously, the afp_client(1)
+talks to a per-user manager daemon (afpfsd in manager mode), which
+spawns a dedicated afpfsd daemon for each mount request.
 
 The arguments and options are:
 

--- a/fuse/afp_server.h
+++ b/fuse/afp_server.h
@@ -1,6 +1,8 @@
 #ifndef _AFP_SERVER_H_
 #define _AFP_SERVER_H_
 
+#include <limits.h>
+
 #define SERVER_FILENAME "/tmp/afp_server"
 
 #define AFP_SERVER_COMMAND_MOUNT 1
@@ -10,6 +12,7 @@
 #define AFP_SERVER_COMMAND_RESUME 5
 #define AFP_SERVER_COMMAND_PING 6
 #define AFP_SERVER_COMMAND_EXIT 7
+#define AFP_SERVER_COMMAND_SPAWN_MOUNT 8
 
 #define AFP_SERVER_RESULT_OKAY 1
 #define AFP_SERVER_RESULT_ERROR 2
@@ -41,6 +44,11 @@ struct afp_server_mount_request {
 struct afp_server_status_request {
     char volumename[AFP_VOLUME_NAME_LEN];
     char servername[AFP_VOLUME_NAME_LEN];
+};
+
+struct afp_server_spawn_mount_request {
+    char mountpoint[255];
+    char socket_id[PATH_MAX];
 };
 
 struct afp_server_response {

--- a/fuse/commands.c
+++ b/fuse/commands.c
@@ -479,6 +479,8 @@ static unsigned char process_exit(struct fuse_client * c)
     log_for_client((void *)c, AFPFSD, LOG_INFO,
                    "Exiting\n");
     trigger_exit();
+    /* Wake the main loop so exit is processed immediately. */
+    signal_main_thread();
     return AFP_SERVER_RESULT_OKAY;
 }
 
@@ -560,7 +562,7 @@ static int process_mount(struct fuse_client * c)
         goto error;
     }
 
-    log_for_client((void *)c, AFPFSD, LOG_NOTICE,
+    log_for_client((void *)c, AFPFSD, LOG_DEBUG,
                    "Mounting %s from %s on %s\n",
                    (char *) req.url.volumename,
                    (char *) req.url.servername,

--- a/include/utils.h
+++ b/include/utils.h
@@ -44,6 +44,6 @@ char *create_path(struct afp_server * server, char * pathname,
 int invalid_filename(struct afp_server * server, const char * filename);
 
 void trigger_exit(void);
-void afp_set_per_mount_daemon_mode(int enabled);
+void afp_set_auto_shutdown_on_unmount(int enabled);
 
 #endif

--- a/lib/afp.c
+++ b/lib/afp.c
@@ -170,11 +170,11 @@ int afp_reply(unsigned short subcommand, struct afp_server * server,
 
 
 static struct afp_server *server_base = NULL;
-static int per_mount_daemon_mode = 0;
+static int auto_shutdown_on_unmount = 0;
 
-void afp_set_per_mount_daemon_mode(int enabled)
+void afp_set_auto_shutdown_on_unmount(int enabled)
 {
-    per_mount_daemon_mode = enabled;
+    auto_shutdown_on_unmount = enabled;
 }
 
 int server_still_valid(struct afp_server * server)
@@ -318,10 +318,9 @@ int afp_unmount_volume(struct afp_volume * volume)
     afp_logout(server, DSI_DONT_WAIT /* don't wait */);
     afp_server_remove(server);
 
-    /* In per-mount daemon mode, exit when last volume is unmounted */
-    if (per_mount_daemon_mode && get_server_base() == NULL) {
+    if (auto_shutdown_on_unmount && get_server_base() == NULL) {
         log_for_client(NULL, AFPFSD, LOG_NOTICE,
-                       "Last volume unmounted in per-mount mode, triggering shutdown\n");
+                       "Last volume unmounted, triggering shutdown\n");
         trigger_exit();
     }
 


### PR DESCRIPTION
introduce afpfsd manager mode and use multi-daemon mounts cross platform

properly shut down the per-mount afpfsd process when umounting