### PR TITLE
overhaul logging fidelity, better FUSE error reporting

### DIFF
--- a/fuse/client.c
+++ b/fuse/client.c
@@ -930,7 +930,7 @@ int read_answer(int sock)
 done:
     /* Print the entire message (null-terminate first for safety) */
     incoming_buffer[len] = '\0';
-    printf("%s", incoming_buffer + sizeof(*answer));
+    printf("%s\n", incoming_buffer + sizeof(*answer));
     ret = answer->result;
     free(incoming_buffer);
     return ret;

--- a/fuse/daemon.c
+++ b/fuse/daemon.c
@@ -75,7 +75,7 @@ void fuse_forced_ending_hook(void)
 
                 if (volume->mounted == AFP_VOLUME_MOUNTED)
                     log_for_client(NULL, AFPFSD, LOG_NOTICE,
-                                   "Unmounting %s\n", volume->mountpoint);
+                                   "Unmounting %s", volume->mountpoint);
 
                 afp_unmount_volume(volume);
             }
@@ -726,7 +726,7 @@ static int run_manager_daemon(void)
     sa.sa_flags = SA_NOCLDSTOP;
     sigaction(SIGCHLD, &sa, NULL);
     log_for_client(NULL, AFPFSD, LOG_NOTICE,
-                   "Starting manager daemon on %s\n", commandfilename);
+                   "Starting manager daemon on %s", commandfilename);
 
     while (1) {
         fd_set rds;
@@ -906,7 +906,7 @@ int main(int argc, char *argv[])
 
     if (remove_other_daemon() < 0)  {
         log_for_client(NULL, AFPFSD, LOG_NOTICE,
-                       "Daemon is already running and alive\n");
+                       "Daemon is already running and alive");
         return -1;
     }
 
@@ -921,7 +921,7 @@ int main(int argc, char *argv[])
         }
 
         log_for_client(NULL, AFPFSD, LOG_NOTICE,
-                       "Starting up AFPFS version %s\n", AFPFS_VERSION);
+                       "Starting up AFPFS version %s", AFPFS_VERSION);
         afp_main_loop(command_fd);
         close_commands(command_fd);
     }

--- a/fuse/fuse_error.c
+++ b/fuse/fuse_error.c
@@ -1,3 +1,11 @@
+/*
+ *  fuse_error.c
+ *
+ *  Copyright (C) 2008 Alex deVries <alexthepuffin@gmail.com>
+ *  Copyright (C) 2025 Daniel Markstedt <daniel@mindani.net>
+ *
+ */
+
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -51,7 +59,7 @@ void report_fuse_errors(struct fuse_client * c)
 
     if (len > 0) {
         log_for_client((void *)c, AFPFSD, LOG_ERR,
-                       "FUSE reported the following error:\n%s", buf);
+                       "FUSE reported the following error: %s", buf);
     }
 }
 
@@ -84,5 +92,81 @@ void fuse_capture_stderr_start(void)
     } else {
         close(fd);
         captured_stderr_fd = -1;
+    }
+}
+
+const char *fuse_result_to_string(int fuse_result)
+{
+    switch (fuse_result) {
+    case 0:
+        return "Success";
+
+    case 1:
+        return "Invalid option arguments or generic error";
+
+    case 2:
+        return "No mount point specified";
+
+    case 3:
+        return "FUSE setup failed";
+
+    case 4:
+        return "Mounting failed";
+
+    case 5:
+        return "Failed to daemonize (detach from session)";
+
+    case 6:
+        return "Failed to set up signal handlers";
+
+    case 7:
+        return "Error occurred during the life of the filesystem";
+
+    default:
+        return "Unknown FUSE error code";
+    }
+}
+
+const char *mount_errno_to_string(int err)
+{
+    switch (err) {
+    case 0:
+        return "No error";
+
+    case EACCES:
+        return "Permission denied - check access to FUSE device and mountpoint";
+
+    case EPERM:
+        return "Operation not permitted - may need root/sudo privileges";
+
+    case EBUSY:
+        return "Mountpoint is already in use or device is busy";
+
+    case ENOTDIR:
+        return "Mountpoint is not a directory";
+
+    case ENOENT:
+        return "Mountpoint or FUSE device does not exist";
+
+    case ENODEV:
+        return "FUSE kernel module not loaded - try 'modprobe fuse' or load macfuse";
+
+    case EINVAL:
+        return "Invalid mount options or arguments";
+
+    case ENOSPC:
+        return "No space available for mount table entry";
+
+    case ENOMEM:
+        return "Insufficient memory to complete mount operation";
+
+    case ENOTBLK:
+        return "Block device required but not provided";
+
+    case EFAULT:
+        return "Bad address in mount parameters";
+
+    default:
+        return strerror(err);
     }
 }

--- a/fuse/fuse_error.h
+++ b/fuse/fuse_error.h
@@ -5,6 +5,8 @@
 
 void report_fuse_errors(struct fuse_client * c);
 void fuse_capture_stderr_start(void);
+const char *fuse_result_to_string(int fuse_result);
+const char *mount_errno_to_string(int err);
 
 #endif
 

--- a/fuse/fuse_int.c
+++ b/fuse/fuse_int.c
@@ -91,12 +91,12 @@ static int fuse_readlink(const char * path, char *buf, size_t size)
     struct afp_volume * volume =
         (struct afp_volume *)
         ((struct fuse_context *)(fuse_get_context()))->private_data;
-    log_for_client(NULL, AFPFSD, LOG_DEBUG, "*** readlink of %s\n", path);
+    log_for_client(NULL, AFPFSD, LOG_DEBUG, "*** readlink of %s", path);
     ret = ml_readlink(volume, path, buf, size);
 
     if (ret == -EFAULT) {
         log_for_client(NULL, AFPFSD, LOG_WARNING,
-                       "Got some sort of internal error in afp_open for readlink\n");
+                       "Got some sort of internal error in afp_open for readlink");
     }
 
     return ret;
@@ -108,7 +108,7 @@ static int fuse_rmdir(const char *path)
     struct afp_volume * volume =
         (struct afp_volume *)
         ((struct fuse_context *)(fuse_get_context()))->private_data;
-    log_for_client(NULL, AFPFSD, LOG_DEBUG, "*** rmdir of %s\n", path);
+    log_for_client(NULL, AFPFSD, LOG_DEBUG, "*** rmdir of %s", path);
     ret = ml_rmdir(volume, path);
     return ret;
 }
@@ -119,7 +119,7 @@ static int fuse_unlink(const char *path)
     struct afp_volume * volume =
         (struct afp_volume *)
         ((struct fuse_context *)(fuse_get_context()))->private_data;
-    log_for_client(NULL, AFPFSD, LOG_DEBUG, "*** unlink of %s\n", path);
+    log_for_client(NULL, AFPFSD, LOG_DEBUG, "*** unlink of %s", path);
     ret = ml_unlink(volume, path);
     return ret;
 }
@@ -146,7 +146,7 @@ static int fuse_getxattr(const char *path, const char *name, char *value,
 
 #endif
     log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                   "*** getxattr %s:%s (size=%zu)\n", path, name, size);
+                   "*** getxattr %s:%s (size=%zu)", path, name, size);
     ret = ml_getxattr(volume, path, name, value, size);
     return ret;
 }
@@ -188,7 +188,7 @@ static int fuse_setxattr(const char *path, const char *name,
 
 #endif
     log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                   "*** setxattr %s:%s (size=%zu)\n", path, name, size);
+                   "*** setxattr %s:%s (size=%zu)", path, name, size);
     ret = ml_setxattr(volume, path, name, value, size, ml_flags);
     return ret;
 }
@@ -200,7 +200,7 @@ static int fuse_listxattr(const char *path, char *list, size_t size)
         (struct afp_volume *)
         ((struct fuse_context *)(fuse_get_context()))->private_data;
     log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                   "*** listxattr %s (size=%zu)\n", path, size);
+                   "*** listxattr %s (size=%zu)", path, size);
     ret = ml_listxattr(volume, path, list, size);
     return ret;
 }
@@ -212,7 +212,7 @@ static int fuse_removexattr(const char *path, const char *name)
         (struct afp_volume *)
         ((struct fuse_context *)(fuse_get_context()))->private_data;
     log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                   "*** removexattr %s:%s\n", path, name);
+                   "*** removexattr %s:%s", path, name);
     ret = ml_removexattr(volume, path, name);
     return ret;
 }
@@ -222,33 +222,28 @@ static int fuse_removexattr(const char *path, const char *name)
 #if defined(__APPLE__) && FUSE_USE_VERSION >= 30
 static int fuse_readdir_darwin(const char *path, void *buf,
                                fuse_darwin_fill_dir_t filler,
-                               off_t offset, struct fuse_file_info *fi,
-                               enum fuse_readdir_flags flags)
+                               __attribute__((unused)) off_t offset,
+                               __attribute__((unused)) struct fuse_file_info *fi,
+                               __attribute__((unused)) enum fuse_readdir_flags flags)
 #elif FUSE_USE_VERSION >= 30 && FUSE_NEW_API
 /* Linux FUSE 3.10+ with fuse_readdir_flags */
 static int fuse_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
-                        off_t offset, struct fuse_file_info *fi,
-                        enum fuse_readdir_flags flags)
+                        __attribute__((unused)) off_t offset,
+                        __attribute__((unused)) struct fuse_file_info *fi,
+                        __attribute__((unused)) enum fuse_readdir_flags flags)
 #else
 /* BSD FUSE 3.x and FUSE 2.x - older API without fuse_readdir_flags */
 static int fuse_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
-                        off_t offset, struct fuse_file_info *fi)
+                        __attribute__((unused)) off_t offset,
+                        __attribute__((unused)) struct fuse_file_info *fi)
 #endif
 {
-#if defined(__APPLE__) && FUSE_USE_VERSION >= 30 || (FUSE_USE_VERSION >= 30 && FUSE_NEW_API)
-    (void) offset;
-    (void) fi;
-    (void) flags;
-#else
-    (void) offset;
-    (void) fi;
-#endif
     struct afp_file_info * filebase = NULL, *p;
     int ret;
     struct afp_volume * volume =
         (struct afp_volume *)
         ((struct fuse_context *)(fuse_get_context()))->private_data;
-    log_for_client(NULL, AFPFSD, LOG_DEBUG, "*** readdir of %s\n", path);
+    log_for_client(NULL, AFPFSD, LOG_DEBUG, "*** readdir of %s", path);
 #if defined(__APPLE__) && FUSE_USE_VERSION >= 30 || (FUSE_USE_VERSION >= 30 && FUSE_NEW_API)
     filler(buf, ".", NULL, 0, 0);
     filler(buf, "..", NULL, 0, 0);
@@ -283,7 +278,7 @@ static int fuse_mknod(const char *path, mode_t mode,
     struct fuse_context * context = fuse_get_context();
     struct afp_volume * volume =
         (struct afp_volume *) context->private_data;
-    log_for_client(NULL, AFPFSD, LOG_DEBUG, "*** mknod of %s\n", path);
+    log_for_client(NULL, AFPFSD, LOG_DEBUG, "*** mknod of %s", path);
     ret = ml_creat(volume, path, mode);
     return ret;
 }
@@ -296,7 +291,7 @@ static int fuse_create(const char *path, mode_t mode, struct fuse_file_info *fi)
         (struct afp_volume *)
         ((struct fuse_context *)(fuse_get_context()))->private_data;
     log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                   "*** create of %s with mode 0%o, flags 0x%x\n", path, mode, fi->flags);
+                   "*** create of %s with mode 0%o, flags 0x%x", path, mode, fi->flags);
     /* Create the file */
     ret = ml_creat(volume, path, mode);
 
@@ -310,11 +305,11 @@ static int fuse_create(const char *path, mode_t mode, struct fuse_file_info *fi)
     if (ret == 0) {
         fi->fh = (unsigned long) fp;
         log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                       "*** create succeeded, fh=%lu, forkid=%d\n",
+                       "*** create succeeded, fh=%lu, forkid=%d",
                        fi->fh, fp->forkid);
     } else {
         log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                       "*** create open failed with ret=%d\n", ret);
+                       "*** create open failed with ret=%d", ret);
     }
 
     return ret;
@@ -327,7 +322,7 @@ static int fuse_flush(const char *path, struct fuse_file_info *fi)
         (struct afp_volume *)
         ((struct fuse_context *)(fuse_get_context()))->private_data;
     int ret = 0;
-    log_for_client(NULL, AFPFSD, LOG_DEBUG, "*** flush of %s\n", path);
+    log_for_client(NULL, AFPFSD, LOG_DEBUG, "*** flush of %s", path);
 
     if (!fp) {
         return 0;
@@ -363,7 +358,7 @@ static int fuse_release(const char * path, struct fuse_file_info * fi)
     struct afp_volume * volume =
         (struct afp_volume *)
         ((struct fuse_context *)(fuse_get_context()))->private_data;
-    log_for_client(NULL, AFPFSD, LOG_DEBUG, "*** release of %s\n", path);
+    log_for_client(NULL, AFPFSD, LOG_DEBUG, "*** release of %s", path);
     ret = ml_close(volume, path, fp);
 
     if (ret < 0) {
@@ -385,7 +380,7 @@ static int fuse_open(const char *path, struct fuse_file_info *fi)
         ((struct fuse_context *)(fuse_get_context()))->private_data;
     int flags = fi->flags;
     log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                   "*** Opening path %s with flags 0x%x\n", path, flags);
+                   "*** Opening path %s with flags 0x%x", path, flags);
     ret = ml_open(volume, path, flags, &fp);
 
     if (ret == 0) {
@@ -405,12 +400,12 @@ static int fuse_write(const char * path, const char *data,
     struct fuse_context * context = fuse_get_context();
     struct afp_volume * volume = (void *) context->private_data;
     log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                   "*** write of %s from %llu for %llu bytes\n",
+                   "*** write of %s from %llu for %llu bytes",
                    path, (unsigned long long) offset, (unsigned long long) size);
     ret = ml_write(volume, path, data, size, offset, fp,
                    context->uid, context->gid);
     log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                   "*** write returned %d\n", ret);
+                   "*** write returned %d", ret);
     return ret;
 }
 
@@ -421,7 +416,7 @@ static int fuse_mkdir(const char * path, mode_t mode)
     struct afp_volume * volume =
         (struct afp_volume *)
         ((struct fuse_context *)(fuse_get_context()))->private_data;
-    log_for_client(NULL, AFPFSD, LOG_DEBUG, "*** mkdir of %s\n", path);
+    log_for_client(NULL, AFPFSD, LOG_DEBUG, "*** mkdir of %s", path);
     ret = ml_mkdir(volume, path, mode);
     return ret;
 }
@@ -473,41 +468,25 @@ error:
 
 #if FUSE_NEW_API
 static int fuse_chown(const char * path, uid_t uid, gid_t gid,
-                      struct fuse_file_info *fi)
-{
-    (void) fi;
-    int ret;
-    struct afp_volume * volume =
-        (struct afp_volume *)
-        ((struct fuse_context *)(fuse_get_context()))->private_data;
-    log_for_client(NULL, AFPFSD, LOG_DEBUG, "** chown\n");
-    ret = ml_chown(volume, path, uid, gid);
-
-    if (ret == -ENOSYS) {
-        log_for_client(NULL, AFPFSD, LOG_WARNING, "chown unsupported\n");
-    }
-
-    return ret;
-}
-
+                      __attribute__((unused)) struct fuse_file_info *fi)
 #else
 static int fuse_chown(const char * path, uid_t uid, gid_t gid)
+#endif
 {
     int ret;
     struct afp_volume * volume =
         (struct afp_volume *)
         ((struct fuse_context *)(fuse_get_context()))->private_data;
-    log_for_client(NULL, AFPFSD, LOG_DEBUG, "** chown\n");
+    log_for_client(NULL, AFPFSD, LOG_DEBUG, "*** chown %s to uid %d, gid %d",
+                   path, (int)uid, (int)gid);
     ret = ml_chown(volume, path, uid, gid);
 
     if (ret == -ENOSYS) {
-        log_for_client(NULL, AFPFSD, LOG_WARNING, "chown unsupported\n");
+        log_for_client(NULL, AFPFSD, LOG_WARNING, "chown unsupported on this server");
     }
 
     return ret;
 }
-
-#endif
 
 #if FUSE_NEW_API
 static int fuse_truncate(const char * path, off_t offset,
@@ -518,14 +497,14 @@ static int fuse_truncate(const char * path, off_t offset,
         (struct afp_volume *)
         ((struct fuse_context *)(fuse_get_context()))->private_data;
     log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                   "*** truncate of %s to %lld, fi=%p, fh=%lu\n",
+                   "*** truncate of %s to %lld, fi=%p, fh=%lu",
                    path, (long long)offset, (void*)fi, fi ? (unsigned long)fi->fh : 0UL);
 
     /* If we have an open file handle, use it directly instead of
      * opening/closing a new fork */
     if (fi && fi->fh) {
         struct afp_file_info *fp = (struct afp_file_info *) fi->fh;
-        log_for_client(NULL, AFPFSD, LOG_DEBUG, "*** truncate using open forkid %d\n",
+        log_for_client(NULL, AFPFSD, LOG_DEBUG, "*** truncate using open forkid %d",
                        fp->forkid);
 
         /* CRITICAL: Only call setforksize if we're actually changing the size.
@@ -545,14 +524,14 @@ static int fuse_truncate(const char * path, off_t offset,
          * The file is being opened, so ll_open will handle O_TRUNC.
          * Don't call ml_truncate as it would close the fork being opened. */
         log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                       "*** truncate with fi but no fh - skipping (will be handled by open)\n");
+                       "*** truncate with fi but no fh - skipping (will be handled by open)");
         ret = 0;
     } else {
-        log_for_client(NULL, AFPFSD, LOG_DEBUG, "*** truncate calling ml_truncate\n");
+        log_for_client(NULL, AFPFSD, LOG_DEBUG, "*** truncate calling ml_truncate");
         ret = ml_truncate(volume, path, offset);
     }
 
-    log_for_client(NULL, AFPFSD, LOG_DEBUG, "*** truncate returning %d\n", ret);
+    log_for_client(NULL, AFPFSD, LOG_DEBUG, "*** truncate returning %d", ret);
     return ret;
 }
 
@@ -572,30 +551,27 @@ static int fuse_truncate(const char * path, off_t offset)
 
 #if FUSE_NEW_API
 static int fuse_chmod(const char * path, mode_t mode,
-                      struct fuse_file_info *fi)
-{
-    (void) fi;
+                      __attribute__((unused)) struct fuse_file_info *fi)
 #else
 static int fuse_chmod(const char * path, mode_t mode)
-{
 #endif
+{
     struct afp_volume * volume =
         (struct afp_volume *)
         ((struct fuse_context *)(fuse_get_context()))->private_data;
     int ret;
-    log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                   "** chmod %s\n", path);
+    log_for_client(NULL, AFPFSD, LOG_DEBUG, "** chmod %s", path);
     ret = ml_chmod(volume, path, mode);
 
     switch (ret) {
     case -EPERM:
         log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                       "You're not the owner of this file.\n");
+                       "You're not the owner of this file, cannot change permissions");
         break;
 
     case -ENOSYS:
         log_for_client(NULL, AFPFSD, LOG_WARNING,
-                       "chmod unsupported or this mode is not possible with this server\n");
+                       "chmod unsupported or this mode is not possible with this server");
         break;
 
     case -EFAULT:
@@ -605,7 +581,7 @@ static int fuse_chmod(const char * path, mode_t mode)
                        "Are you possibly mounting from a netatalk server "
                        "with \"unix priv = no\" in afp.conf?\n"
                        "I'm marking this volume as broken for 'extended' chmod modes.\n"
-                       "Allowed bits are: %o\n", AFP_CHMOD_ALLOWED_BITS_22);
+                       "Allowed bits are: %o", AFP_CHMOD_ALLOWED_BITS_22);
         ret = 0;
         break;
     }
@@ -616,19 +592,17 @@ static int fuse_chmod(const char * path, mode_t mode)
 #if FUSE_USE_VERSION >= 30
 #if FUSE_NEW_API
 static int fuse_utimens(const char *path, const struct timespec tv[2],
-                        struct fuse_file_info *fi)
-{
-    (void) fi;
+                        __attribute__((unused)) struct fuse_file_info *fi)
 #else
 static int fuse_utimens(const char *path, const struct timespec tv[2])
-{
 #endif
+{
     int ret = 0;
     struct afp_volume * volume =
         (struct afp_volume *)
         ((struct fuse_context *)(fuse_get_context()))->private_data;
     log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                   "** utimens\n");
+                   "** utimens");
     /* Convert timespec to utimbuf for ml_utime */
     struct utimbuf timebuf;
 
@@ -653,7 +627,7 @@ static int fuse_utime(const char * path, struct utimbuf * timebuf)
         (struct afp_volume *)
         ((struct fuse_context *)(fuse_get_context()))->private_data;
     log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                   "** utime\n");
+                   "** utime");
     ret = ml_utime(volume, path, timebuf);
     return ret;
 }
@@ -668,7 +642,7 @@ static void afp_destroy(__attribute__((unused)) void * ignore)
 
     if (volume->mounted == AFP_VOLUME_UNMOUNTED) {
         log_for_client(NULL, AFPFSD, LOG_WARNING,
-                       "Skipping unmounting of the volume %s\n", volume->volume_name_printable);
+                       "Skipping unmounting of the volume %s", volume->volume_name_printable);
         return;
     }
 
@@ -691,7 +665,7 @@ static int fuse_symlink(const char * path1, const char * path2)
 
     if ((ret == -EFAULT) || (ret == -ENOSYS)) {
         log_for_client(NULL, AFPFSD, LOG_WARNING,
-                       "Got some sort of internal error in when creating symlink\n");
+                       "Got some sort of internal error in when creating symlink");
     }
 
     return ret;
@@ -772,7 +746,7 @@ static int fuse_getattr_darwin(const char *path, struct fuse_darwin_attr *attr,
         (struct afp_volume *)
         ((struct fuse_context *)(fuse_get_context()))->private_data;
     int ret;
-    log_for_client(NULL, AFPFSD, LOG_DEBUG, "*** getattr of \"%s\"\n", path);
+    log_for_client(NULL, AFPFSD, LOG_DEBUG, "*** getattr of \"%s\"", path);
 
     /* Oddly, we sometimes get <dir1>/<dir2>/(null) for the path */
 
@@ -812,7 +786,7 @@ static int fuse_getattr(const char *path, struct stat *stbuf)
         (struct afp_volume *)
         ((struct fuse_context *)(fuse_get_context()))->private_data;
     int ret;
-    log_for_client(NULL, AFPFSD, LOG_DEBUG, "*** getattr of \"%s\"\n", path);
+    log_for_client(NULL, AFPFSD, LOG_DEBUG, "*** getattr of \"%s\"", path);
 
     /* Oddly, we sometimes get <dir1>/<dir2>/(null) for the path */
 

--- a/lib/afp.c
+++ b/lib/afp.c
@@ -162,7 +162,7 @@ int afp_reply(unsigned short subcommand, struct afp_server * server,
                                          server->data_read, other);
     } else {
         log_for_client(NULL, AFPFSD, LOG_WARNING,
-                       "AFP subcommand %d not supported\n", subcommand);
+                       "AFP subcommand %d not supported", subcommand);
     }
 
     return ret;
@@ -320,7 +320,7 @@ int afp_unmount_volume(struct afp_volume * volume)
 
     if (auto_shutdown_on_unmount && get_server_base() == NULL) {
         log_for_client(NULL, AFPFSD, LOG_NOTICE,
-                       "Last volume unmounted, triggering shutdown\n");
+                       "Last volume unmounted, triggering shutdown");
         trigger_exit();
     }
 
@@ -346,8 +346,8 @@ void afp_free_server(struct afp_server ** sp)
 
     for (p = server->command_requests; p;) {
         log_for_client(NULL, AFPFSD, LOG_NOTICE,
-                       "FSLeft in queue: %p, id: %d command: %d\n",                p, p->requestid,
-                       p->subcommand);
+                       "FSLeft in queue: %p, id: %d command: %d",
+                       p, p->requestid, p->subcommand);
         next = p->next;
         free(p);
         p = next;
@@ -717,7 +717,7 @@ int afp_server_connect(struct afp_server *server, int full)
 
     if (server->fd > 0) {
         log_for_client(NULL, AFPFSD, LOG_INFO,
-                       "Closing old socket fd=%d before reconnection\n", server->fd);
+                       "Closing old socket fd=%d before reconnection", server->fd);
         close(server->fd);
         server->fd = -1;
     }
@@ -725,7 +725,7 @@ int afp_server_connect(struct afp_server *server, int full)
     /* Increment connection generation to detect stale replies */
     server->connection_generation++;
     log_for_client(NULL, AFPFSD, LOG_INFO,
-                   "Connection generation now %u\n", server->connection_generation);
+                   "Connection generation now %u", server->connection_generation);
 
     while (address) {
         switch (address->ai_family) {

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -35,7 +35,7 @@ struct addrinfo *afp_get_address(void * priv, const char * hostname,
 
     if (res != 0) {
         log_for_client(priv, AFPFSD, LOG_ERR,
-                       "Could not resolve %s.\n", hostname);
+                       "Could not resolve %s.", hostname);
         return NULL;
     }
 
@@ -76,10 +76,10 @@ struct afp_server *afp_server_full_connect(void * priv,
     if ((ret = afp_server_connect(tmpserver, 1)) < 0) {
         if (ret == -ETIMEDOUT) {
             log_for_client(priv, AFPFSD, LOG_ERR,
-                           "Could not connect, never got a response to getstatus, %s\n", strerror(-ret));
+                           "Could not connect, never got a response to getstatus, %s", strerror(-ret));
         } else {
             log_for_client(priv, AFPFSD, LOG_ERR,
-                           "Could not connect, %s\n", strerror(-ret));
+                           "Could not connect, %s", strerror(-ret));
         }
 
         afp_server_remove(tmpserver);
@@ -106,7 +106,7 @@ struct afp_server *afp_server_full_connect(void * priv,
 
         if (afp_server_connect(s, 0) != 0) {
             log_for_client(priv, AFPFSD, LOG_ERR,
-                           "Could not connect to server error: %s\n",
+                           "Connection to server failed with error: %s",
                            strerror(errno));
             goto error;
         }

--- a/lib/dsi.c
+++ b/lib/dsi.c
@@ -130,7 +130,7 @@ static int dsi_remove_from_request_queue(struct afp_server *server,
 
 #ifdef DEBUG_DSI
     log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                   "*** Removing %d, %s\n", toremove->requestid,
+                   "*** Removing %d, %s", toremove->requestid,
                    afp_get_command_name(toremove->subcommand));
 #endif
     pthread_mutex_lock(&server->request_queue_mutex);
@@ -163,11 +163,12 @@ static int dsi_remove_from_request_queue(struct afp_server *server,
     pthread_mutex_unlock(&server->request_queue_mutex);
 #ifdef DEBUG_DSI
     log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                   "*** Never removed anything for %d, %s\n", toremove->requestid,
+                   "*** Never removed anything for %d, %s", toremove->requestid,
                    afp_get_command_name(toremove->subcommand));
 #endif
     log_for_client(NULL, AFPFSD, LOG_WARNING,
-                   "Got an unknown reply for requestid %i\n", ntohs(toremove->requestid));
+                   "Got an unknown reply for requestid %i",
+                   ntohs(toremove->requestid));
     return -1;
 }
 
@@ -182,7 +183,7 @@ void dsi_flush_request_queue(struct afp_server *server)
     }
 
     log_for_client(NULL, AFPFSD, LOG_INFO,
-                   "Flushing pending request queue before reconnection\n");
+                   "Flushing pending request queue before reconnection");
     pthread_mutex_lock(&server->request_queue_mutex);
     p = server->command_requests;
 
@@ -190,7 +191,7 @@ void dsi_flush_request_queue(struct afp_server *server)
         next = p->next;
 #ifdef DEBUG_DSI
         log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                       "*** Flushing request %d, %s\n", p->requestid,
+                       "*** Flushing request %d, %s", p->requestid,
                        afp_get_command_name(p->subcommand));
 #endif
         /* Wake any waiting thread with error */
@@ -210,7 +211,7 @@ void dsi_flush_request_queue(struct afp_server *server)
     server->command_requests = NULL;
     pthread_mutex_unlock(&server->request_queue_mutex);
     log_for_client(NULL, AFPFSD, LOG_INFO,
-                   "Request queue flushed\n");
+                   "Request queue flushed");
 }
 
 
@@ -237,7 +238,7 @@ int dsi_send(struct afp_server *server, char * msg, int size, int wait,
     /* Add request to the queue */
     if ((new_request = malloc(sizeof(struct dsi_request))) == NULL) {
         log_for_client(NULL, AFPFSD, LOG_ERR,
-                       "Could not allocate for new request\n");
+                       "Could not allocate for new request");
         return -1;
     }
 
@@ -274,7 +275,7 @@ int dsi_send(struct afp_server *server, char * msg, int size, int wait,
 
     pthread_mutex_lock(&server->send_mutex);
 #ifdef DEBUG_DSI
-    log_for_client(NULL, AFPFSD, LOG_DEBUG, "*** Sending %d, %s\n",
+    log_for_client(NULL, AFPFSD, LOG_DEBUG, "*** Sending %d, %s",
                    ntohs(header->requestid),
                    afp_get_command_name(new_request->subcommand));
 #endif
@@ -301,7 +302,7 @@ int dsi_send(struct afp_server *server, char * msg, int size, int wait,
     server->stats.tx_bytes += size;
     pthread_mutex_unlock(&server->send_mutex);
 #ifdef DEBUG_DSI
-    log_for_client(NULL, AFPFSD, LOG_DEBUG, "=== Waiting for response for %d %s\n",
+    log_for_client(NULL, AFPFSD, LOG_DEBUG, "=== Waiting for response for %d %s",
                    new_request->requestid,
                    afp_get_command_name(new_request->subcommand));
 #endif
@@ -309,7 +310,7 @@ int dsi_send(struct afp_server *server, char * msg, int size, int wait,
     if (new_request->wait < 0) {
         /* Wait forever */
 #ifdef DEBUG_DSI
-        log_for_client(NULL, AFPFSD, LOG_DEBUG, "=== Waiting forever for %d, %s\n",
+        log_for_client(NULL, AFPFSD, LOG_DEBUG, "=== Waiting forever for %d, %s",
                        new_request->requestid,
                        afp_get_command_name(new_request->subcommand));
 #endif
@@ -330,7 +331,7 @@ int dsi_send(struct afp_server *server, char * msg, int size, int wait,
     } else if (new_request->wait > 0) {
         /* wait for new_request->wait seconds */
 #ifdef DEBUG_DSI
-        log_for_client(NULL, AFPFSD, LOG_DEBUG, "=== Waiting for %d %s, for %ds\n",
+        log_for_client(NULL, AFPFSD, LOG_DEBUG, "=== Waiting for %d %s, for %ds",
                        new_request->requestid,
                        afp_get_command_name(new_request->subcommand),
                        new_request->wait);
@@ -343,7 +344,7 @@ int dsi_send(struct afp_server *server, char * msg, int size, int wait,
         if (new_request->wait == 0) {
 #ifdef DEBUG_DSI
             log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                           "=== Changing my mind, no longer waiting for %d\n",
+                           "=== Changing my mind, no longer waiting for %d",
                            new_request->requestid);
 #endif
             goto skip;
@@ -371,7 +372,7 @@ int dsi_send(struct afp_server *server, char * msg, int size, int wait,
         if (rc == ETIMEDOUT) {
             /* FIXME: should handle this case properly */
 #ifdef DEBUG_DSI
-            log_for_client(NULL, AFPFSD, LOG_DEBUG, "=== Timedout for %d\n",
+            log_for_client(NULL, AFPFSD, LOG_DEBUG, "=== Timedout for %d",
                            new_request->requestid);
 #endif
             goto out;
@@ -379,7 +380,7 @@ int dsi_send(struct afp_server *server, char * msg, int size, int wait,
     } else {
         /* Don't wait */
 #ifdef DEBUG_DSI
-        log_for_client(NULL, AFPFSD, LOG_DEBUG, "=== Skipping wait altogether for %d\n",
+        log_for_client(NULL, AFPFSD, LOG_DEBUG, "=== Skipping wait altogether for %d",
                        new_request->requestid);
 #endif
     }
@@ -387,7 +388,7 @@ int dsi_send(struct afp_server *server, char * msg, int size, int wait,
 #ifdef DEBUG_DSI
     log_for_client(NULL, AFPFSD, LOG_DEBUG,
                    "=== Done waiting for %d %s, waiting for %ds,"
-                   " return %d, DSI return %d\n",
+                   " return %d, DSI return %d",
                    new_request->requestid,
                    afp_get_command_name(new_request->subcommand),
                    new_request->wait,
@@ -412,21 +413,21 @@ int dsi_command_reply(struct afp_server* server, unsigned short subcommand,
 
     if ((unsigned long) server->data_read < sizeof(struct dsi_header)) {
         log_for_client(NULL, AFPFSD, LOG_WARNING,
-                       "Got a short reply command, I am just ignoring it. size: %d\n",
+                       "Got a short reply command, I am just ignoring it. size: %d",
                        server->data_read);
         return -1;
     }
 
     if (subcommand == 0) {
         log_for_client(NULL, AFPFSD, LOG_WARNING,
-                       "Broken subcommand: %d\n", subcommand);
+                       "Broken subcommand: %d", subcommand);
         return -1;
     }
 
     if ((subcommand == afpRead) || (subcommand == afpReadExt)) {
         struct afp_rx_buffer * buf = other;
 #ifdef DEBUG_DSI
-        log_for_client(NULL, AFPFSD, LOG_DEBUG, "=== read() for afpRead, %d bytes\n",
+        log_for_client(NULL, AFPFSD, LOG_DEBUG, "=== read() for afpRead, %d bytes",
                        buf->maxsize - buf->size);
 #endif
 
@@ -484,7 +485,7 @@ void dsi_opensession_reply(struct afp_server * server)
             server->replay_cache_size = ntohl(cache_size);
             server->supports_replay_cache = 1;
             log_for_client(NULL, AFPFSD, LOG_INFO,
-                           "Replay cache enabled (size: %u)\n",
+                           "Replay cache enabled (size: %u)",
                            server->replay_cache_size);
         }
 
@@ -496,7 +497,7 @@ void dsi_opensession_reply(struct afp_server * server)
     if (server->tx_quantum == 0) {
         server->tx_quantum = DSI_DEFAULT_TX_QUANTUM;
         log_for_client(NULL, AFPFSD, LOG_WARNING,
-                       "Server did not provide tx_quantum, using default: %u\n",
+                       "Server did not provide tx_quantum, using default: %u",
                        server->tx_quantum);
     }
 }
@@ -587,7 +588,7 @@ void dsi_getstatus_reply(struct afp_server * server)
 
     if ((unsigned long) server->data_read < (sizeof(*reply1) + sizeof(*reply2))) {
         log_for_client(NULL, AFPFSD, LOG_ERR,
-                       "Got incomplete data for getstatus\n");
+                       "Got incomplete data for getstatus");
         return ;
     }
 
@@ -750,7 +751,7 @@ void *dsi_incoming_attention(void * other)
 
     if (shutdown) {
         log_for_client(NULL, AFPFSD, LOG_ERR,
-                       "Got a shutdown notice in packet %d, going down in %d mins\n",
+                       "Got a shutdown notice in packet %d, going down in %d mins",
                        ntohs(packet->header.requestid), mins);
         loop_disconnect(server);
         server->connect_state = SERVER_STATE_DISCONNECTED;
@@ -792,7 +793,7 @@ int dsi_recv(struct afp_server * server)
     /* Make sure we have at least one  header */
     if ((amount_to_read = sizeof(struct dsi_header) - server->data_read) > 0) {
 #ifdef DEBUG_DSI
-        log_for_client(NULL, AFPFSD, LOG_DEBUG, "<<< read() for dsi, %d bytes\n",
+        log_for_client(NULL, AFPFSD, LOG_DEBUG, "<<< read() for dsi, %d bytes",
                        amount_to_read);
 #endif
         ret = read(server->fd, server->incoming_buffer + server->data_read,
@@ -826,7 +827,7 @@ gotenough:
 
     if (!request && (header->flags == DSI_REPLY)) {
         log_for_client(NULL, AFPFSD, LOG_ERR,
-                       "I have no idea what this is a reply to, id %d.\n",
+                       "I have no idea what this is a reply to, id %d",
                        ntohs(header->requestid));
         runt_packet = 1;
         server->stats.runt_packets++;
@@ -836,7 +837,7 @@ gotenough:
     if (request
             && request->connection_generation != server->connection_generation) {
         log_for_client(NULL, AFPFSD, LOG_WARNING,
-                       "Discarding stale reply id %d from connection generation %u (current: %u)\n",
+                       "Discarding stale reply id %d from connection generation %u (current: %u)",
                        ntohs(header->requestid), request->connection_generation,
                        server->connection_generation);
         runt_packet = 1;
@@ -863,7 +864,7 @@ gotenough:
 
         if ((!buf) || (!buf->maxsize)) {
             log_for_client(NULL, AFPFSD, LOG_ERR,
-                           "No buffer allocated for incoming data\n");
+                           "No buffer allocated for incoming data");
             return -1;
         }
 
@@ -873,7 +874,7 @@ gotenough:
 
 #ifdef DEBUG_DSI
         log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                       "<<< read() in response to a request, %d bytes\n", newmax);
+                       "<<< read() in response to a request, %d bytes", newmax);
 #endif
         ret = read(server->fd, buf->data + buf->size,
                    newmax);
@@ -929,7 +930,7 @@ gotenough:
 
         amount_to_read = min(ntohl(header->length), (unsigned long) server->bufsize);
 #ifdef DEBUG_DSI
-        log_for_client(NULL, AFPFSD, LOG_DEBUG, "<<< read() of rest of AFP, %d bytes\n",
+        log_for_client(NULL, AFPFSD, LOG_DEBUG, "<<< read() of rest of AFP, %d bytes",
                        amount_to_read);
 #endif
         ret = read(server->fd, (void *)
@@ -962,8 +963,9 @@ process_packet:
        (or, for an afpRead, just the header and the data's been
         dumped in the preallocated buffer */
 #ifdef DEBUG_DSI
-    log_for_client(NULL, AFPFSD, LOG_DEBUG, "<<< Handling %d\n",
-                   ntohs(header->requestid));
+    log_for_client(NULL, AFPFSD, LOG_DEBUG,
+                   "<<< Handling DSI command %d, request id %d",
+                   header->command, ntohs(header->requestid));
 #endif
 
     switch (header->command) {
@@ -1004,7 +1006,7 @@ process_packet:
 
     default:
         log_for_client(NULL, AFPFSD, LOG_ERR,
-                       "Unknown DSI command %i\n", header->command);
+                       "Unknown DSI command %i", header->command);
         goto error;
     }
 
@@ -1051,7 +1053,7 @@ out:
 
     if (request) {
 #ifdef DEBUG_DSI
-        log_for_client(NULL, AFPFSD, LOG_DEBUG, "<<< Found request %d, %s\n",
+        log_for_client(NULL, AFPFSD, LOG_DEBUG, "<<< Found request %d, %s",
                        request->requestid,
                        afp_get_command_name(request->subcommand));
 #endif
@@ -1059,7 +1061,7 @@ out:
         if (request->wait) {
 #ifdef DEBUG_DSI
             log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                           "<<< Signalling %d, returning %d or %d\n", request->requestid,
+                           "<<< Signalling %d, returning %d or %d", request->requestid,
                            request->return_code, rc);
 #endif
             pthread_mutex_lock(&request->waiting_mutex);
@@ -1076,7 +1078,7 @@ out:
 error:
 #ifdef DEBUG_DSI
     log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                   "returning from dsi_recv with an error\n");
+                   "Returning from dsi_recv with an error");
 #endif
     return -1;
 }

--- a/lib/log.c
+++ b/lib/log.c
@@ -21,5 +21,5 @@ void stdout_log_for_client(
     __attribute__((unused)) int loglevel,
     const char *message)
 {
-    printf("%s", message);
+    printf("%s\n", message);
 }

--- a/lib/lowlevel.c
+++ b/lib/lowlevel.c
@@ -745,7 +745,7 @@ int ll_write(struct afp_volume * volume,
     /* Sanity check: tx_quantum must be non-zero */
     if (max_packet_size == 0) {
         log_for_client(NULL, AFPFSD, LOG_ERR,
-                       "ll_write: tx_quantum is 0, cannot write\n");
+                       "ll_write: tx_quantum is 0, cannot write");
         return -EIO;
     }
 
@@ -768,7 +768,7 @@ int ll_write(struct afp_volume * volume,
         /* Defensive check: never send a zero-byte write */
         if (sizetowrite == 0) {
             log_for_client(NULL, AFPFSD, LOG_ERR,
-                           "ll_write: sizetowrite is 0, aborting\n");
+                           "ll_write: sizetowrite is 0, aborting");
             err = EIO;
             goto error;
         }

--- a/lib/proto_attr.c
+++ b/lib/proto_attr.c
@@ -41,7 +41,7 @@ int afp_listextattr(struct afp_volume * volume,
         char *msg = malloc(len);
 
         if (!msg) {
-            log_for_client(NULL, AFPFSD, LOG_WARNING, "Out of memory\n");
+            log_for_client(NULL, AFPFSD, LOG_WARNING, "Out of memory in afp_listextattr");
             return -1;
         };
 
@@ -154,7 +154,7 @@ int afp_getextattr(struct afp_volume * volume, unsigned int dirid,
         char *msg = malloc(len);
 
         if (!msg) {
-            log_for_client(NULL, AFPFSD, LOG_WARNING, "Out of memory\n");
+            log_for_client(NULL, AFPFSD, LOG_WARNING, "Out of memory in afp_getextattr");
             return -1;
         };
 
@@ -220,7 +220,7 @@ int afp_setextattr(struct afp_volume * volume, unsigned int dirid,
         char *msg = malloc(len);
 
         if (!msg) {
-            log_for_client(NULL, AFPFSD, LOG_WARNING, "Out of memory\n");
+            log_for_client(NULL, AFPFSD, LOG_WARNING, "Out of memory in afp_setextattr");
             return -1;
         };
 
@@ -291,7 +291,7 @@ int afp_removeextattr(struct afp_volume * volume, unsigned int dirid,
         char *msg = malloc(len);
 
         if (!msg) {
-            log_for_client(NULL, AFPFSD, LOG_WARNING, "Out of memory\n");
+            log_for_client(NULL, AFPFSD, LOG_WARNING, "Out of memory in afp_removeextattr");
             return -1;
         }
 

--- a/lib/proto_desktop.c
+++ b/lib/proto_desktop.c
@@ -58,7 +58,8 @@ int afp_geticon_reply(__attribute__((unused)) struct afp_server *server,
     unsigned int len = size - sizeof(*reply_packet);
 
     if (size < (sizeof(*reply_packet) + icon->maxsize)) {
-        log_for_client(NULL, AFPFSD, LOG_WARNING, "getcomment icon is too short\n");
+        log_for_client(NULL, AFPFSD, LOG_WARNING,
+                       "getcomment icon is too short (%u bytes)", size);
         return -1;
     }
 
@@ -157,7 +158,7 @@ int afp_getcomment_reply(__attribute__((unused)) struct afp_server *server,
 
     if (size < sizeof(struct dsi_header)) {
         log_for_client(NULL, AFPFSD, LOG_WARNING,
-                       "getcomment response is too short\n");
+                       "getcomment response is too short (%u bytes)", size);
         return -1;
     }
 
@@ -218,7 +219,8 @@ int afp_opendt_reply(__attribute__((unused)) struct afp_server *server,
     unsigned short *refnum = other;
 
     if (size < sizeof(*reply_packet)) {
-        log_for_client(NULL, AFPFSD, LOG_WARNING, "opendt response is too short\n");
+        log_for_client(NULL, AFPFSD, LOG_WARNING,
+                       "opendt response is too short (%u bytes)", size);
         return -1;
     }
 

--- a/lib/proto_files.c
+++ b/lib/proto_files.c
@@ -176,7 +176,7 @@ int afp_delete(struct afp_volume * volume,
 
     if ((msg = malloc(len)) == NULL) {
         log_for_client(NULL, AFPFSD, LOG_ERR,
-                       "Out of memory\n");
+                       "Out of memory in afp_delete");
         return -1;
     };
 
@@ -244,7 +244,7 @@ int afp_read_reply(struct afp_server *server, char * buf, unsigned int size,
 
     if (size > rx_quantum) {
         log_for_client(NULL, AFPFSD, LOG_ERR,
-                       "This is definitely weird, I guess I'll just drop %d bytes\n",
+                       "This is definitely weird, I guess I'll just drop %d bytes",
                        size - rx_quantum);
         size = rx_quantum;
     }
@@ -294,7 +294,7 @@ int afp_readext_reply(struct afp_server *server, char * buf, unsigned int size,
 
     if (size > rx_quantum) {
         log_for_client(NULL, AFPFSD, LOG_ERR,
-                       "This is definitely weird, I guess I'll just drop %d bytes\n",
+                       "This is definitely weird, I guess I'll just drop %d bytes",
                        size - rx_quantum);
         size = rx_quantum;
     }

--- a/lib/proto_fork.c
+++ b/lib/proto_fork.c
@@ -121,7 +121,7 @@ int afp_openfork_reply(__attribute__((unused)) struct afp_server *server,
             (reply.header.return_code.error_code == kFPDenyConflict)) {
         if (size < sizeof(reply)) {
             log_for_client(NULL, AFPFSD, LOG_ERR,
-                           "openfork response is too short\n");
+                           "openfork response is too short (%u bytes)", size);
             return -1;
         }
 

--- a/lib/proto_server.c
+++ b/lib/proto_server.c
@@ -49,7 +49,7 @@ int afp_getsrvrparms_reply(struct afp_server *server, char * msg,
 
     if (size < header_size) {
         log_for_client(NULL, AFPFSD, LOG_WARNING,
-                       "getsrvparm_reply response too short\n");
+                       "getsrvparm_reply response too short (%u bytes)", size);
         return -1;
     }
 
@@ -108,7 +108,8 @@ int afp_getsrvrmsg_reply(__attribute__((unused)) struct afp_server *server,
     char *mesg = other, *src;
 
     if (size < sizeof(struct afp_getsrvrmsg_reply_packet)) {
-        log_for_client(NULL, AFPFSD, LOG_WARNING, "getsrvrmsg response too short\n");
+        log_for_client(NULL, AFPFSD, LOG_WARNING,
+                       "getsrvrmsg response too short (%u bytes)", size);
         return -1;
     }
 

--- a/lib/proto_volume.c
+++ b/lib/proto_volume.c
@@ -234,7 +234,7 @@ int afp_getvolparms_reply(struct afp_server *server, char * buf,
     bitmap = ntohs(reply->bitmap);
 
     if (!volume) {
-        log_for_client(NULL, AFPFSD, LOG_WARNING, "I don't know what volume this is\n");
+        log_for_client(NULL, AFPFSD, LOG_WARNING, "I don't know what volume this is");
         return -1;
     }
 

--- a/lib/server.c
+++ b/lib/server.c
@@ -41,14 +41,14 @@ struct afp_server *afp_server_complete_connection(
     add_fd_and_signal(server->fd);
     dsi_opensession(server);
     log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                   "afp_server_complete_connection -- DSI session: tx_quantum=%u (max write size)\n",
+                   "afp_server_complete_connection -- DSI session: tx_quantum=%u (max write size)",
                    server->tx_quantum);
 
     /* Figure out what version we're using */
     if (((server->using_version =
                 pick_version(versions, requested_version)) == NULL)) {
         log_for_client(priv, AFPFSD, LOG_ERR,
-                       "Server cannot handle AFP version %d\n",
+                       "Server cannot handle AFP version %d",
                        requested_version);
         goto error;
     }
@@ -57,7 +57,7 @@ struct afp_server *afp_server_complete_connection(
 
     if (using_uam == -1) {
         log_for_client(priv, AFPFSD, LOG_ERR,
-                       "Could not pick a matching UAM.\n");
+                       "Could not pick a matching UAM");
         goto error;
     }
 
@@ -65,13 +65,13 @@ struct afp_server *afp_server_complete_connection(
 
     if (afp_server_login(server, mesg, &len, MAX_ERROR_LEN)) {
         log_for_client(priv, AFPFSD, LOG_ERR,
-                       "Login error: %s\n", mesg);
+                       "Login error: %s", mesg);
         goto error;
     }
 
     if (afp_getsrvrparms(server)) {
         log_for_client(priv, AFPFSD, LOG_ERR,
-                       "Could not get server parameters\n");
+                       "Could not get server parameters");
         goto error;
     }
 
@@ -88,7 +88,7 @@ struct afp_server *afp_server_complete_connection(
 
     if (strlen(loginmsg) > 0)
         log_for_client(priv, AFPFSD, LOG_NOTICE,
-                       "Login message: %s\n", loginmsg);
+                       "Login message: %s", loginmsg);
 
     memcpy(server->loginmesg, loginmsg, AFP_LOGINMESG_LEN);
     return server;

--- a/lib/uams.c
+++ b/lib/uams.c
@@ -121,8 +121,7 @@ static int register_uam(struct afp_uam * uam)
 
     return 0;
 error:
-    log_for_client(NULL, AFPFSD, LOG_WARNING,
-                   "Could not register all UAMs\n");
+    log_for_client(NULL, AFPFSD, LOG_WARNING, "Could not register all UAMs");
     return -1;
 }
 
@@ -1146,7 +1145,7 @@ int afp_dologin(struct afp_server *server,
 
     if ((u = find_uam_by_bitmap(uam)) == NULL) {
         log_for_client(NULL, AFPFSD, LOG_WARNING,
-                       "Unknown uam\n");
+                       "afp_dologin -- Unknown UAM");
         return -1;
     }
 
@@ -1161,7 +1160,7 @@ int afp_dopasswd(struct afp_server *server,
 
     if ((u = find_uam_by_bitmap(uam)) == NULL) {
         log_for_client(NULL, AFPFSD, LOG_WARNING,
-                       "Unknown uam\n");
+                       "afp_dopasswd -- Unknown UAM");
         return -1;
     }
 


### PR DESCRIPTION
flesh out and clarify several log messages

consistently log strings without newline and let the logger routines add one

add helper functions for looking up FUSE result and error codes

print human readable FUSE errors when mounting