### PR TITLE
Complete support for Extended Attribute reads and writes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ Three-layer architecture (see `docs/DEVELOPER.md`):
 **Setup**:
 
 - `meson setup build -Dbuildtype=release|debug`
-- Debug builds get `-DDEBUG` → enables `LOG_FUSE_EVENTS` logging
+- Debug builds get `-DDEBUG` → enables `DEBUG_DSI` and `DEBUG_LOOP` logging
 - FUSE version detected automatically → sets `FUSE_USE_VERSION=29` or `35`
 
 **Conditional features** (see `meson.build`):
@@ -127,8 +127,7 @@ Run `./codefmt.sh` for formatting.
 1. Check if operation has platform-dependent signature
 2. For write operations, ensure flush is properly implemented
 3. Update cached `fp->size` when extending files
-4. Add debug logging under `#ifdef LOG_FUSE_EVENTS` for troubleshooting
-5. Test on both Linux and macOS if possible
+4. Test on both Linux and macOS if possible
 
 ## When Adding Multi-Mount Features
 

--- a/TODO.md
+++ b/TODO.md
@@ -8,6 +8,7 @@ Command line client
 * completion with BSD's readline
 * version detection
 * OS guessing
+* extended attributes
 
 FUSE client
 -----------
@@ -42,8 +43,8 @@ General bugs
   * retrieval tool: a userspace app that can parse icons from resource forks
 
 * Complete implementation of AFP 3.2
-  * Extended attributes
-  * pretty much every function needs testing and correcting
+  * ACLs
+  * extended attribute writes on macOS
 
 * AFP 2.x support
   * desktop database support

--- a/include/afp.h
+++ b/include/afp.h
@@ -280,6 +280,15 @@ struct afp_extattr_info {
     char data[1024];
 };
 
+/* Extended Attribute filtering for server internal metadata */
+/* Netatalk's internal metadata EA - should not be exposed to clients */
+#define NETATALK_EA_META "org.netatalk.Metadata"
+#define NETATALK_EA_META_LEN 22
+
+/* Check if this is an internal server EA that should be filtered */
+#define IS_INTERNAL_SERVER_EA(name) \
+    (strncmp((name), NETATALK_EA_META, NETATALK_EA_META_LEN) == 0)
+
 struct afp_comment {
     unsigned int maxsize;
     unsigned int size;
@@ -556,6 +565,20 @@ int afp_rename(struct afp_volume * volume,
 int afp_listextattr(struct afp_volume * volume,
                     unsigned int dirid, unsigned short bitmap,
                     char *pathname, struct afp_extattr_info * info);
+
+int afp_getextattr(struct afp_volume * volume, unsigned int dirid,
+                   unsigned short bitmap, unsigned int replysize,
+                   const char *pathname, unsigned short namelen, const char *name,
+                   struct afp_extattr_info * info);
+
+int afp_setextattr(struct afp_volume * volume, unsigned int dirid,
+                   unsigned short bitmap, uint64_t offset, const char *pathname,
+                   unsigned short namelen, const char *name,
+                   unsigned int attribdatalen, const char *attribdata);
+
+int afp_removeextattr(struct afp_volume * volume, unsigned int dirid,
+                      unsigned short bitmap, const char *pathname,
+                      unsigned short namelen, const char *name);
 
 /* For debugging */
 char *afp_get_command_name(unsigned char code);

--- a/include/afp_protocol.h
+++ b/include/afp_protocol.h
@@ -186,6 +186,9 @@ enum AFPFunction {
     afpCatSearchExt = 67,
     afpEnumerateExt2 = 68, afpGetExtAttr, afpSetExtAttr,
     afpRemoveExtAttr, afpListExtAttrs,
+    afpGetACL, afpSetACL, afpAccess,
+    afpSpotlightRPC = 76,
+    afpSyncDir = 78, afpSyncFork,
     afpZzzzz = 122,
     afpAddIcon = 192,
 };

--- a/include/midlevel.h
+++ b/include/midlevel.h
@@ -65,6 +65,19 @@ void afp_ml_filebase_free(struct afp_file_info **filebase);
 int ml_passwd(struct afp_server *server,
               char *username, char *oldpasswd, char *newpasswd);
 
+/* Extended Attributes (AFP 3.2+) */
+
+int ml_getxattr(struct afp_volume * volume, const char *path,
+                const char *name, void *value, size_t size);
+
+int ml_setxattr(struct afp_volume * volume, const char *path,
+                const char *name, const void *value, size_t size, int flags);
+
+int ml_listxattr(struct afp_volume * volume, const char *path,
+                 char *list, size_t size);
+
+int ml_removexattr(struct afp_volume * volume, const char *path,
+                   const char *name);
 
 
 #endif

--- a/lib/afp.c
+++ b/lib/afp.c
@@ -71,9 +71,9 @@ int (*afp_replies[])(struct afp_server * server, char * buf, unsigned int len,
     afp_readext_reply, afp_writeext_reply,
     NULL, NULL,                       /*56 - 63 */
     afp_getsessiontoken_reply, afp_blank_reply, NULL, NULL,
-    afp_enumerateext2_reply, NULL, NULL, NULL,    /*64 - 71 */
-    afp_listextattrs_reply, NULL, NULL, NULL,
-    afp_blank_reply, NULL, afp_blank_reply, afp_blank_reply,                       /*72 - 79 */
+    afp_enumerateext2_reply, afp_getextattr_reply, afp_blank_reply, afp_blank_reply, /*64 - 71 */
+    afp_listextattrs_reply, afp_blank_reply, afp_blank_reply, afp_blank_reply,
+    NULL, NULL, afp_blank_reply, afp_blank_reply,                       /*72 - 79 */
 
     NULL, NULL, NULL, NULL,
     NULL, NULL, NULL, NULL,

--- a/lib/afp_replies.h
+++ b/lib/afp_replies.h
@@ -84,4 +84,7 @@ int afp_byterangelockext_reply(struct afp_server *server, char * buf,
 int afp_listextattrs_reply(struct afp_server *server, char * buf,
                            unsigned int size, void *x);
 
+int afp_getextattr_reply(struct afp_server *server, char * buf,
+                         unsigned int size, void *other);
+
 #endif

--- a/lib/debug.c
+++ b/lib/debug.c
@@ -17,9 +17,9 @@ static char *afp_command_names[] = {
     "afpRemoveComment", "afpGetComment", "afpByteRangeLockExt", "afpReadExt", "afpWriteExt",
     "afpGetAuthMethods", "afp_LoginExt", "afpGetSessionToken", "afpDisconnectOldSession",
     "afpEnumerateExt", "afpCatSearchExt", "afpEnumerateExt2", "afpGetExtAttr",
-    "afpSetExtAttr", "afpRemoveExtAttr", "afpListExtAttrs",  /* 74 */
-    "Some AFP 3.2 undocumented feature",
-    "Unknown 76", "Unknown 77", "Unknown 78", "Unknown 79", "Unknown 80", "Unknown 81",
+    "afpSetExtAttr", "afpRemoveExtAttr", "afpListExtAttrs", "afpGetACL",
+    "afpSetACL", "afpAccess", "afpSpotlightRPC", "Unknown 77", "afpSyncDir",
+    "afpSyncFork", "Unknown 80", "Unknown 81",
     "Unknown 82", "Unknown 83", "Unknown 84", "Unknown 85", "Unknown 86", "Unknown 87",
     "Unknown 88", "Unknown 89", "Unknown 90", "Unknown 91", "Unknown 92", "Unknown 93",
     "Unknown 94", "Unknown 95", "Unknown 96", "Unknown 97", "Unknown 98", "Unknown 99",

--- a/lib/proto_attr.c
+++ b/lib/proto_attr.c
@@ -60,7 +60,7 @@ int afp_listextattr(struct afp_volume * volume,
         request_packet->reqcount = 0;
         request_packet->startindex = 0;
         request_packet->bitmap = htons(bitmap);
-        request_packet->maxreplysize = hton64(info->maxsize);
+        request_packet->maxreplysize = htonl(info->maxsize);
         copy_path(server, pathptr, pathname, strlen(pathname));
         unixpath_to_afppath(server, pathptr);
         ret = dsi_send(server, (char *) request_packet, len, DSI_DEFAULT_TIMEOUT,
@@ -75,25 +75,63 @@ int afp_listextattrs_reply(__attribute__((unused)) struct afp_server * server,
                            char *buf,
                            __attribute__((unused)) unsigned int size, void * x)
 {
-    struct {
+    const struct {
         struct dsi_header header __attribute__((__packed__));
         uint16_t reserved ;
         uint32_t datalength ;
-        char *data ;
+        char data[] ;
     } __attribute__((__packed__)) * reply = (void *) buf;
     struct afp_extattr_info * i = x;
+
+    /* Check for error before parsing reply data */
+    if (reply->header.return_code.error_code != 0) {
+        return 0;  /* DSI extracts error_code from header automatically */
+    }
+
     unsigned int len = min(i->maxsize, ntohl(reply->datalength));
     i->size = len;
-    /* Todo: make sure we don't go past the end of the buffer */
-    memcpy(&i->data, &reply->data, len) ;
+
+    if (len > 0) {
+        memcpy(i->data, reply->data, len);
+    }
+
+    return 0;
+}
+
+int afp_getextattr_reply(__attribute__((unused)) struct afp_server * server,
+                         char *buf,
+                         __attribute__((unused)) unsigned int size, void * x)
+{
+    const struct {
+        struct dsi_header header __attribute__((__packed__));
+        uint16_t bitmap;
+        uint32_t datalength;
+        char data[];
+    } __attribute__((__packed__)) * reply = (void *) buf;
+    struct afp_extattr_info * i = x;
+
+    /* Check for error before parsing reply data */
+    if (reply->header.return_code.error_code != 0) {
+        return 0;  /* DSI extracts error_code from header automatically */
+    }
+
+    if (i) {
+        unsigned int len = min(i->maxsize, ntohl(reply->datalength));
+        i->size = len;
+
+        if (len > 0) {
+            memcpy(&i->data, reply->data, len);
+        }
+    }
+
     return 0;
 }
 
 
 int afp_getextattr(struct afp_volume * volume, unsigned int dirid,
-                   __attribute__((unused)) unsigned short bitmap, unsigned int replysize,
-                   char *pathname,
-                   unsigned short namelen, char *name, struct afp_extattr_info * i)
+                   unsigned short bitmap, unsigned int replysize,
+                   const char *pathname, unsigned short namelen, const char *name,
+                   struct afp_extattr_info * i)
 {
     int ret = -1;
 
@@ -101,22 +139,17 @@ int afp_getextattr(struct afp_volume * volume, unsigned int dirid,
         struct {
             struct dsi_header dsi_header __attribute__((__packed__));
             uint8_t command;
-            char pad;
+            uint8_t pad;
             uint16_t volid ;
             uint32_t dirid ;
             uint16_t bitmap ;
             uint64_t offset ;
             uint64_t reqcount;
-            uint32_t replysize;
+            uint32_t maxreplysize;
         } __attribute__((__packed__)) *request_packet;
-        struct {
-            uint16_t len;
-            char *name ;
-        } __attribute__((__packed__)) * req2;
         struct afp_server * server = volume->server;
-        unsigned int len = sizeof(*request_packet) +
-                           sizeof_path_header(server) + strlen(pathname)
-                           + 1 + sizeof(unsigned int) + strlen(name);
+        unsigned int pathlen = sizeof_path_header(server) + strlen(pathname);
+        unsigned int len = sizeof(*request_packet) + pathlen + 1 + 2 + namelen;
         char *p, *p2;
         char *msg = malloc(len);
 
@@ -125,7 +158,7 @@ int afp_getextattr(struct afp_volume * volume, unsigned int dirid,
             return -1;
         };
 
-        p = msg + (sizeof(*request_packet));
+        p = msg + sizeof(*request_packet);
 
         request_packet = (void *) msg;
 
@@ -137,23 +170,25 @@ int afp_getextattr(struct afp_volume * volume, unsigned int dirid,
         request_packet->pad = 0;
         request_packet->volid = htons(volume->volid);
         request_packet->dirid = htonl(dirid);
+        request_packet->bitmap = htons(bitmap);
         request_packet->offset = hton64(0);
-        request_packet->reqcount = hton64(0);
-        request_packet->replysize = htonl(replysize);
+        request_packet->reqcount = hton64(replysize);
+        request_packet->maxreplysize = htonl(replysize);
+        /* Copy path */
         copy_path(server, p, pathname, strlen(pathname));
         unixpath_to_afppath(server, p);
-        p2 = p + sizeof_path_header(server) + strlen(pathname);
+        p2 = p + pathlen;
 
-        if (((unsigned long) p2) & 0x1) {
+        /* Pad to even boundary if needed (AFP protocol requirement) */
+        if ((unsigned long)p2 & 1) {
             p2++;
         }
 
-        req2 = (void *) p2;
-        req2->len = htons(namelen);
-        memcpy(&req2->name, name, namelen);
-        len = (p2 + namelen) - msg;
+        /* EA name: length-prefixed (2 bytes length + name) */
+        *((uint16_t *)p2) = htons(namelen);
+        memcpy(p2 + 2, name, namelen);
         ret = dsi_send(server, (char *) request_packet, len, DSI_DEFAULT_TIMEOUT,
-                       afpDelete, (void *) i);
+                       afpGetExtAttr, (void *) i);
         free(msg);
     }
 
@@ -161,12 +196,9 @@ int afp_getextattr(struct afp_volume * volume, unsigned int dirid,
 }
 
 int afp_setextattr(struct afp_volume * volume, unsigned int dirid,
-                   __attribute__((unused)) unsigned short bitmap,
-                   __attribute__((unused)) uint64_t offset, char * pathname,
-                   __attribute__((unused)) unsigned short namelen,
-                   __attribute__((unused)) char * name,
-                   __attribute__((unused)) unsigned int attribdatalen,
-                   __attribute__((unused)) char * attribdata)
+                   unsigned short bitmap, uint64_t offset, const char *pathname,
+                   unsigned short namelen, const char *name,
+                   unsigned int attribdatalen, const char *attribdata)
 {
     int ret = -1;
 
@@ -181,9 +213,10 @@ int afp_setextattr(struct afp_volume * volume, unsigned int dirid,
             uint64_t offset ;
         } __attribute__((__packed__)) *request_packet;
         struct afp_server * server = volume->server;
-        unsigned int len = sizeof(*request_packet) + sizeof_path_header(
-                               server) + strlen(pathname);
-        char *pathptr;
+        unsigned int pathlen = sizeof_path_header(server) + strlen(pathname);
+        unsigned int len = sizeof(*request_packet) + pathlen + 1 + 2 + namelen +
+                           4 + attribdatalen;
+        char *p, *p2;
         char *msg = malloc(len);
 
         if (!msg) {
@@ -191,7 +224,7 @@ int afp_setextattr(struct afp_volume * volume, unsigned int dirid,
             return -1;
         };
 
-        pathptr = msg + (sizeof(*request_packet));
+        p = msg + sizeof(*request_packet);
 
         request_packet = (void *) msg;
 
@@ -203,13 +236,92 @@ int afp_setextattr(struct afp_volume * volume, unsigned int dirid,
         request_packet->pad = 0;
         request_packet->volid = htons(volume->volid);
         request_packet->dirid = htonl(dirid);
-        copy_path(server, pathptr, pathname, strlen(pathname));
-        unixpath_to_afppath(server, pathptr);
+        request_packet->bitmap = htons(bitmap);
+        request_packet->offset = hton64(offset);
+        /* Copy path */
+        copy_path(server, p, pathname, strlen(pathname));
+        unixpath_to_afppath(server, p);
+        p2 = p + pathlen;
+
+        /* Pad to even boundary if needed (AFP protocol requirement) */
+        if ((unsigned long)p2 & 1) {
+            p2++;
+        }
+
+        /* EA name: length-prefixed (2 bytes length + name) */
+        *((uint16_t *)p2) = htons(namelen);
+        memcpy(p2 + 2, name, namelen);
+        p2 += 2 + namelen;
+        /* EA data size (4 bytes) */
+        *((uint32_t *)p2) = htonl(attribdatalen);
+        p2 += 4;
+
+        /* EA data payload */
+        if (attribdatalen > 0 && attribdata) {
+            memcpy(p2, attribdata, attribdatalen);
+        }
+
         ret = dsi_send(server, (char *) request_packet, len, DSI_DEFAULT_TIMEOUT,
-                       afpDelete, NULL);
+                       afpSetExtAttr, NULL);
         free(msg);
     }
 
     return ret;
 }
 
+int afp_removeextattr(struct afp_volume * volume, unsigned int dirid,
+                      unsigned short bitmap, const char *pathname,
+                      unsigned short namelen, const char *name)
+{
+    int ret = -1;
+
+    if (volume) {
+        struct {
+            struct dsi_header dsi_header __attribute__((__packed__));
+            uint8_t command;
+            uint8_t pad;
+            uint16_t volid;
+            uint32_t dirid;
+            uint16_t bitmap;
+        } __attribute__((__packed__)) *request_packet;
+        struct afp_server * server = volume->server;
+        unsigned int pathlen = sizeof_path_header(server) + strlen(pathname);
+        unsigned int len = sizeof(*request_packet) + pathlen + 1 + 2 + namelen;
+        char *p, *p2;
+        char *msg = malloc(len);
+
+        if (!msg) {
+            log_for_client(NULL, AFPFSD, LOG_WARNING, "Out of memory\n");
+            return -1;
+        }
+
+        p = msg + sizeof(*request_packet);
+        request_packet = (void *) msg;
+        struct dsi_header hdr;
+        dsi_setup_header(server, &hdr, DSI_DSICommand);
+        memcpy(&request_packet->dsi_header, &hdr, sizeof(struct dsi_header));
+        request_packet->command = afpRemoveExtAttr;
+        request_packet->pad = 0;
+        request_packet->volid = htons(volume->volid);
+        request_packet->dirid = htonl(dirid);
+        request_packet->bitmap = htons(bitmap);
+        /* Copy path */
+        copy_path(server, p, pathname, strlen(pathname));
+        unixpath_to_afppath(server, p);
+        p2 = p + pathlen;
+
+        /* Pad to even boundary if needed (AFP protocol requirement) */
+        if ((unsigned long)p2 & 1) {
+            p2++;
+        }
+
+        /* EA name: length-prefixed (2 bytes length + name) */
+        *((uint16_t *)p2) = htons(namelen);
+        memcpy(p2 + 2, name, namelen);
+        ret = dsi_send(server, (char *) request_packet, len, DSI_DEFAULT_TIMEOUT,
+                       afpRemoveExtAttr, NULL);
+        free(msg);
+    }
+
+    return ret;
+}

--- a/meson.build
+++ b/meson.build
@@ -83,6 +83,17 @@ with_afpcmd = ncurses_dep.found() and (readline_dep.found() or editline_dep.foun
 with_fuse = get_option('enable-fuse') and fuse_dep.found()
 with_crypt = gcrypt_dep.found() and libgmp_dep.found()
 
+# Check for extended attribute headers (platform-dependent)
+if cc.has_header('sys/xattr.h')
+    cflags += '-DHAVE_SYS_XATTR_H'
+endif
+if cc.has_header('sys/extattr.h')
+    cflags += '-DHAVE_SYS_EXTATTR_H'
+endif
+if cc.has_header('attr/xattr.h')
+    cflags += '-DHAVE_ATTR_XATTR_H'
+endif
+
 if with_fuse
     fuse_version = fuse_dep.version()
     if fuse_version.version_compare('>=3.0.0')


### PR DESCRIPTION
AFP protocol layer implementation of AFP 3.2 EA commands

AFP 3.2 midlevel wrappers for EA commands

FUSE client implementation of EA commands

Key Implementation Details:

- Proper EA filtering: Only filters org.netatalk.Metadata (internal server metadata)
- Linux namespace handling: Automatically strips/adds "user." prefix for AFP protocol compatibility
- AFP 3.2 protocol compliance:
  - Even-byte padding after pathname
  - 4-byte EA data size field
  - Correct byte ordering (htonl for 32-bit fields)
  - 6-byte response overhead accounted for
- Root directory protection: Prevents EA operations on "/" that cause server errors