### PR TITLE
declare soversion v1 for libafpsl shared library

### DIFF
--- a/daemon/meson.build
+++ b/daemon/meson.build
@@ -1,3 +1,12 @@
+libafpsl_version_major = 1
+libafpsl_version_minor = 0
+libafpsl_version_patch = 0
+libafpsl_version = '@0@.@1@.@2@'.format(
+    libafpsl_version_major,
+    libafpsl_version_minor,
+    libafpsl_version_patch,
+)
+
 afpsld_sources = [
     'daemon.c',
     'commands.c',
@@ -24,18 +33,19 @@ libafpsl = shared_library(
     link_with: libafpclient,
     c_args: cflags,
     install: true,
-    version: afpfsng_version,
+    version: libafpsl_version,
+    soversion: libafpsl_version_major,
 )
 
 pkg.generate(
     libafpsl,
     description: 'AFP stateless client library',
     name: 'libafpsl',
-    version: afpfsng_version,
+    version: libafpsl_version,
 )
 
 afpsl_dep = declare_dependency(
     link_with: libafpsl,
     include_directories: incdir,
-    version: afpfsng_version,
+    version: libafpsl_version,
 )


### PR DESCRIPTION
just like with libafpclient, this bumps the soversion to v1 while introducting a structure for setting the library version separately from the project version

libafpsl has existed from the early years of afpfs-ng, and we have introduced major ABI changes in this fork