### PR TITLE
afpcmd: introduce exit command for detaching from volume

### DIFF
--- a/cmdline/cmdline_afp.c
+++ b/cmdline/cmdline_afp.c
@@ -1454,6 +1454,22 @@ error:
     return -1;
 }
 
+/* Detach from the current volume */
+int com_exit(__attribute__((unused)) char *arg)
+{
+    if (vol == NULL) {
+        printf("Not connected to a volume\n");
+        return 0;
+    }
+
+    printf("Detaching from volume %s\n", vol->volume_name_printable);
+    afp_unmount_volume(vol);
+    vol = NULL;
+    url.volumename[0] = '\0';
+    snprintf(curdir, AFP_MAX_PATH, "/");
+    return 0;
+}
+
 /* Print out the current working directory locally. */
 int com_lpwd(__attribute__((unused)) char * ignore)
 {

--- a/cmdline/cmdline_afp.h
+++ b/cmdline/cmdline_afp.h
@@ -24,6 +24,7 @@ int com_statvfs(char * arg);
 int com_pass(char * arg);
 int com_user(char * arg);
 int com_disconnect(char * arg);
+int com_exit(char * arg);
 
 void cmdline_afp_exit(void);
 

--- a/cmdline/cmdline_main.c
+++ b/cmdline/cmdline_main.c
@@ -197,6 +197,7 @@ COMMAND commands[] = {
     { "df", com_statvfs, "Get volume space information", 1 },
     { "dir", com_dir, "List files in DIR", 1 },
     { "disconnect", com_disconnect, "Disconnect from the current server", 1 },
+    { "exit", com_exit, "Detach from the current volume", 1 },
     { "get", com_get, "Retrieve the file FILENAME and store them locally", 1 },
     { "help", com_help, "Display this text", 0 },
     { "lcd", com_lcd, "Change local directory to DIR", 1 },


### PR DESCRIPTION
it is a common usage pattern to want to switch to another shared volume on the current server, without disconnecting from it