### PR TITLE
refactor FUSE unmount flow to use proper libfuse3 API

### DIFF
--- a/fuse/commands.c
+++ b/fuse/commands.c
@@ -492,8 +492,12 @@ found:
         return AFP_SERVER_RESULT_ERROR;
     }
 
-    afp_unmount_volume(v);
-    /* Trigger daemon exit after unmounting - child daemon should exit */
+    if (afp_unmount_volume(v) != 0) {
+        log_for_client((void *) c, AFPFSD, LOG_ERR,
+                       "Unmount failed for %s; try using 'umount' or 'fusermount -u'", v->mountpoint);
+        return AFP_SERVER_RESULT_ERROR;
+    }
+
     log_for_client((void *) c, AFPFSD, LOG_NOTICE,
                    "Volume unmounted, exiting daemon");
     trigger_exit();

--- a/lib/afp.c
+++ b/lib/afp.c
@@ -302,8 +302,12 @@ int afp_unmount_volume(struct afp_volume * volume)
 
     volume->dtrefnum = 0;
 
-    if (libafpclient->unmount_volume) {
-        libafpclient->unmount_volume(volume);
+    if (libafpclient->unmount_volume && libafpclient->unmount_volume(volume) != 0) {
+        log_for_client(NULL, AFPFSD, LOG_WARNING,
+                       "FUSE unmount not supported - volume %s remains mounted",
+                       volume->volume_name_printable);
+        volume->mounted = AFP_VOLUME_MOUNTED;
+        return -1;
     }
 
     volume->mounted = AFP_VOLUME_UNMOUNTED;
@@ -324,7 +328,7 @@ int afp_unmount_volume(struct afp_volume * volume)
         trigger_exit();
     }
 
-    return -1;
+    return 0;
 }
 
 


### PR DESCRIPTION
call fuse_unmount() before exiting the FUSE thread for a clean shutdown that avoids potential data corruption

we don't support programmatic unmount for FUSE 2.9 or macFUSE for now – so we point the user to umount or fusermount instead

fix afp_init() to retrieve FUSE handle on macOS