### PR TITLE
allow building with any libfuse v2 dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -375,7 +375,7 @@ jobs:
           path: build/meson-logs
 
   build-openbsd:
-    name: OpenBSD
+    name: OpenBSD (with FUSE v2)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -21,7 +21,7 @@ You also want *pkg-config* that is used by the build system to find libraries.
 | libgcrypt  | encrypted UAMs                                            |
 | readline   | afpcmd client                                             |
 | libedit    | alternative to *readline* on f.e. Alpine Linux or FreeBSD |
-| libfuse    | FUSE client; v3 recommended, compatible with v2.9         |
+| libfuse    | FUSE client; v3 recommended, compatible with v2           |
 | libbsd     | mandatory on Linux when glibc < 2.38                      |
 
 #### macOS

--- a/meson.build
+++ b/meson.build
@@ -73,7 +73,7 @@ endif
 gcrypt_dep = dependency('libgcrypt', version: '>=1.2.3', required: false)
 fuse_dep = dependency('fuse3', version: '>=3.0.0', required: false)
 if not fuse_dep.found() or get_option('force-fuse-v2')
-    fuse_dep = dependency('fuse', version: '>=2.9.0', required: false)
+    fuse_dep = dependency('fuse', version: '>=2.0.0', required: false)
 endif
 
 with_afpcmd = readline_dep.found() or editline_dep.found()


### PR DESCRIPTION
relax the meson dependency check of libfuse, allow v2.0.0 and later; we have only tested fully with v2.9, but this allows at least OpenBSD 7.8 to build and run the FUSE client