### PR TITLE
detect 2000s era Macs and Time Capsule machine types

### DIFF
--- a/include/afp.h
+++ b/include/afp.h
@@ -151,12 +151,13 @@ enum server_type {
     AFPFS_SERVER_TYPE_NETATALK,
     AFPFS_SERVER_TYPE_AIRPORT,
     AFPFS_SERVER_TYPE_MACINTOSH,
+    AFPFS_SERVER_TYPE_TIMECAPSULE,
 };
 
 #define is_netatalk(x) ( (x)->machine_type == AFPFS_SERVER_TYPE_NETATALK )
 #define is_airport(x) ( (x)->machine_type == AFPFS_SERVER_TYPE_AIRPORT )
 #define is_macintosh(x) ( (x)->machine_type == AFPFS_SERVER_TYPE_MACINTOSH )
-
+#define is_timecapsule(x) ( (x)->machine_type == AFPFS_SERVER_TYPE_TIMECAPSULE )
 
 
 struct afp_versions {

--- a/lib/identify.c
+++ b/lib/identify.c
@@ -31,11 +31,18 @@ void afp_server_identify(struct afp_server * s)
                        "Identified server %s as AirPort",
                        s->server_name_printable);
         s->server_type = AFPFS_SERVER_TYPE_AIRPORT;
-    } else if (strncmp(s->machine_type, "Macintosh", 9) == 0) {
+    } else if (strncmp(s->machine_type, "Mac", 3) == 0
+               || strncmp(s->machine_type, "iMac", 4) == 0
+               || strncmp(s->machine_type, "Xserve", 6) == 0) {
         log_for_client(NULL, AFPFSD, LOG_DEBUG,
                        "Identified server %s as Macintosh",
                        s->server_name_printable);
         s->server_type = AFPFS_SERVER_TYPE_MACINTOSH;
+    } else if (strncmp(s->machine_type, "TimeCapsule", 11) == 0) {
+        log_for_client(NULL, AFPFSD, LOG_DEBUG,
+                       "Identified server %s as Time Capsule",
+                       s->server_name_printable);
+        s->server_type = AFPFS_SERVER_TYPE_TIMECAPSULE;
     } else {
         log_for_client(NULL, AFPFSD, LOG_DEBUG,
                        "Could not identify server %s (machine type %s)",


### PR DESCRIPTION
before we were only matching "Macintosh" AFP server machine type, now we add anything that begins with "Mac" (MacBook, MacPro, Macmini, etc.) plus Xserve and iMac -- this should cover all bases when it comes to the native AFP servers in OSX

also adding support for Time Capsule machine types