### PR TITLE
pass buffer length to pascal conversion functions consistently

### DIFF
--- a/lib/dsi.c
+++ b/lib/dsi.c
@@ -519,7 +519,7 @@ static int dsi_parse_versions(struct afp_server * server, char * msg)
     p = msg + 1;
 
     for (i = 0; i < num_versions; i++) {
-        len = copy_from_pascal(tmpversionname, p, 33) +1;
+        len = copy_from_pascal(tmpversionname, p, sizeof(tmpversionname)) + 1;
 
         for (tmpversion = afp_versions; tmpversion->av_name; tmpversion++) {
             if (strcmp(tmpversion->av_name, tmpversionname) == 0) {
@@ -594,7 +594,7 @@ void dsi_getstatus_reply(struct afp_server * server)
     data = (char *) server->incoming_buffer + sizeof(struct dsi_header);
     /* First, get the fixed portion */
     p = data + ntohs(reply1->machine_offset);
-    copy_from_pascal(server->machine_type, p, AFP_MACHINETYPE_LEN);
+    copy_from_pascal(server->machine_type, p, sizeof(server->machine_type));
     p = data + ntohs(reply1->version_offset);
     dsi_parse_versions(server, p);
     p = data + ntohs(reply1->uams_offset);
@@ -608,7 +608,7 @@ void dsi_getstatus_reply(struct afp_server * server)
 
     server->flags = ntohs(reply1->flags);
     p = (void *)((unsigned long) server->incoming_buffer + sizeof(*reply1));
-    p += copy_from_pascal(server->server_name, p, AFP_SERVER_NAME_LEN) +1;
+    p += copy_from_pascal(server->server_name, p, sizeof(server->server_name)) + 1;
 
     /* Now work our way through the variable bits */
 
@@ -650,7 +650,7 @@ void dsi_getstatus_reply(struct afp_server * server)
         /* Skip the hint character */
         p2 += 1;
         copy_from_pascal(server->server_name_utf8, p2,
-                         AFP_SERVER_NAME_UTF8_LEN);
+                         sizeof(server->server_name_utf8));
         convert_utf8dec_to_utf8pre(server->server_name_utf8,
                                    strlen(server->server_name_utf8),
                                    server->server_name_printable, AFP_SERVER_NAME_UTF8_LEN);

--- a/lib/proto_map.c
+++ b/lib/proto_map.c
@@ -128,7 +128,8 @@ int afp_mapid_reply(__attribute__((unused)) struct afp_server *server,
         struct dsi_header header __attribute__((__packed__));
         char *name ;
     }  __attribute__((__packed__)) * reply = (void *) buf;
-    char *name = other;
+    static char name[AFP_MAX_PATH];
+    char *name_ptr = other;
 
     // RJVB: there should be at least 2 bytes after the dsi_header
     if (size < (sizeof(unsigned short) + sizeof(struct dsi_header))) {
@@ -139,7 +140,13 @@ int afp_mapid_reply(__attribute__((unused)) struct afp_server *server,
         return -1;
     }
 
-    copy_from_pascal_two(name, reply->name, 255);
+    memset(name, 0, AFP_MAX_PATH);
+    copy_from_pascal_two(name, reply->name, sizeof(name));
+
+    if (name_ptr != NULL) {
+        memcpy(name_ptr, name, AFP_MAX_PATH);
+    }
+
     return 0;
 }
 

--- a/lib/proto_replyblock.c
+++ b/lib/proto_replyblock.c
@@ -70,7 +70,7 @@ int parse_reply_block(__attribute__((unused)) struct afp_server *server,
 
     if (bitmap & kFPLongNameBit) {
         unsigned short *offset = (void *) p2;
-        copy_from_pascal(filecur->name, buf + (ntohs(*offset)), AFP_MAX_PATH);
+        copy_from_pascal(filecur->name, buf + (ntohs(*offset)), sizeof(filecur->name));
         p2 += 2;
     }
 
@@ -135,7 +135,7 @@ int parse_reply_block(__attribute__((unused)) struct afp_server *server,
     if (bitmap & kFPUTF8NameBit) {
         unsigned short *offset = (void *) p2;
         copy_from_pascal_two(filecur->name, buf + (ntohs(*offset)) + 4,
-                             AFP_MAX_PATH);
+                             sizeof(filecur->name));
         p2 += 2;
         p2 += 4;
     }


### PR DESCRIPTION
use sizeof() and static buffer sizes to pass the len argument to pascal string conversion functions

in a previous commit, we introduced null termination to the pascal functions, which caused truncation when the string was exactly the max length