### PR TITLE
update the afp_client status command for multiple afpfsd

### DIFF
--- a/cmdline/cmdline_afp.c
+++ b/cmdline/cmdline_afp.c
@@ -1202,7 +1202,11 @@ int com_status(__attribute__((unused)) char * arg)
 {
     int len = 40960;
     char text[40960];
-    afp_status_header(text, &len);
+
+    if (afp_status_header(text, &len) < 0) {
+        return -1;
+    }
+
     printf("%s", text);
     len = 40960;
     afp_status_server(server, text, &len);

--- a/fuse/afp_server.h
+++ b/fuse/afp_server.h
@@ -5,19 +5,29 @@
 
 #define SERVER_FILENAME "/tmp/afp_server"
 
+/*
+ * IMPORTANT: These command/result codes MUST match include/afpfsd.h exactly.
+ * They define the IPC protocol between mount_afpfs/afp_client and afpfsd.
+ *
+ * Note: This header uses simplified structures (no header field) for backward
+ * compatibility with the existing FUSE client implementation. The constants
+ * must stay synchronized with afpfsd.h.
+ */
 #define AFP_SERVER_COMMAND_MOUNT 1
-#define AFP_SERVER_COMMAND_STATUS 2
-#define AFP_SERVER_COMMAND_UNMOUNT 3
-#define AFP_SERVER_COMMAND_SUSPEND 4
-#define AFP_SERVER_COMMAND_RESUME 5
-#define AFP_SERVER_COMMAND_PING 6
-#define AFP_SERVER_COMMAND_EXIT 7
-#define AFP_SERVER_COMMAND_SPAWN_MOUNT 8
+#define AFP_SERVER_COMMAND_STATUS 4
+#define AFP_SERVER_COMMAND_UNMOUNT 6
+#define AFP_SERVER_COMMAND_SUSPEND 8
+#define AFP_SERVER_COMMAND_RESUME 9
+#define AFP_SERVER_COMMAND_PING 11
+#define AFP_SERVER_COMMAND_EXIT 12
 
-#define AFP_SERVER_RESULT_OKAY 1
-#define AFP_SERVER_RESULT_ERROR 2
-#define AFP_SERVER_RESULT_TRYING 3
-#define AFP_SERVER_RESULT_WARNING 4
+/* Internal command for manager daemon - not in afpfsd.h */
+#define AFP_SERVER_COMMAND_SPAWN_MOUNT 100
+
+#define AFP_SERVER_RESULT_OKAY 0
+#define AFP_SERVER_RESULT_ERROR 1
+#define AFP_SERVER_RESULT_TRYING 2
+#define AFP_SERVER_RESULT_WARNING 3
 
 struct afp_server_resume_request {
     char server_name[AFP_SERVER_NAME_LEN];

--- a/fuse/daemon.c
+++ b/fuse/daemon.c
@@ -543,6 +543,35 @@ static int handle_manager_command(int client_fd)
         break;
     }
 
+    case AFP_SERVER_COMMAND_STATUS: {
+        /* Manager daemon: return a basic status message */
+        struct afp_server_response response;
+        char status_msg[1024];
+        int count = 0;
+
+        /* Count active mounts */
+        for (struct manager_child *child = child_list; child; child = child->next) {
+            count++;
+        }
+
+        if (count == 0) {
+            snprintf(status_msg, sizeof(status_msg),
+                     "afpfs-ng manager daemon running\n"
+                     "No active mounts\n");
+        } else {
+            snprintf(status_msg, sizeof(status_msg),
+                     "afpfs-ng manager daemon running\n"
+                     "Active mounts: %d\n",
+                     count);
+        }
+
+        response.result = AFP_SERVER_RESULT_OKAY;
+        response.len = strlen(status_msg);
+        write(client_fd, &response, sizeof(response));
+        write(client_fd, status_msg, response.len);
+        break;
+    }
+
     default:
         /* Unknown command */
         break;


### PR DESCRIPTION
make the afp_client status command work in the afpfsd manager daemon structure

align the command and return value constant definitions between afp_server.h and afpfsd.h

handle returning with error in afp_status_header() calls