### PR TITLE
make DSI default timeout dynamically configurable

### DIFF
--- a/cmdline/cmdline_afp.c
+++ b/cmdline/cmdline_afp.c
@@ -65,6 +65,7 @@ static struct afp_url url;
 static int cmdline_log_min_rank = 2; /* Default rank: notice */
 static int verbose_mode = 0;
 static char connect_servername[AFP_SERVER_NAME_UTF8_LEN];
+static int cmdline_dsi_timeout = 0;
 
 int full_url = 0;
 
@@ -156,7 +157,7 @@ static int reconnect_session(int restore_volume, int restore_dir)
     }
 
     if (afp_sl_connect(&reconnect_url, uam_mask, &new_server_id, mesg,
-                       &error) != 0) {
+                       &error, cmdline_dsi_timeout) != 0) {
         return -1;
     }
 
@@ -2125,6 +2126,11 @@ void cmdline_set_verbose(int verbose)
     verbose_mode = verbose;
 }
 
+void cmdline_set_dsi_timeout(int timeout)
+{
+    cmdline_dsi_timeout = timeout;
+}
+
 static void cmdline_log_for_client(__attribute__((unused)) void * priv,
                                    __attribute__((unused)) enum logtypes logtype,
                                    int loglevel, const char *message)
@@ -2165,7 +2171,8 @@ static int cmdline_server_startup(int batch_mode)
         strlcpy(connect_servername, url.servername, sizeof(connect_servername));
     }
 
-    if (afp_sl_connect(&url, uam_mask, &server_id, mesg, &error)) {
+    if (afp_sl_connect(&url, uam_mask, &server_id, mesg, &error,
+                       cmdline_dsi_timeout)) {
         printf("Could not connect to server\n");
         return -1;
     }

--- a/cmdline/cmdline_afp.h
+++ b/cmdline/cmdline_afp.h
@@ -29,6 +29,7 @@ int cmdline_afp_setup(int recursive, int batch_mode, char * url_string);
 void cmdline_afp_setup_client(void);
 void cmdline_set_log_level(int loglevel);
 void cmdline_set_verbose(int verbose);
+void cmdline_set_dsi_timeout(int timeout);
 int cmdline_batch_transfer(char * local_path, int direction, int recursive);
 char *afp_remote_file_generator(const char *text, int state);
 

--- a/cmdline/cmdline_main.c
+++ b/cmdline/cmdline_main.c
@@ -477,11 +477,13 @@ int main(int argc, char *argv[])
     int verbose = 0;
     int show_usage = 0;
     int log_level = LOG_NOTICE;
+    int dsi_timeout = 0;
     struct option long_options[] = {
         {"help", 0, 0, 'h'},
         {"recursive", 0, 0, 'r'},
         {"verbose", 0, 0, 'V'},
         {"loglevel", 1, 0, 'v'},
+        {"timeout", 1, 0, 't'},
         {NULL, 0, NULL, 0},
     };
     char *url = NULL;
@@ -490,7 +492,7 @@ int main(int argc, char *argv[])
     int direction = 0; /* 0 = GET (remote->local), 1 = PUT (local->remote) */
 
     while (1) {
-        c = getopt_long(argc, argv, "hrVv:",
+        c = getopt_long(argc, argv, "hrVv:t:",
                         long_options, &option_index);
 
         if (c == -1) {
@@ -508,6 +510,10 @@ int main(int argc, char *argv[])
 
         case 'V':
             verbose = 1;
+            break;
+
+        case 't':
+            dsi_timeout = strtol(optarg, NULL, 10);
             break;
 
         case 'v': {
@@ -538,6 +544,7 @@ int main(int argc, char *argv[])
     cmdline_afp_setup_client();
     cmdline_set_log_level(log_level);
     cmdline_set_verbose(verbose);
+    cmdline_set_dsi_timeout(dsi_timeout);
 
     /* Check arguments for batch mode */
     if (argc - optind == 2) {

--- a/daemon/commands.c
+++ b/daemon/commands.c
@@ -1862,6 +1862,10 @@ static int process_connect(struct daemon_client * c)
         goto error;
     }
 
+    if (req->dsi_timeout > 0) {
+        s->dsi_default_timeout = req->dsi_timeout;
+    }
+
     /* Immediately copy data from server before it can be freed asynchronously */
     server_copy = s;
 

--- a/daemon/stateless.c
+++ b/daemon/stateless.c
@@ -1192,7 +1192,7 @@ int afp_sl_getvols(struct afp_url * url, unsigned int start,
  */
 
 int afp_sl_connect(struct afp_url * url, unsigned int uam_mask,
-                   serverid_t *id, char *loginmesg, int *error)
+                   serverid_t *id, char *loginmesg, int *error, int dsi_timeout)
 {
     struct afp_server_connect_request req;
     const struct afp_server_connect_response *resp;
@@ -1208,6 +1208,7 @@ int afp_sl_connect(struct afp_url * url, unsigned int uam_mask,
     req.header.command = AFP_SERVER_COMMAND_CONNECT;
     memcpy(&req.url, url, sizeof(struct afp_url));
     req.uam_mask = uam_mask;
+    req.dsi_timeout = dsi_timeout;
 
     if (send_command(sizeof(req), (char *)&req, AFP_SERVER_COMMAND_CONNECT) < 0) {
         return AFP_SERVER_RESULT_DAEMON_ERROR;

--- a/docs/manpages/afp_client.1
+++ b/docs/manpages/afp_client.1
@@ -1,4 +1,4 @@
-.Dd January 25, 2026
+.Dd April 18, 2026
 .Dt AFP_CLIENT 1
 .Os afpfs-ng
 .Sh NAME
@@ -143,6 +143,11 @@ as the volume password, you will be prompted for it.
 .It Fl u , Fl -user Ar username
 Authenticate with the AFP server as
 .Ar username .
+.It Fl t , Fl -timeout Ar seconds
+Override the default DSI request timeout.
+If not specified, the timeout is selected automatically based on the
+server type: Time Capsule servers default to 30 seconds to accommodate
+spinning disk wake-up latency; all other server types default to 5 seconds.
 .It Fl v , Fl -afpversion Ar afp_version
 Specify the AFP protocol version that will be used for a mount.
 By default afpfs-ng will choose the highest AFP version shared between

--- a/docs/manpages/afpcmd.1
+++ b/docs/manpages/afpcmd.1
@@ -1,4 +1,4 @@
-.Dd January 26, 2026
+.Dd April 18, 2026
 .Dt AFPCMD 1
 .Os afpfs-ng
 .Sh NAME
@@ -50,6 +50,11 @@ Enables verbose mode for file transfers.
 When enabled, displays detailed messages during upload and download operations,
 including per-file transfer statistics.
 By default, only a summary message is shown after each transfer completes.
+.It Fl t , Fl -timeout Ar seconds
+Override the default DSI request timeout.
+If not specified, the timeout is selected automatically based on the
+server type: Time Capsule servers default to 30 seconds to accommodate
+spinning disk wake-up latency; all other server types default to 5 seconds.
 .It Fl v , Fl -loglevel Ar level
 Sets the log verbosity level.
 Accepted values are

--- a/fuse/client.c
+++ b/fuse/client.c
@@ -353,6 +353,7 @@ static void usage(void)
         "         -m, --map <mapname>        : use this uid/gid mapping method, one of:\n"
         "                                      common, loginids\n"
         "         -O, --options <flags>      : FUSE mount options; see the fuse man page\n"
+        "         -t, --timeout <seconds>    : DSI request timeout (overrides server-type default)\n"
         "\n"
         "    unmount <mountpoint> : unmount the specified mountpoint\n"
         "    status [mountpoint]  : get status of the AFP daemon;\n"
@@ -577,6 +578,7 @@ static int do_mount(int argc, char ** argv)
         {"uam", 1, 0, 'a'},
         {"map", 1, 0, 'm'},
         {"options", 1, 0, 'O'},
+        {"timeout", 1, 0, 't'},
         {0, 0, 0, 0},
     };
 
@@ -593,7 +595,7 @@ static int do_mount(int argc, char ** argv)
 
     while (1) {
         optnum++;
-        c = getopt_long(argc, argv, "a:m:O:o:P:p:u:v:", long_options, &option_index);
+        c = getopt_long(argc, argv, "a:m:O:o:P:p:t:u:v:", long_options, &option_index);
 
         if (c == -1) {
             break;
@@ -633,6 +635,10 @@ static int do_mount(int argc, char ** argv)
 
         case 'p':
             snprintf(request.url.password, AFP_MAX_PASSWORD_LEN, "%s", optarg);
+            break;
+
+        case 't':
+            request.dsi_timeout = strtol(optarg, NULL, 10);
             break;
 
         case 'u':

--- a/fuse/commands.c
+++ b/fuse/commands.c
@@ -642,6 +642,10 @@ static int process_mount(struct fuse_client * c)
         goto error;
     }
 
+    if (req.dsi_timeout > 0) {
+        s->dsi_default_timeout = req.dsi_timeout;
+    }
+
     if ((volume = mount_volume(c, s, req.url.volumename,
                                req.url.volpassword)) == NULL) {
         goto error;

--- a/fuse/fuse_ipc.h
+++ b/fuse/fuse_ipc.h
@@ -30,6 +30,7 @@ struct afp_server_mount_request {
     unsigned int map;
     int changeuid;
     char fuse_options[256];
+    int dsi_timeout;
 };
 
 struct afp_server_status_request {

--- a/include/afp.h
+++ b/include/afp.h
@@ -191,6 +191,9 @@ struct afp_server {
 
     unsigned int tx_delay;
 
+    /* DSI request timeout in seconds; set by server type detection or user override */
+    int dsi_default_timeout;
+
     /* Connection information */
     //the linked list returned by getaddrinfo
     struct addrinfo *address;

--- a/include/afp_server.h
+++ b/include/afp_server.h
@@ -41,6 +41,7 @@ struct afp_server_connect_request {
     struct afp_server_request_header header;
     struct afp_url url;
     unsigned int uam_mask;
+    int dsi_timeout;
 };
 
 struct afp_server_connect_response {

--- a/include/afpsl.h
+++ b/include/afpsl.h
@@ -43,7 +43,7 @@ int afp_sl_exit(void);
 int afp_sl_status(const char * volumename, const char * servername,
                   char *text, unsigned int *remaining);
 int afp_sl_connect(struct afp_url * url, unsigned int uam_mask,
-                   serverid_t *id, char *loginmesg, int *error);
+                   serverid_t *id, char *loginmesg, int *error, int dsi_timeout);
 int afp_sl_disconnect(serverid_t *id);
 int afp_sl_getvolid(struct afp_url * url, volumeid_t *volid);
 int afp_sl_attach(struct afp_url * url, unsigned int volume_options,

--- a/include/dsi.h
+++ b/include/dsi.h
@@ -33,10 +33,11 @@ int dsi_recv(struct afp_server * server);
 #define DSI_BLOCK_TIMEOUT -1
 #define DSI_DONT_WAIT 0
 #define DSI_DEFAULT_TIMEOUT 5
-//a spun down time capsule can take up to 20 secs to
-//wake up and reply to a mount request
+/* A spun down time capsule can take up to 20 secs to
+ * wake up and reply to a mount request */
 #define DSI_OPENVOLUME_TIMEOUT 20
 #define DSI_LOGIN_TIMEOUT 20
+#define DSI_TIMECAPSULE_DEFAULT_TIMEOUT 30
 
 #define GETSTATUS_BUF_SIZE 1024
 

--- a/lib/afp.c
+++ b/lib/afp.c
@@ -562,6 +562,7 @@ struct afp_server *afp_server_init(struct addrinfo * address)
     s->attention_quantum = AFP_DEFAULT_ATTENTION_QUANTUM;
     s->attention_buffer = malloc(s->attention_quantum);
     s->attention_len = 0;
+    s->dsi_default_timeout = DSI_DEFAULT_TIMEOUT;
     s->connect_state = SERVER_STATE_DISCONNECTED;
     s->address = address;
     /* Initialize mutexes */

--- a/lib/dsi.c
+++ b/lib/dsi.c
@@ -761,7 +761,7 @@ void *dsi_incoming_attention(void * other)
     if (checkmessage) {
         afp_getsrvrmsg(server, AFPMESG_SERVER,
                        ((server->using_version && server->using_version->av_number >= 30) ? 1 : 0),
-                       DSI_DEFAULT_TIMEOUT, mesg);
+                       server->dsi_default_timeout, mesg);
 
         if (bcmp(mesg, "The server is going down for maintenance.", 41) == 0) {
             shutdown = 1;

--- a/lib/identify.c
+++ b/lib/identify.c
@@ -8,6 +8,7 @@
 
 #include <string.h>
 #include "afp.h"
+#include "dsi.h"
 
 /*
  * afp_server_identify()
@@ -43,6 +44,10 @@ void afp_server_identify(struct afp_server * s)
                        "Identified server %s as Time Capsule",
                        s->server_name_printable);
         s->server_type = AFPFS_SERVER_TYPE_TIMECAPSULE;
+
+        if (s->dsi_default_timeout == DSI_DEFAULT_TIMEOUT) {
+            s->dsi_default_timeout = DSI_TIMECAPSULE_DEFAULT_TIMEOUT;
+        }
     } else {
         log_for_client(NULL, AFPFSD, LOG_DEBUG,
                        "Could not identify server %s (machine type %s)",

--- a/lib/proto_attr.c
+++ b/lib/proto_attr.c
@@ -63,7 +63,8 @@ int afp_listextattr(struct afp_volume * volume,
         request_packet->maxreplysize = htonl(info->maxsize);
         copy_path(server, pathptr, pathname, strlen(pathname));
         unixpath_to_afppath(server, pathptr);
-        ret = dsi_send(server, (char *) request_packet, len, DSI_DEFAULT_TIMEOUT,
+        ret = dsi_send(server, (char *) request_packet, len,
+                       server->dsi_default_timeout,
                        afpListExtAttrs, (void *) info);
         free(msg);
     }
@@ -189,7 +190,8 @@ int afp_getextattr(struct afp_volume * volume, unsigned int dirid,
         /* EA name: length-prefixed (2 bytes length + name) */
         *((uint16_t *)p2) = htons(namelen);
         memcpy(p2 + 2, name, namelen);
-        ret = dsi_send(server, (char *) request_packet, len, DSI_DEFAULT_TIMEOUT,
+        ret = dsi_send(server, (char *) request_packet, len,
+                       server->dsi_default_timeout,
                        afpGetExtAttr, (void *) i);
         free(msg);
     }
@@ -265,7 +267,8 @@ int afp_setextattr(struct afp_volume * volume, unsigned int dirid,
             memcpy(p2, attribdata, attribdatalen);
         }
 
-        ret = dsi_send(server, (char *) request_packet, len, DSI_DEFAULT_TIMEOUT,
+        ret = dsi_send(server, (char *) request_packet, len,
+                       server->dsi_default_timeout,
                        afpSetExtAttr, NULL);
         free(msg);
     }
@@ -324,7 +327,8 @@ int afp_removeextattr(struct afp_volume * volume, unsigned int dirid,
         /* EA name: length-prefixed (2 bytes length + name) */
         *((uint16_t *)p2) = htons(namelen);
         memcpy(p2 + 2, name, namelen);
-        ret = dsi_send(server, (char *) request_packet, len, DSI_DEFAULT_TIMEOUT,
+        ret = dsi_send(server, (char *) request_packet, len,
+                       server->dsi_default_timeout,
                        afpRemoveExtAttr, NULL);
         free(msg);
     }

--- a/lib/proto_desktop.c
+++ b/lib/proto_desktop.c
@@ -44,7 +44,7 @@ int afp_geticon(struct afp_volume * volume, unsigned int filecreator,
     request_packet.pad2 = 0;
     request_packet.length = htons(length);
     return dsi_send(volume->server, (char *)&request_packet,
-                    sizeof(request_packet), DSI_DEFAULT_TIMEOUT,
+                    sizeof(request_packet), volume->server->dsi_default_timeout,
                     afpGetIcon, (void *) icon);
 }
 
@@ -108,7 +108,8 @@ int afp_addcomment(struct afp_volume *volume, unsigned int did,
 
     copy_to_pascal(p, comment);
     *size = strlen(comment);
-    rc = dsi_send(volume->server, (char *)msg, len, DSI_DEFAULT_TIMEOUT,
+    rc = dsi_send(volume->server, (char *)msg, len,
+                  volume->server->dsi_default_timeout,
                   afpAddComment, (void *) comment);
     free(msg);
     return rc;
@@ -140,7 +141,8 @@ int afp_getcomment(struct afp_volume *volume, unsigned int did,
     request_packet->dirid = htonl(did);
     copy_path(volume->server, path, pathname, strlen(pathname));
     unixpath_to_afppath(volume->server, path);
-    rc = dsi_send(volume->server, (char *)msg, len, DSI_DEFAULT_TIMEOUT,
+    rc = dsi_send(volume->server, (char *)msg, len,
+                  volume->server->dsi_default_timeout,
                   afpGetComment, (void *) comment);
     free(msg);
     return rc;
@@ -184,7 +186,7 @@ int afp_closedt(struct afp_server * server, unsigned short refnum)
     request_packet.pad = 0;
     request_packet.refnum = htons(refnum);
     return dsi_send(server, (char *) &request_packet,
-                    sizeof(request_packet), DSI_DEFAULT_TIMEOUT, afpCloseDT, NULL);
+                    sizeof(request_packet), server->dsi_default_timeout, afpCloseDT, NULL);
 }
 
 
@@ -204,7 +206,7 @@ int afp_opendt(struct afp_volume *volume, unsigned short * refnum)
     request_packet.pad = 0;
     request_packet.volid = htons(volume->volid);
     return dsi_send(volume->server, (char *) &request_packet,
-                    sizeof(request_packet), DSI_DEFAULT_TIMEOUT, afpOpenDT,
+                    sizeof(request_packet), volume->server->dsi_default_timeout, afpOpenDT,
                     (void *) refnum);
 }
 

--- a/lib/proto_directory.c
+++ b/lib/proto_directory.c
@@ -90,7 +90,7 @@ int afp_moveandrename(struct afp_volume *volume,
     p += sizeof_path_header(server) + dlen;
     copy_path(server, p, new_name, nlen);
     unixpath_to_afppath(server, p);
-    ret = dsi_send(server, msg, len, DSI_DEFAULT_TIMEOUT, afpMoveAndRename,
+    ret = dsi_send(server, msg, len, server->dsi_default_timeout, afpMoveAndRename,
                    NULL);
     free(msg);
     return ret;
@@ -133,7 +133,7 @@ int afp_rename(struct afp_volume *volume,
     pathtoptr = pathfromptr + sizeof_path_header(server) + strlen(path_from);
     copy_path(server, pathtoptr, path_to, strlen(path_to));
     unixpath_to_afppath(server, pathtoptr);
-    ret = dsi_send(server, msg, len, DSI_DEFAULT_TIMEOUT, afpRename, NULL);
+    ret = dsi_send(server, msg, len, server->dsi_default_timeout, afpRename, NULL);
     free(msg);
     return ret;
 }
@@ -170,7 +170,7 @@ int afp_createdir(struct afp_volume * volume, unsigned int dirid,
     request_packet->dirid = htonl(dirid);
     copy_path(server, pathptr, pathname, strlen(pathname));
     unixpath_to_afppath(server, pathptr);
-    ret = dsi_send(server, msg, len, DSI_DEFAULT_TIMEOUT,
+    ret = dsi_send(server, msg, len, server->dsi_default_timeout,
                    afpCreateDir, (void *)did_p);
     free(msg);
     return ret;
@@ -366,7 +366,7 @@ int afp_enumerate(
         65535 : server->bufsize);
     copy_path(server, path, pathname, strlen(pathname));
     unixpath_to_afppath(server, path);
-    rc = dsi_send(server, data, len, DSI_DEFAULT_TIMEOUT,
+    rc = dsi_send(server, data, len, server->dsi_default_timeout,
                   afpEnumerate, (void **) &files);
     *file_p = files;
     free(data);
@@ -425,7 +425,7 @@ int afp_enumerateext(
         65535 : server->bufsize);
     copy_path(server, path, pathname, strlen(pathname));
     unixpath_to_afppath(server, path);
-    rc = dsi_send(server, data, len, DSI_DEFAULT_TIMEOUT,
+    rc = dsi_send(server, data, len, server->dsi_default_timeout,
                   afpEnumerateExt, (void **) &files);
     *file_p = files;
     free(data);
@@ -483,7 +483,7 @@ int afp_enumerateext2(
     afp_enumerateext2_request_packet->maxreplysize = htonl(server->bufsize);
     copy_path(server, path, pathname, strlen(pathname));
     unixpath_to_afppath(server, path);
-    rc = dsi_send(server, data, len, DSI_DEFAULT_TIMEOUT,
+    rc = dsi_send(server, data, len, server->dsi_default_timeout,
                   afpEnumerateExt2, (void **) &files);
     *file_p = files;
     free(data);

--- a/lib/proto_files.c
+++ b/lib/proto_files.c
@@ -128,7 +128,7 @@ static int afp_setparms_lowlevel(struct afp_volume * volume,
 #endif
     }
 
-    ret = dsi_send(server, (char *) msg, p - msg, DSI_DEFAULT_TIMEOUT,
+    ret = dsi_send(server, (char *) msg, p - msg, server->dsi_default_timeout,
                    command, NULL);
     free(msg);
     return ret;
@@ -194,7 +194,8 @@ int afp_delete(struct afp_volume * volume,
     request_packet->dirid = htonl(dirid);
     copy_path(server, pathptr, pathname, strlen(pathname));
     unixpath_to_afppath(server, pathptr);
-    ret = dsi_send(server, (char *) request_packet, len, DSI_DEFAULT_TIMEOUT,
+    ret = dsi_send(server, (char *) request_packet, len,
+                   server->dsi_default_timeout,
                    afpDelete, NULL);
     free(msg);
     return ret;
@@ -228,7 +229,7 @@ int afp_read(struct afp_volume * volume, unsigned short forkid,
     readext_packet.newlinemask = 0;
     readext_packet.newlinechar = 0;
     rc = dsi_send(volume->server, (char *) &readext_packet,
-                  sizeof(readext_packet), DSI_DEFAULT_TIMEOUT,
+                  sizeof(readext_packet), volume->server->dsi_default_timeout,
                   afpRead, (void *) rx);
     return rc;
 }
@@ -278,7 +279,7 @@ int afp_readext(struct afp_volume * volume, unsigned short forkid,
     readext_packet.offset = hton64(offset);
     readext_packet.reqcount = hton64(count);
     rc = dsi_send(volume->server, (char *) &readext_packet,
-                  sizeof(readext_packet), DSI_DEFAULT_TIMEOUT,
+                  sizeof(readext_packet), volume->server->dsi_default_timeout,
                   afpReadExt, (void *) rx);
     return rc;
 }
@@ -379,7 +380,8 @@ int afp_getfiledirparms(struct afp_volume *volume, unsigned int did,
     getfiledirparms->directory_bitmap = htons(dirbitmap);
     copy_path(server, path, pathname, strlen(pathname));
     unixpath_to_afppath(server, path);
-    ret = dsi_send(server, (char *) getfiledirparms, len, DSI_DEFAULT_TIMEOUT,
+    ret = dsi_send(server, (char *) getfiledirparms, len,
+                   server->dsi_default_timeout,
                    afpGetFileDirParms, (void *) fpp);
     free(msg);
     return ret;
@@ -417,7 +419,8 @@ int afp_createfile(struct afp_volume * volume, unsigned char flag,
     request_packet->did = htonl(did);
     copy_path(server, path, pathname, strlen(pathname));
     unixpath_to_afppath(server, path);
-    ret = dsi_send(server, (char *) request_packet, len, DSI_DEFAULT_TIMEOUT,
+    ret = dsi_send(server, (char *) request_packet, len,
+                   server->dsi_default_timeout,
                    afpCreateFile, NULL);
     free(msg);
     return ret;
@@ -459,7 +462,8 @@ int afp_write(struct afp_volume * volume, unsigned short forkid,
     request_packet->forkid = htons(forkid);
     request_packet->offset = htonl(offset);
     request_packet->reqcount = htonl(reqcount);
-    ret = dsi_send(server, (char *) request_packet, len, DSI_DEFAULT_TIMEOUT,
+    ret = dsi_send(server, (char *) request_packet, len,
+                   server->dsi_default_timeout,
                    afpWrite, (void *) written);
     free(msg);
     return ret;
@@ -521,7 +525,8 @@ int afp_writeext(struct afp_volume * volume, unsigned short forkid,
     request_packet->forkid = htons(forkid);
     request_packet->offset = hton64(offset);
     request_packet->reqcount = hton64(reqcount);
-    ret = dsi_send(server, (char *) request_packet, len, DSI_DEFAULT_TIMEOUT,
+    ret = dsi_send(server, (char *) request_packet, len,
+                   server->dsi_default_timeout,
                    afpWriteExt, (void *) written);
     free(msg);
     return ret;

--- a/lib/proto_fork.c
+++ b/lib/proto_fork.c
@@ -44,7 +44,7 @@ int afp_setforkparms(struct afp_volume * volume,
         request64.padding = 0;
         request64.newlen64 = hton64(len);
         return dsi_send(volume->server, (char *) &request64,
-                        sizeof(request64), DSI_DEFAULT_TIMEOUT, afpSetForkParms, NULL);
+                        sizeof(request64), volume->server->dsi_default_timeout, afpSetForkParms, NULL);
     } else {
         /* Legacy 32-bit version */
         struct {
@@ -62,7 +62,7 @@ int afp_setforkparms(struct afp_volume * volume,
         request32.bitmap = htons(bitmap);
         request32.newlen = htonl(len);
         return dsi_send(volume->server, (char *) &request32,
-                        sizeof(request32), DSI_DEFAULT_TIMEOUT, afpSetForkParms, NULL);
+                        sizeof(request32), volume->server->dsi_default_timeout, afpSetForkParms, NULL);
     }
 }
 
@@ -82,7 +82,8 @@ int afp_closefork(struct afp_volume * volume,
     request_packet.pad = 0;
     request_packet.forkid = htons(forkid);
     return dsi_send(volume->server, (char *) &request_packet,
-                    sizeof(request_packet), DSI_DEFAULT_TIMEOUT, afpFlushFork, NULL);
+                    sizeof(request_packet), volume->server->dsi_default_timeout, afpFlushFork,
+                    NULL);
 }
 
 
@@ -102,7 +103,8 @@ int afp_flushfork(struct afp_volume * volume,
     request_packet.pad = 0;
     request_packet.forkid = htons(forkid);
     return dsi_send(volume->server, (char *) &request_packet,
-                    sizeof(request_packet), DSI_DEFAULT_TIMEOUT, afpFlushFork, NULL);
+                    sizeof(request_packet), volume->server->dsi_default_timeout, afpFlushFork,
+                    NULL);
 }
 
 int afp_openfork_reply(__attribute__((unused)) struct afp_server *server,
@@ -173,7 +175,7 @@ int afp_openfork(struct afp_volume * volume,
     afp_openfork_request->accessmode = htons(accessmode);
     copy_path(server, pathptr, filename, strlen(filename));
     unixpath_to_afppath(server, pathptr);
-    ret = dsi_send(server, (char *) msg, len, DSI_DEFAULT_TIMEOUT,
+    ret = dsi_send(server, (char *) msg, len, server->dsi_default_timeout,
                    afpOpenFork, (void *) fp);
     free(msg);
     return ret;
@@ -203,7 +205,7 @@ int afp_byterangelock(struct afp_volume * volume,
     request.offset = htonl(offset);
     request.len = htonl(len);
     rc = dsi_send(volume->server, (char *) &request,
-                  sizeof(request), DSI_DEFAULT_TIMEOUT,
+                  sizeof(request), volume->server->dsi_default_timeout,
                   afpByteRangeLock, (void *) generated_offset);
     return rc;
 }
@@ -249,7 +251,7 @@ int afp_byterangelockext(struct afp_volume * volume,
     request.offset = hton64(offset);
     request.len = hton64(len);
     rc = dsi_send(volume->server, (char *) &request,
-                  sizeof(request), DSI_DEFAULT_TIMEOUT,
+                  sizeof(request), volume->server->dsi_default_timeout,
                   afpByteRangeLockExt, (void *) generated_offset);
     return rc;
 }

--- a/lib/proto_login.c
+++ b/lib/proto_login.c
@@ -97,7 +97,7 @@ int afp_changepassword(struct afp_server *server, const char * ua_name,
     }
 
     memcpy(p, userauthinfo, userauthinfo_len);
-    ret = dsi_send(server, (char *) msg, len, DSI_DEFAULT_TIMEOUT,
+    ret = dsi_send(server, (char *) msg, len, server->dsi_default_timeout,
                    afpChangePassword, (void *)rx);
     free(msg);
     return ret;

--- a/lib/proto_map.c
+++ b/lib/proto_map.c
@@ -41,7 +41,7 @@ int afp_getuserinfo(struct afp_server * server, int thisuser,
     request.userid = htonl(userid);
     request.bitmap = htons(bitmap);
     ret = dsi_send(server, (char *) &request, sizeof(request),
-                   DSI_DEFAULT_TIMEOUT, afpGetUserInfo, (void *) &uidgid);
+                   server->dsi_default_timeout, afpGetUserInfo, (void *) &uidgid);
 
     if (bitmap & kFPGetUserInfo_USER_ID) {
         *newuid = uidgid.uid;
@@ -117,7 +117,7 @@ int afp_mapid(struct afp_server * server, unsigned char subfunction,
     request.subfunction = subfunction;
     request.id = htonl(id);
     ret = dsi_send(server, (char *) &request, sizeof(request),
-                   DSI_DEFAULT_TIMEOUT, afpMapID, (void *) name);
+                   server->dsi_default_timeout, afpMapID, (void *) name);
     return ret;
 }
 
@@ -177,7 +177,7 @@ int afp_mapname(struct afp_server * server, unsigned char subfunction,
     request->command = afpMapName;
     request->subfunction = subfunction;
     ret = dsi_send(server, (char *) request, len,
-                   DSI_DEFAULT_TIMEOUT, afpMapName, (void *) id);
+                   server->dsi_default_timeout, afpMapName, (void *) id);
     free(msg);
     return ret;
 }

--- a/lib/proto_server.c
+++ b/lib/proto_server.c
@@ -27,7 +27,7 @@ int afp_getsrvrparms(struct afp_server *server)
     memcpy(&afp_getsrvrparms_request.dsi_header, &hdr, sizeof(struct dsi_header));
     afp_getsrvrparms_request.command = afpGetSrvrParms;
     dsi_send(server, (char *) &afp_getsrvrparms_request,
-             sizeof(afp_getsrvrparms_request), DSI_DEFAULT_TIMEOUT,
+             sizeof(afp_getsrvrparms_request), server->dsi_default_timeout,
              afpGetSrvrParms, NULL);
     return 0;
 }
@@ -172,5 +172,5 @@ int afp_zzzzz(struct afp_server *server)
     request.pad = 0;
     request.reserved = 0;
     return dsi_send(server, (char *) &request,
-                    sizeof(request), DSI_DEFAULT_TIMEOUT, afpZzzzz, NULL);
+                    sizeof(request), server->dsi_default_timeout, afpZzzzz, NULL);
 }

--- a/lib/proto_session.c
+++ b/lib/proto_session.c
@@ -71,7 +71,7 @@ int afp_getsessiontoken(struct afp_server * server, int type,
     memcpy(data, outgoing_token->data, datalen);
     ret = dsi_send(server, (char *)request,
                    sizeof(*request) + datalen + timelen,
-                   DSI_DEFAULT_TIMEOUT, afpGetSessionToken,
+                   server->dsi_default_timeout, afpGetSessionToken,
                    (void *) incoming_token);
     free(request);
     return 0;
@@ -148,7 +148,7 @@ int afp_disconnectoldsession(struct afp_server * server, int type,
     memcpy(token_data, token->data, token->length);
     ret = dsi_send(server, (char *)request,
                    sizeof(*request) + token->length,
-                   DSI_DEFAULT_TIMEOUT, afpDisconnectOldSession, NULL);
+                   server->dsi_default_timeout, afpDisconnectOldSession, NULL);
     free(request);
     return ret;
 }

--- a/lib/proto_volume.c
+++ b/lib/proto_volume.c
@@ -119,7 +119,7 @@ int afp_volclose(struct afp_volume * volume)
     request.pad = 0;
     request.volid = htons(volume->volid);
     return dsi_send(volume->server, (char *) &request, sizeof(request),
-                    DSI_DEFAULT_TIMEOUT, afpCloseVol, NULL);
+                    volume->server->dsi_default_timeout, afpCloseVol, NULL);
 }
 
 
@@ -267,7 +267,7 @@ int afp_flush(struct afp_volume * volume)
     afp_flush_request.pad = 0;
     afp_flush_request.volid = htons(volume->volid);
     ret = dsi_send(volume->server, (char *) &afp_flush_request,
-                   sizeof(afp_flush_request), DSI_DEFAULT_TIMEOUT,
+                   sizeof(afp_flush_request), volume->server->dsi_default_timeout,
                    afpFlush, (void *) volume);
     return ret;
 }
@@ -290,7 +290,7 @@ int afp_getvolparms(struct afp_volume * volume, unsigned short bitmap)
     afp_getvolparms_request.volid = htons(volume->volid);
     afp_getvolparms_request.bitmap = htons(bitmap);
     ret = dsi_send(volume->server, (char *) &afp_getvolparms_request,
-                   sizeof(afp_getvolparms_request), DSI_DEFAULT_TIMEOUT,
+                   sizeof(afp_getvolparms_request), volume->server->dsi_default_timeout,
                    afpGetVolParms, (void *) volume);
     return ret;
 }

--- a/lib/server.c
+++ b/lib/server.c
@@ -84,7 +84,7 @@ struct afp_server *afp_server_complete_connection(
 
     afp_getsrvrmsg(server, AFPMESG_LOGIN,
                    ((server->using_version && server->using_version->av_number >= 30) ? 1 : 0),
-                   DSI_DEFAULT_TIMEOUT, loginmsg); /* block */
+                   server->dsi_default_timeout, loginmsg); /* block */
 
     if (strlen(loginmsg) > 0)
         log_for_client(priv, AFPFSD, LOG_NOTICE,


### PR DESCRIPTION
Add a dsi_default_timeout field to struct afp_server, initialized to DSI_DEFAULT_TIMEOUT (5s) and overridden per server type after identify: Time Capsule servers get DSI_TIMECAPSULE_DEFAULT_TIMEOUT (30s) to accommodate spinning disk wake-up latency.

Both AFP clients now accept a -t/--timeout <seconds> option to let the user override the timeout at launch, taking precedence over the server-type default. The value is threaded through the IPC request structs (afp_server_mount_request, afp_server_connect_request) and applied to the server object after connection. All protocol call sites that previously used the DSI_DEFAULT_TIMEOUT compile-time constant now read server->dsi_default_timeout instead.