### PR TITLE
afpcmd self test invoked with optarg

### DIFF
--- a/cmdline/cmdline_main.c
+++ b/cmdline/cmdline_main.c
@@ -244,9 +244,6 @@ COMMAND commands[] = {
     { "status", com_status, "Get some server status", 1 },
     { "touch", com_touch, "Touch FILE", 1 },
     { "?", com_help, "Same as `help'", 0 },
-#ifdef DEBUG
-    { "test", test_urls, "Run client tests", 1},
-#endif
     { (char *)NULL, NULL, (char *)NULL, 0 }
 };
 
@@ -451,9 +448,10 @@ static void usage(void)
 {
     printf(
         "Netatalk Client %s - Apple Filing Protocol CLI client application\n"
-        "afpcmd [-h] [-r] [-V] [-v loglevel] <afp url>\n"
+        "afpcmd [-h] [-r] [-t] [-V] [-v loglevel] <afp url>\n"
         "Options:\n"
-        "\t-h:          show this help message\n"
+        "\t-h:          show this help message and exit\n"
+        "\t-t:          run client self-tests and exit\n"
         "\t-r:          set the recursive flag\n"
         "\t-V:          verbose mode (show detailed transfer messages)\n"
         "\t-v loglevel: set log verbosity (debug, info, notice, warning, error)\n"
@@ -476,9 +474,11 @@ int main(int argc, char *argv[])
     int recursive = 0;
     int verbose = 0;
     int show_usage = 0;
+    int test_mode = 0;
     int log_level = LOG_NOTICE;
     struct option long_options[] = {
         {"help", 0, 0, 'h'},
+        {"test", 0, 0, 't'},
         {"recursive", 0, 0, 'r'},
         {"verbose", 0, 0, 'V'},
         {"loglevel", 1, 0, 'v'},
@@ -490,7 +490,7 @@ int main(int argc, char *argv[])
     int direction = 0; /* 0 = GET (remote->local), 1 = PUT (local->remote) */
 
     while (1) {
-        c = getopt_long(argc, argv, "hrVv:",
+        c = getopt_long(argc, argv, "hrtVv:",
                         long_options, &option_index);
 
         if (c == -1) {
@@ -504,6 +504,10 @@ int main(int argc, char *argv[])
 
         case 'r':
             recursive = 1;
+            break;
+
+        case 't':
+            test_mode = 1;
             break;
 
         case 'V':
@@ -538,6 +542,12 @@ int main(int argc, char *argv[])
     cmdline_afp_setup_client();
     cmdline_set_log_level(log_level);
     cmdline_set_verbose(verbose);
+
+    if (test_mode) {
+        int result = test_urls();
+        cmdline_afp_exit();
+        return result;
+    }
 
     /* Check arguments for batch mode */
     if (argc - optind == 2) {

--- a/cmdline/cmdline_testafp.c
+++ b/cmdline/cmdline_testafp.c
@@ -1,7 +1,7 @@
 /*
-	Copyright (C) 2008 Alex deVries <alexthepuffin@gmail.com>
-
-*/
+ *  Copyright (C) 2008 Alex deVries <alexthepuffin@gmail.com>
+ *  Copyright (C) 2026 Daniel Markstedt <daniel@mindani.net>
+ */
 
 #include "afp.h"
 #include "midlevel.h"
@@ -36,6 +36,7 @@ static int test_one_url(char * url_string,
 
     if (afp_url_validate(url_string, &valid_url)) {
         printf("* Could not parse %s\n", url_string);
+        return 1;
     } else {
         printf("* Parsed %s correctly\n", url_string);
     }
@@ -43,28 +44,33 @@ static int test_one_url(char * url_string,
     return 0;
 }
 
-int test_urls(__attribute__((unused)) char *arg)
+int test_urls(void)
 {
+    int failures = 0;
     printf("Testing AFP URL parsing\n");
-    test_one_url("afp://user::name;AUTH=DHCAST128:pa@@sword@server/volume/path",
-                 TCPIP, "user:name", "DHCAST128", "pa@sword", "server", 548, "volume", "path");
-    test_one_url("afp://username;AUTH=DHCAST128:password@server/volume/path",
-                 TCPIP, "username", "DHCAST128", "password", "server", 548, "volume", "path");
-    test_one_url("afp://username;AUTH=DHCAST128:password@server:548/volume/path",
-                 TCPIP, "username", "DHCAST128", "password", "server", 548, "volume", "path");
-    test_one_url("afp://username:password@server/volume/path",
-                 TCPIP, "username", "", "password", "server", 548, "volume", "path");
-    test_one_url("afp://username@server/volume/path",
-                 TCPIP, "username", "", "", "server", 548, "volume", "path");
-    test_one_url("afp://server/volume/path",
-                 TCPIP, "", "", "", "server", 548, "volume", "path");
-    test_one_url("afp://server/",
-                 TCPIP, "", "", "", "server", 548, "", "");
-    test_one_url("afp://server:22/",
-                 TCPIP, "", "", "", "server", 22, "", "");
-    test_one_url("afp://server:22",
-                 TCPIP, "", "", "", "server", 22, "", "");
-    test_one_url("afp://server:22/volume/",
-                 TCPIP, "", "", "", "server", 22, "volume", "");
-    return 0;
+    failures +=
+        test_one_url("afp://user::name;AUTH=DHCAST128:pa@@sword@server/volume/path",
+                     TCPIP, "user:name", "DHCAST128", "pa@sword", "server", 548, "volume", "path");
+    failures +=
+        test_one_url("afp://username;AUTH=DHCAST128:password@server/volume/path",
+                     TCPIP, "username", "DHCAST128", "password", "server", 548, "volume", "path");
+    failures +=
+        test_one_url("afp://username;AUTH=DHCAST128:password@server:548/volume/path",
+                     TCPIP, "username", "DHCAST128", "password", "server", 548, "volume", "path");
+    failures += test_one_url("afp://username:password@server/volume/path",
+                             TCPIP, "username", "", "password", "server", 548, "volume", "path");
+    failures += test_one_url("afp://username@server/volume/path",
+                             TCPIP, "username", "", "", "server", 548, "volume", "path");
+    failures += test_one_url("afp://server/volume/path",
+                             TCPIP, "", "", "", "server", 548, "volume", "path");
+    failures += test_one_url("afp://server/",
+                             TCPIP, "", "", "", "server", 548, "", "");
+    failures += test_one_url("afp://server:22/",
+                             TCPIP, "", "", "", "server", 22, "", "");
+    failures += test_one_url("afp://server:22",
+                             TCPIP, "", "", "", "server", 22, "", "");
+    failures += test_one_url("afp://server:22/volume/",
+                             TCPIP, "", "", "", "server", 22, "volume", "");
+    printf("AFP URL parsing self-tests: %s\n", failures ? "FAILED" : "PASSED");
+    return failures ? 1 : 0;
 }

--- a/cmdline/cmdline_testafp.h
+++ b/cmdline/cmdline_testafp.h
@@ -1,4 +1,6 @@
 #ifndef __CMDLINE_TESTAFP_H_
-int test_urls(char *);
-#endif
+#define __CMDLINE_TESTAFP_H_
 
+int test_urls(void);
+
+#endif

--- a/docs/manpages/afpcmd.1
+++ b/docs/manpages/afpcmd.1
@@ -1,4 +1,4 @@
-.Dd January 26, 2026
+.Dd June 14, 2026
 .Dt AFPCMD 1
 .Os Netatalk Client
 .Sh NAME
@@ -21,6 +21,8 @@
 .Ar afp_url
 .Nm
 .Fl h
+.Nm
+.Fl t
 .Sh DESCRIPTION
 .Nm
 is a command-line tool to help transfer files to and from a
@@ -43,6 +45,8 @@ and commands. If not already running, afpcmd will attempt to start it.
 .Bl -tag -width Ds
 .It Fl h , Fl -help
 Shows the help message.
+.It Fl t , Fl -test
+Runs the client self-tests and exits.
 .It Fl r , Fl -recursive
 Sets the recursive flag.
 .It Fl V , Fl -verbose

--- a/meson.build
+++ b/meson.build
@@ -29,10 +29,6 @@ cflags = [
     '-D_GNU_SOURCE',
 ]
 
-if build_type == 'debug'
-    cflags += '-DDEBUG'
-endif
-
 if host_os in ['dragonfly', 'freebsd', 'openbsd']
     libsearch_dirs += '/usr/local/lib'
     include_dirs += ['/usr/local/include']

--- a/test/test_afpcmd_interactive.t
+++ b/test/test_afpcmd_interactive.t
@@ -59,22 +59,25 @@ sub afpcmd_pipe {
 }
 
 # -----------------------------------------------------------------------
-# test_builtin: built-in 'test' command validates AFP URL parsing
+# test_mode: -t validates AFP URL parsing without connecting to a server
 # -----------------------------------------------------------------------
 {
-    my $out = afpcmd_pipe($AFP_URL, 'test', 'quit');
+    my $out = `afpcmd -t 2>&1`;
+    is($?, 0, 'test_mode: exits 0');
     like($out, qr/Testing AFP URL parsing/,
-        'test_builtin: header');
+        'test_mode: header');
     like($out, qr{afp://user::name;AUTH=DHCAST128:pa\@\@sword\@.* correctly},
-        'test_builtin: auth-user URL');
+        'test_mode: auth-user URL');
     like($out, qr{afp://username:password\@.* correctly},
-        'test_builtin: basic URL');
+        'test_mode: basic URL');
     like($out, qr{afp://username\@.* correctly},
-        'test_builtin: no-password URL');
+        'test_mode: no-password URL');
     like($out, qr{afp://server/.* correctly},
-        'test_builtin: bare-host URL');
+        'test_mode: bare-host URL');
     like($out, qr{afp://server:22.* correctly},
-        'test_builtin: URL with port');
+        'test_mode: URL with port');
+    like($out, qr/self-tests: PASSED/,
+        'test_mode: summary');
 }
 
 # -----------------------------------------------------------------------


### PR DESCRIPTION
remove the 'test' interactive command in the afpcmd client, and add a -t/--test optarg instead that runs the tests and exits

any failed test case will return a non zero exit code