### PR TITLE
clean up obsolete netatalk workaround code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ struct afp_volume {
     struct afp_file_info *open_forks;  // Linked list of open files
     pthread_mutex_t open_forks_mutex;
     struct did_cache_entry *did_cache_base;  // Directory ID cache
-    unsigned int extra_flags;  // VOLUME_EXTRA_FLAGS_VOL_CHMOD_BROKEN, etc.
+    unsigned int extra_flags;
     void *priv;  // FUSE/CLI-specific context
 };
 
@@ -90,19 +90,16 @@ struct afp_file_info {
 
 ## Common Pitfalls
 
-1. **Netatalk chmod quirks**: Server type `AFPFS_SERVER_TYPE_NETATALK` with `VOLUME_EXTRA_FLAGS_VOL_CHMOD_BROKEN`
-only supports `AFP_CHMOD_ALLOWED_BITS_22`. See `lib/midlevel.c:75-85`.
-
-2. **FUSE operation order**: `create() → write() → flush() → getattr() → release()`.
+1. **FUSE operation order**: `create() → write() → flush() → getattr() → release()`.
 Flush is critical on macOS.
 
-3. **AFP error codes**: Return values like `kFPAccessDenied` must be mapped to errno (`-EACCES`).
+2. **AFP error codes**: Return values like `kFPAccessDenied` must be mapped to errno (`-EACCES`).
 See `fuse/fuse_error.c`.
 
-4. **Thread safety**: libafpclient spawns threads and overrides signals.
+3. **Thread safety**: libafpclient spawns threads and overrides signals.
 Use provided loop, don't write custom `select()` loops.
 
-5. **Path translation**: `unixpath_to_afppath()` converts `/` to `:` for AFP protocol.
+4. **Path translation**: `unixpath_to_afppath()` converts `/` to `:` for AFP protocol.
 See `lib/utils.c`.
 
 ## Development Workflow

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -288,15 +288,11 @@ so there's been no testing.  Donations appreciated.
 
 ### Netatalk
 
-This open source server has a few issues, and afpfs-ng tries to work around
-them.  The most significant one is around file permissions; there's a bug in
-older versions whereby some permissions cannot be set with a chmod (particularly
-the execute bit on files).
+This open source server has been extensively tested with afpfs-ng
+and should work well with afpfs-ng.
 
-You should use netatalk 2.0.4 or later with afpfs-ng.
-
-After you attempt to 'chmod +x foo', 'status' will show you if it is broken or
-not.
+You must use netatalk 2.0.4 or later with afpfs-ng as earlier versions has
+broken Unix privilege support, notably when setting the execute bit.
 
 ### LaCie devices
 
@@ -313,7 +309,7 @@ directory.
 
 ## J.Other
 
-- length of file is currently fixed at 255; this isn't correct for AFP >3.0
+Deliberately left blank.
 
 ## K. References
 
@@ -326,8 +322,7 @@ Not all references are easy to find. The useful ones are:
 And other software:
 
 - netatalk: Netatalk is the server side, and it implements AFP 3.4 over
-  Appletalk and TCP/IP. It has a long history and has been heavily tested, but
-  is creative in some of its implementation.
+  Appletalk and TCP/IP. It has a long history and has been heavily tested.
 
 - afpfs: The original afpfs was last released for Linux kernel 2.2.5 and was
   written in kernel space. It was written by Ben Hekster, then taken over by

--- a/fuse/fuse_int.c
+++ b/fuse/fuse_int.c
@@ -578,12 +578,7 @@ static int fuse_chmod(const char * path, mode_t mode)
 
     case -EFAULT:
         log_for_client(NULL, AFPFSD, LOG_ERR,
-                       "I was trying to change permissions but you're setting "
-                       "some mode bits that we don't support.\n"
-                       "Are you possibly mounting from a netatalk server "
-                       "with \"unix priv = no\" in afp.conf?\n"
-                       "I'm marking this volume as broken for 'extended' chmod modes.\n"
-                       "Allowed bits are: %o", AFP_CHMOD_ALLOWED_BITS_22);
+                       "We don't support these permission bits on this server");
         ret = 0;
         break;
     }

--- a/include/afp.h
+++ b/include/afp.h
@@ -78,9 +78,11 @@ struct afp_file_info {
     int eof;
 };
 
-
+#if 0
+/* obsolete netatalk workaround flags */
 #define VOLUME_EXTRA_FLAGS_VOL_CHMOD_KNOWN 0x1
 #define VOLUME_EXTRA_FLAGS_VOL_CHMOD_BROKEN 0x2
+#endif
 #define VOLUME_EXTRA_FLAGS_SHOW_APPLEDOUBLE 0x4
 #define VOLUME_EXTRA_FLAGS_VOL_SUPPORTS_UNIX 0x8
 #define VOLUME_EXTRA_FLAGS_NO_LOCKING 0x10

--- a/include/afp_protocol.h
+++ b/include/afp_protocol.h
@@ -350,9 +350,4 @@ enum {
     kRecon1Refresh = 7, kGetKerberosSessionKey = 8
 };
 
-
-#define AFP_CHMOD_ALLOWED_BITS_22 \
-	(S_IRUSR |S_IWUSR | S_IRGRP | S_IWGRP |S_IROTH | S_IWOTH | S_IFREG )
-
-
 #endif

--- a/lib/dsi.c
+++ b/lib/dsi.c
@@ -568,7 +568,6 @@ void dsi_getstatus_reply(struct afp_server * server)
 {
     /* Todo: check for buffer overruns */
     char *data, *p, *p2;
-    int len;
     uint16_t *offset;
     /* This is the fixed portion */
     struct dsi_getstatus_header {
@@ -650,17 +649,8 @@ void dsi_getstatus_reply(struct afp_server * server)
         p2 = data + utf8_name_offset;
         /* Skip the hint character */
         p2 += 1;
-        len = copy_from_pascal(server->server_name_utf8, p2,
-                               AFP_SERVER_NAME_UTF8_LEN);
-
-        /* This is a workaround.  There's a bug in netatalk that in some
-         * circumstances puts the UTF8 servername off by one character */
-        if (len == 0) {
-            p2++;
-            len = copy_from_pascal(server->server_name_utf8, p2,
-                                   AFP_SERVER_NAME_UTF8_LEN);
-        }
-
+        copy_from_pascal(server->server_name_utf8, p2,
+                         AFP_SERVER_NAME_UTF8_LEN);
         convert_utf8dec_to_utf8pre(server->server_name_utf8,
                                    strlen(server->server_name_utf8),
                                    server->server_name_printable, AFP_SERVER_NAME_UTF8_LEN);

--- a/lib/lowlevel.c
+++ b/lib/lowlevel.c
@@ -125,16 +125,15 @@ int ll_zero_file(struct afp_volume * volume, unsigned short forkid,
     int ret;
 
     /* The Airport Extreme 7.1.1 will crash if you send it
-     * DataForkLenBit.  Netatalk replies with an error if you
-     * send it ExtDataForkLenBit.  So we need to choose. */
+     * DataForkLenBit. */
 
-    if ((volume->server->using_version->av_number < 30)  ||
-            (volume->server->server_type == AFPFS_SERVER_TYPE_NETATALK))
+    if (volume->server->using_version->av_number < 30) {
         bitmap = (resource ?
                   kFPRsrcForkLenBit : kFPDataForkLenBit);
-    else
+    } else {
         bitmap = (resource ?
                   kFPExtRsrcForkLenBit : kFPExtDataForkLenBit);
+    }
 
     ret = afp_setforkparms(volume, forkid, bitmap, 0);
 
@@ -172,16 +171,15 @@ int ll_setfork_size(struct afp_volume * volume, unsigned short forkid,
     int ret;
 
     /* The Airport Extreme 7.1.1 will crash if you send it
-     * DataForkLenBit.  Netatalk replies with an error if you
-     * send it ExtDataForkLenBit.  So we need to choose. */
+     * DataForkLenBit. */
 
-    if ((volume->server->using_version->av_number < 30)  ||
-            (volume->server->server_type == AFPFS_SERVER_TYPE_NETATALK))
+    if (volume->server->using_version->av_number < 30) {
         bitmap = (resource ?
                   kFPRsrcForkLenBit : kFPDataForkLenBit);
-    else
+    } else {
         bitmap = (resource ?
                   kFPExtRsrcForkLenBit : kFPExtDataForkLenBit);
+    }
 
     ret = afp_setforkparms(volume, forkid, bitmap, size);
 

--- a/lib/status.c
+++ b/lib/status.c
@@ -35,7 +35,6 @@ static void print_volume_status(struct afp_volume *v, struct afp_server *s,
                                 char *text, int *pos_p, int *len)
 {
     int pos = *pos_p;
-    unsigned int fl = v->extra_flags;
     pos += snprintf(text + pos, *len - pos,
                     "Volume \"%s\"\n    id: %d\n    attribs: 0x%x\n    mounted: %s%s\n",
                     v->volume_name_printable, v->volid,
@@ -56,23 +55,7 @@ static void print_volume_status(struct afp_volume *v, struct afp_server *s,
         pos += snprintf(text + pos, *len - pos,
                         "    Unix permissions: %s",
                         (v->extra_flags & VOLUME_EXTRA_FLAGS_VOL_SUPPORTS_UNIX) ?
-                        "Yes" : "No");
-
-        if (s->server_type == AFPFS_SERVER_TYPE_NETATALK) {
-            pos += snprintf(text + pos, *len - pos,
-                            ", Netatalk permissions broken: ");
-
-            if (fl & VOLUME_EXTRA_FLAGS_VOL_CHMOD_KNOWN)
-                if (fl & VOLUME_EXTRA_FLAGS_VOL_CHMOD_BROKEN)
-                    pos += snprintf(text + pos, *len - pos,
-                                    "Yes\n");
-                else
-                    pos += snprintf(text + pos, *len - pos,
-                                    "No\n");
-            else
-                pos += snprintf(text + pos, *len - pos,
-                                "Unknown\n");
-        }
+                        "Yes\n" : "No\n");
     }
 
     *pos_p = pos;


### PR DESCRIPTION
very old versions of netatalk had bugs and quirks that needed to be worked around, but it's time to remove this now since a lot has changed in 20 years

if afpfs-ng triggers buggy behavior in netatalk in the future, this should be addressed at the source