### PR TITLE
compatibility with libfuse v2 on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,8 +160,40 @@ jobs:
           name: meson-logs-${{ github.job }}
           path: build/meson-logs
 
-  build-macos:
-    name: macOS
+  build-macos-fuse2:
+    name: macOS (with FUSE v2)
+    runs-on: macos-latest
+    env:
+      HOMEBREW_NO_INSTALL_CLEANUP: 1
+      HOMEBREW_NO_AUTO_UPDATE: 1
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Install dependencies
+        run: |
+          brew update
+          brew upgrade
+          brew install \
+            macfuse \
+            meson
+      - name: Setup
+        run: meson setup build -Dforce-fuse-v2=true
+      - name: Compile
+        run: meson compile -C build
+      - name: Install
+        run: sudo meson install -C build
+      - name: Run
+        run: afpcmd -h
+      - name: Uninstall
+        run: sudo ninja -C build uninstall
+      - name: Upload meson logs
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: meson-logs-${{ github.job }}
+          path: build/meson-logs
+
+  build-macos-fuse3:
+    name: macOS (with FUSE v3)
     runs-on: macos-latest
     env:
       HOMEBREW_NO_INSTALL_CLEANUP: 1

--- a/fuse/fuse_int.c
+++ b/fuse/fuse_int.c
@@ -719,7 +719,11 @@ static int fuse_rename(const char * path_from, const char * path_to)
 #endif
 
 #ifdef __APPLE__
+#if FUSE_USE_VERSION >= 30
 static int fuse_statfs(const char *path, struct statfs *stat)
+#else
+static int fuse_statfs(const char *path, struct statvfs *stat)
+#endif
 {
     struct afp_volume * volume =
         (struct afp_volume *)
@@ -755,12 +759,10 @@ static int fuse_statfs(const char *path, struct statvfs *stat)
 #endif
 
 
-#ifdef __APPLE__
-#if FUSE_USE_VERSION >= 30
+#if defined(__APPLE__) && FUSE_USE_VERSION >= 30
 static int fuse_getattr_darwin(const char *path, struct fuse_darwin_attr *attr,
-                               struct fuse_file_info *fi)
+                               __attribute__((unused)) struct fuse_file_info *fi)
 {
-    (void) fi;
     char *c;
     struct stat stbuf;
     struct afp_volume * volume =
@@ -790,18 +792,14 @@ static int fuse_getattr_darwin(const char *path, struct fuse_darwin_attr *attr,
 
     return ret;
 }
-
-#endif
 #else
 #if FUSE_NEW_API
 static int fuse_getattr(const char *path, struct stat *stbuf,
-                        struct fuse_file_info *fi)
-{
-    (void) fi;
+                        __attribute__((unused)) struct fuse_file_info *fi)
 #else
 static int fuse_getattr(const char *path, struct stat *stbuf)
-{
 #endif
+{
     char *c;
     struct afp_volume * volume =
         (struct afp_volume *)

--- a/meson.build
+++ b/meson.build
@@ -66,7 +66,7 @@ endif
 
 gcrypt_dep = dependency('libgcrypt', version: '>=1.2.3', required: false)
 fuse_dep = dependency('fuse3', version: '>=3.0.0', required: false)
-if not fuse_dep.found()
+if not fuse_dep.found() or get_option('force-fuse-v2')
     fuse_dep = dependency('fuse', version: '>=2.9.0', required: false)
 endif
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,3 +4,9 @@ option(
     value: true,
     description: 'Enable FUSE support',
 )
+option(
+    'force-fuse-v2',
+    type: 'boolean',
+    value: false,
+    description: 'Force FUSE v2 compatibility mode (if FUSE v3 is detected)',
+)


### PR DESCRIPTION
tweak compatibility macros so that all required functions for libfuse v2 are available when building on macOS

introduce a '-Dforce-fuse-v2' meson build system boolean option to force building with libfuse v2 when both v2 and v3 are available