### PR TITLE
lib: harden AFP reply block parsing

### DIFF
--- a/lib/afp_replies.h
+++ b/lib/afp_replies.h
@@ -1,7 +1,7 @@
 #ifndef __AFP_REPLIES_H_
 #define __AFP_REPLIES_H_
 
-int parse_reply_block(struct afp_server *server, char * buf,
+int parse_reply_block(struct afp_server *server, const char * buf,
                       unsigned int size, unsigned char isdir,
                       unsigned int filebitmap, unsigned int dirbitmap,
                       struct afp_file_info * filecur);

--- a/lib/proto_directory.c
+++ b/lib/proto_directory.c
@@ -2,6 +2,7 @@
  *  proto_directory.c
  *
  *  Copyright (C) 2006 Alex deVries <alexthepuffin@gmail.com>
+ *  Copyright (C) 2026 Daniel Markstedt <daniel@mindani.net>
  *
  */
 
@@ -25,6 +26,17 @@ typedef struct ext2_reply_entry {
     uint8_t isdir;
     uint8_t pad;
 } __attribute__((__packed__)) ext2_reply_entry;
+
+static void free_file_list(struct afp_file_info *base)
+{
+    struct afp_file_info *next;
+
+    while (base) {
+        next = base->next;
+        free(base);
+        base = next;
+    }
+}
 
 int afp_moveandrename(struct afp_volume *volume,
                       unsigned int src_did,
@@ -215,24 +227,34 @@ int afp_enumerate_reply(struct afp_server *server, char * buf,
     struct afp_file_info * filebase = NULL, *filecur = NULL, *prev = NULL;
     void **x = other;
 
-    if (reply->dsi_header.return_code.error_code) {
-        return reply->dsi_header.return_code.error_code;
-    }
-
     if (size < sizeof(*reply)) {
         return -1;
     }
 
-    for (i = 0; i < ntohs(reply->reqcount); i++) {
-        entry = (reply_entry *) p;
+    if (reply->dsi_header.return_code.error_code) {
+        return reply->dsi_header.return_code.error_code;
+    }
 
-        if (p > max) {
+    for (i = 0; i < ntohs(reply->reqcount); i++) {
+        unsigned int entry_size;
+
+        if ((size_t)(max - p) < sizeof(*entry)) {
+            free_file_list(filebase);
+            return -1;
+        }
+
+        entry = (reply_entry *) p;
+        entry_size = entry->size;
+
+        if (entry_size < sizeof(*entry) || (size_t)(max - p) < entry_size) {
+            free_file_list(filebase);
             return -1;
         }
 
         prev = filecur;
 
         if ((filecur = malloc(sizeof(struct afp_file_info))) == NULL) {
+            free_file_list(filebase);
             return -1;
         }
 
@@ -243,12 +265,16 @@ int afp_enumerate_reply(struct afp_server *server, char * buf,
             prev->next = filecur;
         }
 
-        parse_reply_block(server, p + sizeof(*entry),
-                          ntohs(entry->size), entry->isdir,
-                          ntohs(reply->filebitmap),
-                          ntohs(reply->dirbitmap),
-                          filecur);
-        p += entry->size;
+        if (parse_reply_block(server, p + sizeof(*entry),
+                              entry_size - sizeof(*entry), entry->isdir,
+                              ntohs(reply->filebitmap),
+                              ntohs(reply->dirbitmap),
+                              filecur) < 0) {
+            free_file_list(filebase);
+            return -1;
+        }
+
+        p += entry_size;
     }
 
     *x = filebase;
@@ -272,32 +298,38 @@ int afp_enumerateext2_reply(struct afp_server *server, char * buf,
         uint16_t reqcount;
     } __attribute__((__packed__)) * reply = (void *) buf;
     const ext2_reply_entry *entry;
-    char *p = buf + sizeof(*reply);
-    /* FIXME: max was stubbed out and the bounds check was never implemented.
-     * The loop advances p by entry->size (uint16_t, server-supplied) with no
-     * validation, so a malicious or buggy server can walk p past buf+size.
-     * Per the spec, ActualCount (here: reqcount) bounds the iteration, but
-     * each entry->size must also be validated:
-     *   1. p + sizeof(*entry) <= max  — before casting p to ext2_reply_entry*
-     *   2. ntohs(entry->size) >= sizeof(*entry)  — prevent stall/underflow
-     *   3. p + ntohs(entry->size) <= max  — before advancing p
-     * Restore 'char *max = buf + size' and add these three guards inside the
-     * loop, breaking out (not returning an error) on violation per spec note:
-     * "enumerate until kFPObjectNotFound... filter out duplicates". */
+    const char *p = buf + sizeof(*reply);
+    const char *max = buf + size;
     int i;
     struct afp_file_info * filebase = NULL, *filecur = NULL, *new_file = NULL,
                            **x = (struct afp_file_info **) other;
-
-    if (reply->dsi_header.return_code.error_code) {
-        return reply->dsi_header.return_code.error_code;
-    }
 
     if (size < sizeof(*reply)) {
         return -1;
     }
 
+    if (reply->dsi_header.return_code.error_code) {
+        return reply->dsi_header.return_code.error_code;
+    }
+
     for (i = 0; i < ntohs(reply->reqcount); i++) {
+        unsigned int entry_size;
+
+        if ((size_t)(max - p) < sizeof(*entry)) {
+            free_file_list(filebase);
+            return -1;
+        }
+
+        entry = (const void *) p;
+        entry_size = ntohs(entry->size);
+
+        if (entry_size < sizeof(*entry) || (size_t)(max - p) < entry_size) {
+            free_file_list(filebase);
+            return -1;
+        }
+
         if ((new_file = malloc(sizeof(struct afp_file_info))) == NULL) {
+            free_file_list(filebase);
             return -1;
         }
 
@@ -311,13 +343,16 @@ int afp_enumerateext2_reply(struct afp_server *server, char * buf,
             filecur = new_file;
         }
 
-        entry = (ext2_reply_entry *) p;
-        parse_reply_block(server, p + sizeof(*entry),
-                          ntohs(entry->size), entry->isdir,
-                          ntohs(reply->filebitmap),
-                          ntohs(reply->dirbitmap),
-                          filecur);
-        p += ntohs(entry->size);
+        if (parse_reply_block(server, p + sizeof(*entry),
+                              entry_size - sizeof(*entry), entry->isdir,
+                              ntohs(reply->filebitmap),
+                              ntohs(reply->dirbitmap),
+                              filecur) < 0) {
+            free_file_list(filebase);
+            return -1;
+        }
+
+        p += entry_size;
     }
 
     *x = filebase;

--- a/lib/proto_files.c
+++ b/lib/proto_files.c
@@ -2,6 +2,7 @@
  *  proto_files.c
  *
  *  Copyright (C) 2006 Alex deVries <alexthepuffin@gmail.com>
+ *  Copyright (C) 2026 Daniel Markstedt <daniel@mindani.net>
  *
  */
 
@@ -318,21 +319,24 @@ int afp_getfiledirparms_reply(struct afp_server *server, char * buf,
     }  __attribute__((__packed__)) * reply_packet = (void *) buf;
     struct afp_file_info * filecur = other;
 
-    if (reply_packet->header.return_code.error_code) {
-        return reply_packet->header.return_code.error_code;
-    }
-
     if (size < sizeof(*reply_packet)) {
         return -1;
     }
 
-    parse_reply_block(server,
-                      buf + (sizeof(*reply_packet)),
-                      size,
-                      reply_packet->isdir,
-                      ntohs(reply_packet->filebitmap),
-                      ntohs(reply_packet->dirbitmap),
-                      filecur);
+    if (reply_packet->header.return_code.error_code) {
+        return reply_packet->header.return_code.error_code;
+    }
+
+    if (parse_reply_block(server,
+                          buf + (sizeof(*reply_packet)),
+                          size - sizeof(*reply_packet),
+                          reply_packet->isdir,
+                          ntohs(reply_packet->filebitmap),
+                          ntohs(reply_packet->dirbitmap),
+                          filecur) < 0) {
+        return -1;
+    }
+
     filecur->isdir = reply_packet->isdir;
     return 0;
 }
@@ -546,4 +550,3 @@ int afp_writeext_reply(__attribute__((unused)) struct afp_server *server,
 
     return 0;
 }
-

--- a/lib/proto_replyblock.c
+++ b/lib/proto_replyblock.c
@@ -2,6 +2,7 @@
  *  proto_replyblock.c
  *
  *  Copyright (C) 2006 Alex deVries <alexthepuffin@gmail.com>
+ *  Copyright (C) 2026 Daniel Markstedt <daniel@mindani.net>
  *
  */
 
@@ -13,19 +14,100 @@
 #include "afp_replies.h"
 
 
-/* FIXME: should do bounds checking */
+static int need_bytes(const char *p, const char *end, size_t len)
+{
+    return p <= end && (size_t)(end - p) >= len;
+}
+
+static int copy_pascal_bounded(char *dest, size_t dest_len,
+                               const char *base, unsigned int size,
+                               unsigned int offset)
+{
+    const char *src;
+    const char *end = base + size;
+    unsigned char len;
+
+    if (offset >= size) {
+        return -1;
+    }
+
+    src = base + offset;
+
+    if (!need_bytes(src, end, 1)) {
+        return -1;
+    }
+
+    len = (unsigned char) * src;
+
+    if (!need_bytes(src + 1, end, len)) {
+        return -1;
+    }
+
+    if (dest_len == 0) {
+        return 0;
+    }
+
+    if ((size_t)len >= dest_len) {
+        return -1;
+    }
+
+    memset(dest, 0, dest_len);
+    memcpy(dest, src + 1, len);
+    return 0;
+}
+
+static int copy_afpname_bounded(char *dest, size_t dest_len,
+                                const char *base, unsigned int size,
+                                unsigned int offset)
+{
+    const char *src;
+    const char *end = base + size;
+    unsigned short len;
+    const unsigned short *len_p;
+
+    if (offset > size || size - offset < 6) {
+        return -1;
+    }
+
+    src = base + offset + 4;
+
+    if (!need_bytes(src, end, 2)) {
+        return -1;
+    }
+
+    len_p = (const void *) src;
+    len = ntohs(*len_p);
+
+    if (!need_bytes(src + 2, end, len)) {
+        return -1;
+    }
+
+    if (dest_len == 0) {
+        return 0;
+    }
+
+    if ((size_t)len >= dest_len) {
+        return -1;
+    }
+
+    memset(dest, 0, dest_len);
+    memcpy(dest, src + 2, len);
+    return 0;
+}
+
 int parse_reply_block(__attribute__((unused)) struct afp_server *server,
-                      char *buf,
-                      __attribute__((unused)) unsigned int size, unsigned char isdir,
+                      const char *buf,
+                      unsigned int size, unsigned char isdir,
                       unsigned int filebitmap,
                       unsigned int dirbitmap,
                       struct afp_file_info * filecur)
 {
     unsigned short bitmap;
-    char *p2;
+    const char *p2, *end;
     memset(filecur, 0, sizeof(struct afp_file_info));
     filecur->isdir = isdir;
     p2 = buf;
+    end = buf + size;
 
     if (isdir) {
         bitmap = dirbitmap ;
@@ -34,120 +116,218 @@ int parse_reply_block(__attribute__((unused)) struct afp_server *server,
     }
 
     if (bitmap & kFPAttributeBit) {
-        unsigned short *attr = (void *) p2;
+        const unsigned short *attr = (const void *) p2;
+
+        if (!need_bytes(p2, end, 2)) {
+            return -1;
+        }
+
         filecur->attributes = ntohs(*attr);
         p2 += 2;
     }
 
     if (bitmap & kFPParentDirIDBit) {
-        unsigned int *did = (void *) p2;
+        const unsigned int *did = (const void *) p2;
+
+        if (!need_bytes(p2, end, 4)) {
+            return -1;
+        }
+
         filecur->did = ntohl(*did);
         p2 += 4;
     }
 
     if (bitmap & kFPCreateDateBit) {
-        unsigned int *date = (void *) p2;
+        const unsigned int *date = (const void *) p2;
+
+        if (!need_bytes(p2, end, 4)) {
+            return -1;
+        }
+
         filecur->creation_date = AD_DATE_TO_UNIX(*date);
         p2 += 4;
     }
 
     if (bitmap & kFPModDateBit) {
-        unsigned int *date = (void *) p2;
+        const unsigned int *date = (const void *) p2;
+
+        if (!need_bytes(p2, end, 4)) {
+            return -1;
+        }
+
         filecur->modification_date = AD_DATE_TO_UNIX(*date);
         p2 += 4;
     }
 
     if (bitmap & kFPBackupDateBit) {
-        unsigned int *date = (void *) p2;
+        const unsigned int *date = (const void *) p2;
+
+        if (!need_bytes(p2, end, 4)) {
+            return -1;
+        }
+
         filecur->backup_date = AD_DATE_TO_UNIX(*date);
         p2 += 4;
     }
 
     if (bitmap & kFPFinderInfoBit) {
+        if (!need_bytes(p2, end, 32)) {
+            return -1;
+        }
+
         memcpy(filecur->finderinfo, p2, 32);
         p2 += 32;
     }
 
     if (bitmap & kFPLongNameBit) {
-        unsigned short *offset = (void *) p2;
-        copy_from_pascal(filecur->name, buf + (ntohs(*offset)), sizeof(filecur->name));
+        const unsigned short *offset = (const void *) p2;
+
+        if (!need_bytes(p2, end, 2)
+                || copy_pascal_bounded(filecur->name, sizeof(filecur->name),
+                                       buf, size, ntohs(*offset)) < 0) {
+            return -1;
+        }
+
         p2 += 2;
     }
 
     if (bitmap & kFPShortNameBit) {
+        if (!need_bytes(p2, end, 2)) {
+            return -1;
+        }
+
         p2 += 2;
     }
 
     if (bitmap & kFPNodeIDBit) {
-        unsigned int *id = (void *) p2;
+        const unsigned int *id = (const void *) p2;
+
+        if (!need_bytes(p2, end, 4)) {
+            return -1;
+        }
+
         filecur->fileid = ntohl(*id);
         p2 += 4;
     }
 
     if (isdir) {
         if (bitmap & kFPOffspringCountBit) {
-            unsigned short *offspring = (void *) p2;
+            const unsigned short *offspring = (const void *) p2;
+
+            if (!need_bytes(p2, end, 2)) {
+                return -1;
+            }
+
             filecur->offspring = ntohs(*offspring);
             p2 += 2;
         }
 
         if (bitmap & kFPOwnerIDBit) {
-            unsigned int *owner = (void *) p2;
+            const unsigned int *owner = (const void *) p2;
+
+            if (!need_bytes(p2, end, 4)) {
+                return -1;
+            }
+
             filecur->unixprivs.uid = ntohl(*owner);
             p2 += 4;
         }
 
         if (bitmap & kFPGroupIDBit) {
-            unsigned int *group = (void *) p2;
+            const unsigned int *group = (const void *) p2;
+
+            if (!need_bytes(p2, end, 4)) {
+                return -1;
+            }
+
             filecur->unixprivs.gid = ntohl(*group);
             p2 += 4;
         }
 
         if (bitmap & kFPAccessRightsBit) {
-            unsigned int *access = (void *) p2;
+            const unsigned int *access = (const void *) p2;
+
+            if (!need_bytes(p2, end, 4)) {
+                return -1;
+            }
+
             filecur->accessrights = ntohl(*access);
             p2 += 4;
         }
     } else {
         if (bitmap & kFPDataForkLenBit) {
-            unsigned int *len = (void *) p2;
+            const unsigned int *len = (const void *) p2;
+
+            if (!need_bytes(p2, end, 4)) {
+                return -1;
+            }
+
             filecur->size = ntohl(*len);
             p2 += 4;
         }
 
         if (bitmap & kFPRsrcForkLenBit) {
-            unsigned int   *size = (void *) p2;
-            filecur->resourcesize = ntohl(*size);
+            const unsigned int *rsrc_len = (const void *) p2;
+
+            if (!need_bytes(p2, end, 4)) {
+                return -1;
+            }
+
+            filecur->resourcesize = ntohl(*rsrc_len);
             p2 += 4;
         }
 
         if (bitmap & kFPExtDataForkLenBit) {
-            unsigned long long *len = (void *) p2;
+            const unsigned long long *len = (const void *) p2;
+
+            if (!need_bytes(p2, end, 8)) {
+                return -1;
+            }
+
             filecur->size = ntoh64(*len);
             p2 += 8;
         }
 
         if (bitmap & kFPLaunchLimitBit) {
+            if (!need_bytes(p2, end, 2)) {
+                return -1;
+            }
+
             p2 += 2;
         }
     }
 
     if (bitmap & kFPUTF8NameBit) {
-        unsigned short *offset = (void *) p2;
-        copy_from_pascal_two(filecur->name, buf + (ntohs(*offset)) + 4,
-                             sizeof(filecur->name));
+        const unsigned short *offset = (const void *) p2;
+
+        if (!need_bytes(p2, end, 6)
+                || copy_afpname_bounded(filecur->name, sizeof(filecur->name),
+                                        buf, size, ntohs(*offset)) < 0) {
+            return -1;
+        }
+
         p2 += 2;
         p2 += 4;
     }
 
     if (bitmap & kFPExtRsrcForkLenBit) {
-        unsigned long long *size = (void *) p2;
-        filecur->resourcesize = ntoh64(*size);
+        const unsigned long long *rsrc_len = (const void *) p2;
+
+        if (!need_bytes(p2, end, 8)) {
+            return -1;
+        }
+
+        filecur->resourcesize = ntoh64(*rsrc_len);
         p2 += 8;
     }
 
     if (bitmap & kFPUnixPrivsBit) {
-        struct afp_unixprivs *unixpriv = (void *) p2;
+        const struct afp_unixprivs *unixpriv = (const void *) p2;
+
+        if (!need_bytes(p2, end, sizeof(*unixpriv))) {
+            return -1;
+        }
+
         filecur->unixprivs.uid = ntohl(unixpriv->uid);
         filecur->unixprivs.gid = ntohl(unixpriv->gid);
         filecur->unixprivs.permissions = ntohl(unixpriv->permissions);
@@ -157,4 +337,3 @@ int parse_reply_block(__attribute__((unused)) struct afp_server *server,
 
     return 0;
 }
-


### PR DESCRIPTION
Validate reply-block field sizes before reading server-supplied data, including enumerate entry lengths and AFP name offsets.

Reject names that do not fit in afp_file_info instead of silently truncating them, propagate parser failures from reply handlers, and make reply-buffer parsing const-correct.