### PR TITLE
enable xattr writes with macFUSE as the bug is fixed with v5.1.3

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,23 +19,26 @@ In addition to the above, you need:
 
 - libgcrypt, libgmp for the encrypted login methods
 - readline (or libedit) and ncurses for the command line client
-- libfuse v3 (backwards compatible with v2.9) for the FUSE client
+- libfuse3 (backwards compatible with v2.9) for the FUSE client
 
 ### FreeBSD
 
 In addition to the above, you need:
 
 - libgcrypt (1.4.0 or later), libgmp for the encrypted login methods
-- readline (or libedit) and ncurses for the command line client
-- libfuse v3 (backwards compatible with v2.9) for the FUSE client
+- libfuse3 (backwards compatible with v2.9) for the FUSE client
 
 ### macOS
 
-Use Homebrew or MacPorts to install the baseline dependencies.
+Use Homebrew or MacPorts to install the dependencies.
 
-macFUSE is required for the FUSE client, and can be installed from
-[https://macfuse.github.io/](the macFUSE website) or via Homebrew.
+- libgcrypt for the encrypted login methods
+- macFUSE (5.1.3 or later) for the FUSE client
+
+macFUSE can be installed from [https://macfuse.github.io/](the macFUSE website) or via Homebrew.
 Follow the instructions to install the macFUSE software and kernel extension.
+
+Note that macFUSE 5.1.2 and earlier have a bug that prevents writing extended attributes.
 
 ## Compile and install
 

--- a/README.md
+++ b/README.md
@@ -14,49 +14,50 @@ You can use afpfs-ng either to mount an AFP share with FUSE, or interactively wi
 
 ### FUSE
 
-Mount the time_travel volume from delorean.local on /mnt/timetravel without authentication:
+Mount the *File Sharing* volume from afpserver.local on /home/myuser/fusemount without authentication:
 
-    % mount_afpfs "afp://delorean.local/time_travel" /mnt/timetravel
+    % mount_afpfs "afp://afpserver.local/File Sharing" /home/myuser/fusemount
 
-Same, with authentication (you will be prompted for the password):
+Same, with authentication (**myuser:-** prompts for myuser's password):
 
-    % mount_afpfs "afp://simon:-@delorean.local/time_travel" /mnt/timetravel
+    % mount_afpfs "afp://myuser:-@afpserver.local/File Sharing" /home/myuser/fusemount
 
 Same, with authentication, forcing the UAM of your choice (usually not needed):
 
-    % mount_afpfs "afp://simon;AUTH=DHCAST128:-@delorean.local/time_travel" /mnt/timetravel
+    % mount_afpfs "afp://myuser;AUTH=DHCAST128:-@afpserver.local/File Sharing" /home/myuser/fusemount
 
 **Note:** Quotation marks around the AFP URL are mandatory when spaces,
 a colon, or other special characters are present.
 
 Unmount the volume:
 
-    % fusermount -u /mnt/timetravel
+    % fusermount -u /home/myuser/fusemount
 
 #### macFUSE
 
 If you are using macFUSE on macOS, use `umount` instead:
 
-    % umount /mnt/timetravel
+    % umount /Users/myuser/fusemount
 
 ### command line client
 
-Open volume time_travel on delorean.local:
+Open volume File Sharing on afpserver.local:
 
-    $ afpcmd "afp://simon:mypassword@delorean.local/time_travel"
-    Attempting connection to delorean.local ...
-    Connected to server Delorean using UAM "DHX2"
-    Connected to volume time_travel
+    $ afpcmd "afp://myuser:-@afpserver.local/File Sharing"
+    Password: [input hidden]
+    Attempting connection to afpserver.local ...
+    Connected to server afpserver using UAM "DHX2"
+    Connected to volume File Sharing
     afpcmd:
 
-Connect anonymously to delorean.local, list all volumes available to guest users:
+Connect anonymously to afpserver.local, list all volumes available to guest users:
 
-    $ afpcmd "afp://guest;AUTH=No User Authent:@delorean.local"
-    Attempting connection to delorean.local ...
-    Connected to server Delorean using UAM "No User Authent"
-    Specify a volume with 'cd volume'. Choose one of: dropbox, time_travel
-    afpcmd: cd dropbox
-    Connected to volume dropbox
+    $ afpcmd "afp://guest;AUTH=No User Authent:@afpserver.local"
+    Attempting connection to afpserver.local ...
+    Connected to server afpserver using UAM "No User Authent"
+    Specify a volume with 'cd volume'. Choose one of: Dropbox, File Sharing
+    afpcmd: cd Dropbox
+    Connected to volume Dropbox
     afpcmd: ls
     -rw-r--r--   6148 2025-07-11 14:09 .DS_Store
     -rw-------      0 2025-10-12 00:39 bork.txt
@@ -71,10 +72,11 @@ and *help* for a list of all supported commands.
 
 Download a file from the AFP share to the current directory:
 
-    $ afpcmd "afp://simon:mypassword@delorean.local/time_travel/afpfs-ng-0.9.0.tar.xz" .
-    Attempting connection to delorean.local ...
-    Connected to server Delorean using UAM "DHX2"
-    Connected to volume time_travel
+    $ afpcmd "afp://myuser:-@afpserver.local/File Sharing/afpfs-ng-0.9.0.tar.xz" .
+    Password: [input hidden]
+    Attempting connection to afpserver.local ...
+    Connected to server afpserver using UAM "DHX2"
+    Connected to volume File Sharing
         Getting file /afpfs-ng-0.9.0.tar.xz
     Transferred 108320 bytes in 0.002 seconds. (54000 kB/s)
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -149,27 +149,21 @@ rsync -aX source.txt /mnt/afp/      # rsync with -X flag
 
 ##### macOS
 
-On macOS, EA read and list operations work correctly.
-However, EA write operations are currently blocked by a [macFUSE bug](https://github.com/macfuse/macfuse/issues/1134)
-where the EA name parameter arrives empty in the `setxattr` callback.
-This affects both manual EA setting and file copying:
+On macOS, EA read, write, and list operations work correctly.
 
 ```shell
-# List EAs (works)
+# List EAs
 xattr -l /Volumes/afp/file.txt
 
-# Read EA (works)
+# Read EA
 xattr -p com.apple.metadata:kMDLabel /Volumes/afp/file.txt
 
-# Write EA (blocked by macFUSE bug)
-xattr -w user.test "value" /Volumes/afp/file.txt  # Fails
+# Write EA
+xattr -w user.test "value" /Volumes/afp/file.txt
 
 # Copying files with EAs
-cp file.txt /Volumes/afp/  # File data copies without EAs
+cp file.txt /Volumes/afp/
 ```
-
-**Workaround**: Use the native macOS AFP client (`mount_afp`) for operations requiring EA writes,
-or wait for a macFUSE fix.
 
 ##### FreeBSD
 

--- a/docs/REPORTING_BUGS.md
+++ b/docs/REPORTING_BUGS.md
@@ -1,4 +1,4 @@
-# Repoting Bugs
+# Reporting Bugs
 
 This quick document describes how to gather debugging information for afpfs-ng.
 
@@ -53,7 +53,12 @@ Tar up all the relevant files with something like:
 By default, a process called afpfsd runs in the background, you may have one
 lingering.
 
-To do this, start with:
+The most graceful way to stop it is to run:
+
+    fusermount -u /path/to/mountpoint
+    afp_client exit
+
+If this doesn't work, try:
 
     killall afpfsd
 


### PR DESCRIPTION
macFUSE's libfuse3 now returns a proper name attribute for setxattr so we can enable xattr writes on macOS

also overhauls the REPORTING_BUGS, README and INSTALL docs for accuracy