### PR TITLE
fix use-after-free in afp_unmount_volume by detaching after FUSE unmount

### DIFF
--- a/lib/afp.c
+++ b/lib/afp.c
@@ -434,17 +434,16 @@ int afp_unmount_volume(struct afp_volume * volume)
     }
 
     volume->mounted = AFP_VOLUME_UNMOUNTING;
-    afp_detach_volume(volume);
 
     if (libafpclient->unmount_volume && libafpclient->unmount_volume(volume) != 0) {
         log_for_client(NULL, AFPFSD, LOG_WARNING,
-                       "FUSE unmount not supported - volume %s remains mounted",
-                       volume->volume_name_printable);
+                       "FUSE unmount not supported - volume remains mounted on %s",
+                       volume->mountpoint);
         volume->mounted = AFP_VOLUME_MOUNTED;
-        volume->attached = AFP_VOLUME_ATTACHED;
         return -1;
     }
 
+    afp_detach_volume(volume);
     volume->mounted = AFP_VOLUME_UNMOUNTED;
     return 0;
 }


### PR DESCRIPTION
afp_detach_volume() can call afp_server_remove() when auto_disconnect_on_unmount is set (the default in afpfsd), which frees the volumes array and leaves the volume pointer dangling. Calling libafpclient->unmount_volume() on that freed pointer caused a spurious warning with empty mountpoint/volume name fields.

Fix by calling unmount_volume first while the volume struct is still valid, then detaching only on success. Also remove the stale attached state restore in the error path since attached is no longer modified before that point.