### PR TITLE
retry read/select on EINTR in FUSE client/daemon socket I/O

### DIFF
--- a/fuse/client.c
+++ b/fuse/client.c
@@ -927,7 +927,10 @@ int read_answer(int sock)
         tv.tv_sec = 30;
         tv.tv_usec = 0;
         ords = rds;
-        ret = select(sock + 1, &ords, NULL, NULL, &tv);
+
+        do {
+            ret = select(sock + 1, &ords, NULL, NULL, &tv);
+        } while (ret < 0 && errno == EINTR);
 
         if (ret == 0) {
             printf("No response from server\n");
@@ -938,8 +941,10 @@ int read_answer(int sock)
         if (FD_ISSET(sock, &ords)) {
             if (len == 0) {
                 /* Read header first */
-                packetlen = read(sock, incoming_buffer + len,
-                                 sizeof(struct afp_server_response));
+                do {
+                    packetlen = read(sock, incoming_buffer + len,
+                                     sizeof(struct afp_server_response));
+                } while (packetlen < 0 && errno == EINTR);
 
                 if (packetlen <= 0) {
                     /* If the outgoing command was UNMOUNT, treat EOF as success */
@@ -973,7 +978,9 @@ int read_answer(int sock)
                     answer = (void *) incoming_buffer;
                 }
             } else {
-                packetlen = read(sock, incoming_buffer + len, buffer_size - len);
+                do {
+                    packetlen = read(sock, incoming_buffer + len, buffer_size - len);
+                } while (packetlen < 0 && errno == EINTR);
 
                 if (packetlen == 0) {
                     printf("Connection closed\n");

--- a/fuse/commands.c
+++ b/fuse/commands.c
@@ -824,10 +824,16 @@ static int process_command(struct fuse_client * c)
 {
     int ret;
     int fd;
-    ret = read(c->fd, &c->incoming_string, AFP_CLIENT_INCOMING_BUF);
+
+    do {
+        ret = read(c->fd, &c->incoming_string, AFP_CLIENT_INCOMING_BUF);
+    } while (ret < 0 && errno == EINTR);
 
     if (ret <= 0) {
-        perror("reading");
+        if (ret < 0) {
+            perror("reading");
+        }
+
         goto out;
     }
 


### PR DESCRIPTION
Signal delivery (SIGCHLD, SIGUSR2) can interrupt blocking read() and select() calls in the daemon and client. Without retrying on EINTR, the daemon printed a spurious "reading: Interrupted system call" error and dropped the client connection, while the client would mishandle interrupted header/body reads. Wrap all affected call sites with do/while EINTR retry loops.