### PR TITLE
implement log level for the FUSE client

### DIFF
--- a/docs/manpages/afpfsd.1.md
+++ b/docs/manpages/afpfsd.1.md
@@ -25,6 +25,9 @@ manager, which coordinates the mount daemons.
 **-l|--logmethod** sets the method used to log; values are stdout or
 syslog
 
+**-v|--loglevel** sets the log verbosity level; values are debug, info,
+notice, warning, error
+
 **-f|--foreground** doesn't fork the daemon
 
 **-d|--debug** puts the daemon in the foreground and dumps logs to

--- a/fuse/client.c
+++ b/fuse/client.c
@@ -727,6 +727,11 @@ static int handle_mount_afp(int argc, char * argv[])
     outgoing_buffer[0] = AFP_SERVER_COMMAND_MOUNT;
     req->map = AFP_MAPPING_UNKNOWN;
 
+    if (mountpoint == NULL) {
+        printf("No mount point specified\n");
+        return -1;
+    }
+
     if (resolve_mountpoint(mountpoint, req->mountpoint, 255) < 0) {
         printf("Failed to resolve mount point\n");
         return -1;

--- a/fuse/commands.h
+++ b/fuse/commands.h
@@ -3,5 +3,6 @@
 
 int fuse_register_afpclient(void);
 void fuse_set_log_method(int new_method);
+void fuse_set_log_level(int loglevel);
 
 #endif

--- a/fuse/fuse_int.c
+++ b/fuse/fuse_int.c
@@ -72,8 +72,8 @@ static void stat_to_darwin_attr(const struct stat *st,
 }
 #endif
 
-void log_fuse_event(__attribute__((unused)) enum loglevels loglevel,
-                    __attribute__((unused)) int logtype,
+void log_fuse_event(__attribute__((unused)) enum logtypes logtype,
+                    __attribute__((unused)) int loglevel,
                     __attribute__((unused)) char *format, ...)
 {
 #ifdef LOG_FUSE_EVENTS

--- a/include/libafpclient.h
+++ b/include/libafpclient.h
@@ -9,7 +9,7 @@
 #define MAX_CLIENT_RESPONSE 2048
 
 
-enum loglevels {
+enum logtypes {
     AFPFSD,
 };
 
@@ -19,7 +19,7 @@ struct afp_volume;
 struct libafpclient {
     int (*unmount_volume)(struct afp_volume * volume);
     void (*log_for_client)(void * priv,
-                           enum loglevels loglevel, int logtype, const char *message);
+                           enum logtypes logtype, int loglevel, const char *message);
     void (*forced_ending_hook)(void);
     int (*scan_extra_fds)(int command_fd, fd_set *set, int * max_fd);
     void (*loop_started)(void);
@@ -42,9 +42,9 @@ void signal_main_thread(void);
 void set_log_method(int m);
 
 void log_for_client(void * priv,
-                    enum loglevels loglevel, int logtype, char *message, ...);
+                    enum logtypes logtype, int loglevel, char *message, ...);
 
 void stdout_log_for_client(void * priv,
-                           enum loglevels loglevel, int logtype, const char *message);
+                           enum logtypes logtype, int loglevel, const char *message);
 
 #endif

--- a/lib/log.c
+++ b/lib/log.c
@@ -5,22 +5,21 @@
 #include "libafpclient.h"
 
 void log_for_client(void * priv,
-                    enum loglevels loglevel, int logtype, char *format, ...)
+                    enum logtypes logtype, int loglevel, char *format, ...)
 {
     va_list ap;
     char new_message[MAX_ERROR_LEN];
     va_start(ap, format);
     vsnprintf(new_message, MAX_ERROR_LEN, format, ap);
     va_end(ap);
-    libafpclient->log_for_client(priv, loglevel, logtype, new_message);
+    libafpclient->log_for_client(priv, logtype, loglevel, new_message);
 }
 
 void stdout_log_for_client(
     __attribute__((unused)) void * priv,
-    __attribute__((unused)) enum loglevels loglevel,
-    __attribute__((unused)) int logtype,
+    __attribute__((unused)) enum logtypes logtype,
+    __attribute__((unused)) int loglevel,
     const char *message)
 {
     printf("%s\n", message);
 }
-

--- a/lib/loop.c
+++ b/lib/loop.c
@@ -229,17 +229,20 @@ int afp_main_loop(int command_fd)
     signal(SIGTERM, termination_handler);
     signal(SIGINT, termination_handler);
 #ifdef DEBUG_LOOP
-    printf("afp_main_loop -- Starting up loop\n");
+    log_for_client(NULL, AFPFSD, LOG_DEBUG,
+                   "afp_main_loop -- Starting main loop\n");
 #endif
 
     while (1) {
 #ifdef DEBUG_LOOP
-        printf("afp_main_loop -- Setting new fds\n");
+        log_for_client(NULL, AFPFSD, LOG_DEBUG,
+                       "afp_main_loop -- Setting new fds\n");
         {
             int j;
 
             for (j = 0; j < 16; j++) if (FD_ISSET(j, &rds)) {
-                    printf("afp_main_loop -- fd %d is set\n", j);
+                    log_for_client(NULL, AFPFSD, LOG_DEBUG,
+                                   "afp_main_loop -- FD %d is set\n", j);
                 }
         }
 #endif
@@ -255,7 +258,8 @@ int afp_main_loop(int command_fd)
         }
 
 #ifdef DEBUG_LOOP
-        printf("afp_main_loop -- Starting new select\n");
+        log_for_client(NULL, AFPFSD, LOG_DEBUG,
+                       "afp_main_loop -- Starting new select\n");
 #endif
 
         // Check exit conditions BEFORE pselect
@@ -296,7 +300,8 @@ int afp_main_loop(int command_fd)
             switch (errno) {
             case EBADF:
 #ifdef DEBUG_LOOP
-                printf("afp_main_loop -- Dealing with a bad file descriptor\n");
+                log_for_client(NULL, AFPFSD, LOG_DEBUG,
+                               "afp_main_loop -- Dealing with a bad file descriptor\n");
 #endif
 
                 if (fderrors > 100) {
@@ -310,13 +315,15 @@ int afp_main_loop(int command_fd)
 
             default:
 #ifdef DEBUG_LOOP
-                printf("afp_main_loop -- Dealing with some other error, %d\n",
-                       errno);
+                log_for_client(NULL, AFPFSD, LOG_DEBUG,
+                               "afp_main_loop -- Dealing with some other error, %d\n",
+                               errno);
 #endif
 
                 if (libafpclient->scan_extra_fds) {
 #ifdef DEBUG_LOOP
-                    printf("afp_main_loop -- Other error\n");
+                    log_for_client(NULL, AFPFSD, LOG_DEBUG,
+                                   "afp_main_loop -- Other error\n");
 #endif
                     ret = libafpclient->scan_extra_fds(
                               command_fd, &ords, &max_fd);
@@ -353,20 +360,23 @@ int afp_main_loop(int command_fd)
             switch (process_server_fds(&ords, max_fd, &onfd)) {
             case -1:
 #ifdef DEBUG_LOOP
-                printf("afp_main_loop --  error returning from process_server_fds()\n");
+                log_for_client(NULL, AFPFSD, LOG_DEBUG,
+                               "afp_main_loop -- error returning from process_server_fds()\n");
 #endif
                 goto error;
 
             case 1:
 #ifdef DEBUG_LOOP
-                printf("afp_main_loop -- success returning from process_server_fds()\n");
+                log_for_client(NULL, AFPFSD, LOG_DEBUG,
+                               "afp_main_loop -- success returning from process_server_fds()\n");
 #endif
                 continue;
             }
 
             if (libafpclient->scan_extra_fds) {
 #ifdef DEBUG_LOOP
-                printf("afp_main_loop --  Scanning client fds\n");
+                log_for_client(NULL, AFPFSD, LOG_DEBUG,
+                               "afp_main_loop --  Scanning client fds\n");
 #endif
 
                 if (libafpclient->scan_extra_fds(
@@ -378,7 +388,8 @@ int afp_main_loop(int command_fd)
     }
 
 #ifdef DEBUG_LOOP
-    printf("afp_main_loop -- done with loop altogether\n");
+    log_for_client(NULL, AFPFSD, LOG_DEBUG,
+                   "afp_main_loop -- done with loop altogether\n");
 #endif
 error:
 


### PR DESCRIPTION
afpfsd now takes -v,--loglevel with a syslog loglevel constant

fixes a few bugs that make the stdout logging work as well

wraps the DSI and main loop debug logging in log_to_client() rather than raw printf

sanitizes the internal naming: before, the code referred to what is typically "logtype" as "loglevel"

and, when mounting lock the mutex paired with the condition before waiting, to avoid deadlock