### PR TITLE
route Apple xattrs through fork metadata

### DIFF
--- a/cmdline/cmdline_afp.c
+++ b/cmdline/cmdline_afp.c
@@ -444,6 +444,18 @@ static int metadata_error_unsupported(int ret)
     return ret == -ENOTSUP || ret == -EOPNOTSUPP || ret == -ENOSYS;
 }
 
+static int metadata_name_special(const char *name)
+{
+    const char *stripped = afp_xattr_strip_user_prefix(name);
+
+    if (!stripped) {
+        return 0;
+    }
+
+    return strcmp(stripped, AFP_XATTR_FINDERINFO) == 0
+           || strcmp(stripped, AFP_XATTR_RESOURCEFORK) == 0;
+}
+
 static void metadata_warn_unsupported(void)
 {
     if (!metadata_warning_emitted) {
@@ -655,8 +667,7 @@ static int clear_remote_metadata(const char *path)
     }
 
     while ((next = metadata_list_next(list, list_size, &pos, &name)) > 0) {
-        if (strcmp(name, "com.apple.FinderInfo") == 0
-                || strcmp(name, "com.apple.ResourceFork") == 0
+        if (metadata_name_special(name)
                 || metadata_name_filtered(name)) {
             continue;
         }
@@ -835,8 +846,7 @@ static int copy_local_metadata_to_remote(const char *local_path,
             void *value = NULL;
             size_t value_size = 0;
 
-            if (strcmp(name, "com.apple.FinderInfo") == 0
-                    || strcmp(name, "com.apple.ResourceFork") == 0
+            if (metadata_name_special(name)
                     || metadata_name_filtered(name)) {
                 continue;
             }
@@ -982,8 +992,7 @@ static int copy_remote_metadata_to_local(const char *remote_path,
             void *value = NULL;
             size_t value_size = 0;
 
-            if (strcmp(name, "com.apple.FinderInfo") == 0
-                    || strcmp(name, "com.apple.ResourceFork") == 0
+            if (metadata_name_special(name)
                     || metadata_name_filtered(name)) {
                 continue;
             }
@@ -1129,8 +1138,7 @@ static int copy_remote_metadata(const char *source, const char *target,
         void *value = NULL;
         size_t value_size = 0;
 
-        if (strcmp(name, "com.apple.FinderInfo") == 0
-                || strcmp(name, "com.apple.ResourceFork") == 0
+        if (metadata_name_special(name)
                 || metadata_name_filtered(name)) {
             continue;
         }
@@ -1352,7 +1360,7 @@ int com_pass(__attribute__((unused)) char *unused)
             break;
 
         default:
-            printf("Password change failed (error code: %d).\n", ret);
+            printf("Password change failed with unknown error.\n");
             break;
         }
 
@@ -2704,6 +2712,13 @@ int com_resourcefork(char *arg)
             return metadata_command_error("open input", -errno);
         }
 
+        ret = afp_sl_setresourcefork(&vol_id, path, NULL, 0, 0);
+
+        if (ret < 0) {
+            close(fd);
+            return metadata_command_error("resourcefork set", ret);
+        }
+
         while (1) {
             ssize_t amount = read(fd, buffer, sizeof(buffer));
 
@@ -2713,8 +2728,7 @@ int com_resourcefork(char *arg)
             }
 
             if (amount == 0) {
-                ret = offset == 0
-                      ? afp_sl_setresourcefork(&vol_id, path, NULL, 0, 0) : 0;
+                ret = 0;
                 break;
             }
 
@@ -3128,7 +3142,7 @@ int com_status(__attribute__((unused)) char *unused)
     ret = afp_sl_status(NULL, NULL, text, &len);
 
     if (ret != AFP_SERVER_RESULT_OKAY) {
-        printf("Could not get status (result=%d)\n", ret);
+        printf("Could not get status\n");
         return -1;
     }
 
@@ -3159,7 +3173,7 @@ int com_statvfs(__attribute__((unused)) char *unused)
         } else if (ret == AFP_SERVER_RESULT_ACCESS) {
             printf("Permission denied\n");
         } else {
-            printf("Failed to get filesystem statistics (error: %d)\n", ret);
+            printf("Failed to get filesystem statistics\n");
         }
 
         return -1;
@@ -3270,8 +3284,7 @@ int com_cd(char *arg)
             } else if (ret == AFP_SERVER_RESULT_NOVOLUME) {
                 printf("Volume %s does not exist on this server\n", path);
             } else {
-                printf("Could not attach to volume %s (error code: %d)\n",
-                       url.volumename, ret);
+                printf("Could not attach to volume %s\n", url.volumename);
             }
 
             url.volumename[0] = '\0';
@@ -3503,8 +3516,7 @@ static int cmdline_server_startup(int batch_mode)
             } else if (ret == AFP_SERVER_RESULT_NOVOLUME) {
                 printf("Volume %s does not exist on this server\n", url.volumename);
             } else {
-                printf("Could not attach to volume %s (error code: %d)\n",
-                       url.volumename, ret);
+                printf("Could not attach to volume %s\n", url.volumename);
             }
 
             return -1;

--- a/daemon/commands.c
+++ b/daemon/commands.c
@@ -1625,37 +1625,29 @@ static unsigned char process_metadata(struct daemon_client *c)
     }
 
     switch (request->header.command) {
-    case AFP_SERVER_COMMAND_GETXATTR:
-        if (!(volume->attributes & kSupportsExtAttrs)) {
-            ret = -ENOTSUP;
-        } else {
-            char *xattr_data = NULL;
+    case AFP_SERVER_COMMAND_GETXATTR: {
+        char *xattr_data = NULL;
 
-            if (request->size) {
-                xattr_data = data;
-            }
-
-            ret = ml_getxattr(volume, request->path, request->name,
-                              xattr_data, request->size);
+        if (request->size) {
+            xattr_data = data;
         }
 
-        break;
+        ret = ml_getxattr(volume, request->path, request->name,
+                          xattr_data, request->size);
+    }
+    break;
 
-    case AFP_SERVER_COMMAND_LISTXATTR:
-        if (!(volume->attributes & kSupportsExtAttrs)) {
-            ret = -ENOTSUP;
-        } else {
-            char *listxattr_data = NULL;
+    case AFP_SERVER_COMMAND_LISTXATTR: {
+        char *listxattr_data = NULL;
 
-            if (request->size) {
-                listxattr_data = data;
-            }
-
-            ret = ml_listxattr(volume, request->path,
-                               listxattr_data, request->size);
+        if (request->size) {
+            listxattr_data = data;
         }
 
-        break;
+        ret = ml_listxattr(volume, request->path,
+                           listxattr_data, request->size);
+    }
+    break;
 
     case AFP_SERVER_COMMAND_GETFINDERINFO: {
         char *finderinfo_data = NULL;
@@ -1681,9 +1673,8 @@ static unsigned char process_metadata(struct daemon_client *c)
         break;
 
     case AFP_SERVER_COMMAND_SETXATTR:
-        ret = !(volume->attributes & kSupportsExtAttrs) ? -ENOTSUP
-              : ml_setxattr(volume, request->path, request->name,
-                            request->data, request->size, request->flags);
+        ret = ml_setxattr(volume, request->path, request->name,
+                          request->data, request->size, request->flags);
         break;
 
     case AFP_SERVER_COMMAND_SETFINDERINFO:
@@ -1702,8 +1693,7 @@ static unsigned char process_metadata(struct daemon_client *c)
         break;
 
     case AFP_SERVER_COMMAND_REMOVEXATTR:
-        ret = !(volume->attributes & kSupportsExtAttrs) ? -ENOTSUP
-              : ml_removexattr(volume, request->path, request->name);
+        ret = ml_removexattr(volume, request->path, request->name);
         break;
 
     case AFP_SERVER_COMMAND_REMOVEFINDERINFO:

--- a/fuse/fuse_int.c
+++ b/fuse/fuse_int.c
@@ -60,8 +60,6 @@
 #endif
 
 #ifdef __APPLE__
-#define AFP_XATTR_RESOURCEFORK "com.apple.ResourceFork"
-#define AFP_XATTR_FINDERINFO "com.apple.FinderInfo"
 #define AFP_FINDERINFO_FLAG_INVISIBLE 0x4000
 #define AFP_ACCESS_UNKNOWN_BITS 0x000fc001
 #define AFP_ACCESS_READ_BITS    ((1U << 1) | (1U << 7) | (1U << 9) | (1U << 11))
@@ -87,57 +85,12 @@
 
 #include "dsi.h"
 #include "afp_protocol.h"
+#include "afp_xattr.h"
 #include "codepage.h"
 #include "midlevel.h"
 #include "fuse_error.h"
 
 #ifdef __APPLE__
-static int xattr_list_contains(const char *list, size_t used,
-                               const char *name)
-{
-    size_t namelen = strlen(name);
-    size_t offset = 0;
-
-    while (offset < used) {
-        size_t remaining = used - offset;
-        size_t entrylen = strnlen(list + offset, remaining);
-
-        if (entrylen == remaining) {
-            return 0;
-        }
-
-        if (entrylen == namelen &&
-                memcmp(list + offset, name, namelen) == 0) {
-            return 1;
-        }
-
-        offset += entrylen + 1;
-    }
-
-    return 0;
-}
-
-static int append_xattr_name(char *list, size_t size, size_t *used,
-                             const char *name)
-{
-    size_t namelen = strlen(name) + 1;
-
-    if (list && size > 0) {
-        if (xattr_list_contains(list, *used, name)) {
-            return 0;
-        }
-
-        if (*used + namelen > size) {
-            return -ERANGE;
-        }
-
-        memcpy(list + *used, name, namelen);
-    }
-
-    *used += namelen;
-    return 0;
-}
-
 static uint16_t finderinfo_get_flags(const char finderinfo[32])
 {
     return ((uint16_t)(unsigned char)finderinfo[8] << 8)
@@ -295,7 +248,8 @@ static int fuse_setxattr(const char *path, const char *name,
         log_for_client(NULL, AFPFSD, LOG_DEBUG,
                        "*** setxattr resource fork %s (size=%zu position=%u)",
                        path, size, position);
-        ret = ml_setresourcefork(volume, path, value, size, position);
+        ret = ml_setresourcefork_flags(volume, path, value, size, position,
+                                       ml_flags);
         return ret;
     }
 
@@ -306,7 +260,7 @@ static int fuse_setxattr(const char *path, const char *name,
 
         log_for_client(NULL, AFPFSD, LOG_DEBUG,
                        "*** setxattr FinderInfo %s (size=%zu)", path, size);
-        ret = ml_setfinderinfo(volume, path, value, size);
+        ret = ml_setfinderinfo_flags(volume, path, value, size, ml_flags);
         return ret;
     }
 
@@ -327,64 +281,9 @@ static int fuse_listxattr(const char *path, char *list, size_t size)
     struct afp_volume * volume =
         (struct afp_volume *)
         ((struct fuse_context *)(fuse_get_context()))->private_data;
-#ifdef __APPLE__
-    char scratch[4096];
-    char *target = list;
-    size_t target_size = size;
-#endif
     log_for_client(NULL, AFPFSD, LOG_DEBUG,
                    "*** listxattr %s (size=%zu)", path, size);
-#ifdef __APPLE__
-
-    if (!list || size == 0) {
-        target = scratch;
-        target_size = sizeof(scratch);
-    }
-
-    ret = ml_listxattr(volume, path, target, target_size);
-#else
     ret = ml_listxattr(volume, path, list, size);
-#endif
-#ifdef __APPLE__
-
-    if (ret >= 0) {
-        size_t used = ret;
-        char finderinfo[32];
-
-        if (ml_getresourcefork(volume, path, NULL, 0, 0) > 0) {
-            ret = append_xattr_name(target, target_size, &used,
-                                    AFP_XATTR_RESOURCEFORK);
-
-            if (ret < 0) {
-                return ret;
-            }
-        }
-
-        if (ml_getfinderinfo(volume, path, finderinfo, sizeof(finderinfo)) == 32
-                && memcmp(finderinfo, "\0\0\0\0\0\0\0\0"
-                          "\0\0\0\0\0\0\0\0"
-                          "\0\0\0\0\0\0\0\0"
-                          "\0\0\0\0\0\0\0\0", 32) != 0) {
-            ret = append_xattr_name(target, target_size, &used,
-                                    AFP_XATTR_FINDERINFO);
-
-            if (ret < 0) {
-                return ret;
-            }
-        }
-
-        if (target != list && list && size > 0) {
-            if (used > size) {
-                return -ERANGE;
-            }
-
-            memcpy(list, target, used);
-        }
-
-        ret = used;
-    }
-
-#endif
     return ret;
 }
 

--- a/include/afp.h
+++ b/include/afp.h
@@ -13,6 +13,7 @@
 #include <netinet/in.h>
 
 #include "afp_protocol.h"
+#include "afp_xattr.h"
 #include "libafpclient.h"
 
 /* This is the maximum AFP version this library supports */
@@ -290,21 +291,6 @@ struct afp_server {
     char *attention_buffer;
 
 };
-
-struct afp_extattr_info {
-    unsigned int maxsize;
-    unsigned int size;
-    char data[1024];
-};
-
-/* Extended Attribute filtering for server internal metadata */
-/* Netatalk's internal metadata EA - should not be exposed to clients */
-#define NETATALK_EA_META "org.netatalk.Metadata"
-#define NETATALK_EA_META_LEN 22
-
-/* Check if this is an internal server EA that should be filtered */
-#define IS_INTERNAL_SERVER_EA(name) \
-    (strncmp((name), NETATALK_EA_META, NETATALK_EA_META_LEN) == 0)
 
 struct afp_comment {
     unsigned int maxsize;

--- a/include/afp_xattr.h
+++ b/include/afp_xattr.h
@@ -1,0 +1,40 @@
+#ifndef __AFP_XATTR_H_
+#define __AFP_XATTR_H_
+
+#include <string.h>
+
+#define AFP_XATTR_RESOURCEFORK "com.apple.ResourceFork"
+#define AFP_XATTR_FINDERINFO "com.apple.FinderInfo"
+
+#define NETATALK_XATTR_META "org.netatalk.Metadata"
+#define NETATALK_XATTR_META_LEN 22
+
+#define AFP_EXTATTR_DATA_MAX 4096
+#define AFP_XATTR_NAME_MAX 255U
+
+#define AFP_XATTR_USER_PREFIX "user."
+#define AFP_XATTR_USER_PREFIX_LEN 5
+
+/* Utility for stripping the "user." prefix from xattr names. */
+static inline const char *afp_xattr_strip_user_prefix(const char *name)
+{
+    if (name && strncmp(name, AFP_XATTR_USER_PREFIX,
+                        AFP_XATTR_USER_PREFIX_LEN) == 0) {
+        return name + AFP_XATTR_USER_PREFIX_LEN;
+    }
+
+    return name;
+}
+
+struct afp_extattr_info {
+    unsigned int maxsize;
+    unsigned int size;
+    unsigned int copied;
+    char data[AFP_EXTATTR_DATA_MAX];
+};
+
+/* Check if this is an internal server xattr that should be filtered */
+#define IS_INTERNAL_SERVER_XATTR(name) \
+    (strncmp((name), NETATALK_XATTR_META, NETATALK_XATTR_META_LEN) == 0)
+
+#endif /* __AFP_XATTR_H_ */

--- a/include/midlevel.h
+++ b/include/midlevel.h
@@ -88,6 +88,10 @@ int ml_getresourcefork(struct afp_volume * volume, const char *path,
 int ml_setresourcefork(struct afp_volume * volume, const char *path,
                        const void *value, size_t size, off_t position);
 
+int ml_setresourcefork_flags(struct afp_volume * volume, const char *path,
+                             const void *value, size_t size, off_t position,
+                             int flags);
+
 int ml_removeresourcefork(struct afp_volume * volume, const char *path);
 
 int ml_getfinderinfo(struct afp_volume * volume, const char *path,
@@ -95,6 +99,9 @@ int ml_getfinderinfo(struct afp_volume * volume, const char *path,
 
 int ml_setfinderinfo(struct afp_volume * volume, const char *path,
                      const void *value, size_t size);
+
+int ml_setfinderinfo_flags(struct afp_volume * volume, const char *path,
+                           const void *value, size_t size, int flags);
 
 int ml_removefinderinfo(struct afp_volume * volume, const char *path);
 

--- a/lib/midlevel.c
+++ b/lib/midlevel.c
@@ -15,6 +15,7 @@
 #include <string.h>
 #include <errno.h>
 #include <limits.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <sys/time.h>
 #include <time.h>
@@ -37,13 +38,13 @@
 #include "codepage.h"
 #include "midlevel.h"
 #include "afp_internal.h"
+#include "afp_xattr.h"
 #include "forklist.h"
 #include "uams.h"
 #include "lowlevel.h"
 
 
 #define min(a,b) (((a)<(b)) ? (a) : (b))
-#define AFP_XATTR_NAME_MAX 255U
 
 static int normalize_xattr_name(const char *name, const char **afp_name,
                                 unsigned short *afp_namelen)
@@ -54,16 +55,32 @@ static int normalize_xattr_name(const char *name, const char **afp_name,
         return -ENAMETOOLONG;
     }
 
-    *afp_name = name;
+    const char *stripped = afp_xattr_strip_user_prefix(name);
 
-    if (length >= sizeof("user.") - 1U
-            && memcmp(name, "user.", sizeof("user.") - 1U) == 0) {
-        *afp_name += sizeof("user.") - 1U;
-        length -= sizeof("user.") - 1U;
+    if (stripped != name) {
+        length -= AFP_XATTR_USER_PREFIX_LEN;
     }
 
+    *afp_name = stripped;
     *afp_namelen = (unsigned short)length;
     return 0;
+}
+
+static const char *normalized_xattr_name_for_compare(const char *name)
+{
+    return afp_xattr_strip_user_prefix(name);
+}
+
+static int is_resourcefork_xattr(const char *name)
+{
+    return strcmp(normalized_xattr_name_for_compare(name),
+                  AFP_XATTR_RESOURCEFORK) == 0;
+}
+
+static int is_finderinfo_xattr(const char *name)
+{
+    return strcmp(normalized_xattr_name_for_compare(name),
+                  AFP_XATTR_FINDERINFO) == 0;
 }
 
 static int get_unixprivs(struct afp_volume * volume,
@@ -1735,6 +1752,67 @@ static int open_appledouble_meta(struct afp_volume *volume, const char *path,
     return appledouble_open_meta(volume, converted_path, resource, flags, fp);
 }
 
+static int validate_special_xattr_flags(int flags, int exists_ret)
+{
+    int exists;
+
+    if ((flags & kXAttrCreate) && (flags & kXAttrREplace)) {
+        return -EINVAL;
+    }
+
+    if (exists_ret < 0 && exists_ret != -ENOATTR && exists_ret != -EFBIG) {
+        return exists_ret;
+    }
+
+    exists = exists_ret >= 0 || exists_ret == -EFBIG;
+
+    if ((flags & kXAttrCreate) && exists) {
+        return -EEXIST;
+    }
+
+    if ((flags & kXAttrREplace) && !exists) {
+        return -ENOATTR;
+    }
+
+    return 0;
+}
+
+static int append_listed_xattr_name(char *list, size_t size, size_t *used,
+                                    const char *name)
+{
+    size_t namelen = strnlen(name, AFP_XATTR_NAME_MAX + 1U);
+#ifdef __APPLE__
+    size_t output_namelen = namelen;
+#else
+    size_t output_namelen = namelen + sizeof("user.") - 1U;
+#endif
+
+    if (namelen > AFP_XATTR_NAME_MAX) {
+        return -ENAMETOOLONG;
+    }
+
+    if (output_namelen > SIZE_MAX - 1U
+            || *used > SIZE_MAX - output_namelen - 1U) {
+        return -EOVERFLOW;
+    }
+
+    if (list && size > 0) {
+        if (*used + output_namelen + 1U > size) {
+            return -ERANGE;
+        }
+
+#ifdef __APPLE__
+        memcpy(list + *used, name, namelen + 1U);
+#else
+        memcpy(list + *used, "user.", sizeof("user.") - 1U);
+        memcpy(list + *used + sizeof("user.") - 1U, name, namelen + 1U);
+#endif
+    }
+
+    *used += output_namelen + 1U;
+    return 0;
+}
+
 int ml_getresourcefork(struct afp_volume * volume, const char *path,
                        void *value, size_t size, off_t position)
 {
@@ -1745,7 +1823,7 @@ int ml_getresourcefork(struct afp_volume * volume, const char *path,
     uint64_t remaining;
     int ret;
 
-    if (!volume || !path) {
+    if (!volume || !path || (!value && size > 0)) {
         return -EINVAL;
     }
 
@@ -1756,7 +1834,7 @@ int ml_getresourcefork(struct afp_volume * volume, const char *path,
 
     ret = ll_getattr(volume, converted_path, &stbuf, 1);
 
-    if (ret < 0) {
+    if (ret < 0 && ret != -EFBIG) {
         return ret;
     }
 
@@ -1843,7 +1921,7 @@ int ml_setresourcefork(struct afp_volume * volume, const char *path,
         return ret;
     }
 
-    if (position == 0) {
+    if (position == 0 && size == 0) {
         ret = ll_zero_file(volume, fp.forkid, 1);
 
         if (ret != 0) {
@@ -1877,8 +1955,33 @@ int ml_setresourcefork(struct afp_volume * volume, const char *path,
     return 0;
 }
 
+int ml_setresourcefork_flags(struct afp_volume * volume, const char *path,
+                             const void *value, size_t size, off_t position,
+                             int flags)
+{
+    int ret;
+
+    if (flags & (kXAttrCreate | kXAttrREplace)) {
+        ret = validate_special_xattr_flags(flags,
+                                           ml_getresourcefork(volume, path,
+                                               NULL, 0, 0));
+
+        if (ret < 0) {
+            return ret;
+        }
+    }
+
+    return ml_setresourcefork(volume, path, value, size, position);
+}
+
 int ml_removeresourcefork(struct afp_volume * volume, const char *path)
 {
+    int ret = ml_getresourcefork(volume, path, NULL, 0, 0);
+
+    if (ret < 0 && ret != -EFBIG) {
+        return ret;
+    }
+
     return ml_setresourcefork(volume, path, NULL, 0, 0);
 }
 
@@ -1965,6 +2068,24 @@ int ml_setfinderinfo(struct afp_volume * volume, const char *path,
     return 0;
 }
 
+int ml_setfinderinfo_flags(struct afp_volume * volume, const char *path,
+                           const void *value, size_t size, int flags)
+{
+    int ret;
+
+    if (flags & (kXAttrCreate | kXAttrREplace)) {
+        ret = validate_special_xattr_flags(flags,
+                                           ml_getfinderinfo(volume, path,
+                                               NULL, 0));
+
+        if (ret < 0) {
+            return ret;
+        }
+    }
+
+    return ml_setfinderinfo(volume, path, value, size);
+}
+
 int ml_removefinderinfo(struct afp_volume * volume, const char *path)
 {
     char finderinfo[32];
@@ -1986,13 +2107,21 @@ int ml_getxattr(struct afp_volume * volume, const char *path,
         return -EINVAL;
     }
 
+    if (is_resourcefork_xattr(name)) {
+        return ml_getresourcefork(volume, path, value, size, 0);
+    }
+
+    if (is_finderinfo_xattr(name)) {
+        return ml_getfinderinfo(volume, path, value, size);
+    }
+
     /* Ignore EAs if server doesn't support them */
     if (!(volume->attributes & kSupportsExtAttrs)) {
         return -ENOATTR;
     }
 
     /* Filter internal server EAs - pretend they don't exist */
-    if (IS_INTERNAL_SERVER_EA(name)) {
+    if (IS_INTERNAL_SERVER_XATTR(name)) {
         return -ENOATTR;
     }
 
@@ -2022,6 +2151,7 @@ int ml_getxattr(struct afp_volume * volume, const char *path,
      * fixed-size, so cap the request at the storage we actually have. */
     info.maxsize = sizeof(info.data);
     info.size = 0;
+    info.copied = 0;
     /* Get the extended attribute */
     ret = afp_getextattr(volume, dirid, 0, info.maxsize,
                          basename, afp_namelen, afp_name, &info);
@@ -2058,6 +2188,10 @@ int ml_getxattr(struct afp_volume * volume, const char *path,
         return -ERANGE;
     }
 
+    if (info.copied < info.size) {
+        return -ERANGE;
+    }
+
     /* Copy data to user buffer */
     if (value && info.size > 0) {
         memcpy(value, info.data, info.size);
@@ -2080,13 +2214,21 @@ int ml_setxattr(struct afp_volume * volume, const char *path,
         return -EINVAL;
     }
 
+    if (is_resourcefork_xattr(name)) {
+        return ml_setresourcefork_flags(volume, path, value, size, 0, flags);
+    }
+
+    if (is_finderinfo_xattr(name)) {
+        return ml_setfinderinfo_flags(volume, path, value, size, flags);
+    }
+
     /* Silently succeed when server doesn't support EAs to allow file copies */
     if (!(volume->attributes & kSupportsExtAttrs)) {
         return 0;
     }
 
     /* Filter internal server EAs - silently succeed to allow file copies */
-    if (IS_INTERNAL_SERVER_EA(name)) {
+    if (IS_INTERNAL_SERVER_XATTR(name)) {
         return 0;
     }
 
@@ -2152,64 +2294,64 @@ int ml_listxattr(struct afp_volume * volume, const char *path,
     struct afp_extattr_info info;
     unsigned int dirid;
     char basename[AFP_MAX_PATH];
-    int ret;
+    size_t filtered_size = 0;
+    int ret = 0;
 
     if (!volume || !path) {
         return -EINVAL;
     }
 
-    /* Return empty list when server doesn't support EAs */
-    if (!(volume->attributes & kSupportsExtAttrs)) {
-        return 0;
+    if ((volume->attributes & kSupportsExtAttrs) && strcmp(path, "/") != 0) {
+        /* Parse path into directory ID and basename */
+        ret = get_dirid(volume, path, basename, &dirid);
+
+        if (ret != 0) {
+            return ret;
+        }
+
+        /* Note: We don't call ll_get_directory_entry here to avoid file locking
+         * conflicts. The FUSE layer already verified the file exists via getattr.
+         * If the file doesn't exist, the AFP command will return kFPObjectNotFound. */
+        /* Same minimum-1024 rule as ml_getxattr, capped to the fixed reply buffer. */
+        info.maxsize = sizeof(info.data);
+        info.size = 0;
+        info.copied = 0;
+        /* List extended attributes */
+        ret = afp_listextattr(volume, dirid, 0, basename, &info);
+
+        switch (ret) {
+        case kFPNoErr:
+            break;
+
+        case kFPAccessDenied:
+            return -EACCES;
+
+        case kFPObjectNotFound:
+            return -ENOENT;
+
+        case kFPParamErr:
+            /* TC returns kFPParamErr when MaxReplySize is too small; treat as
+             * empty list so callers see no attributes rather than a hard error. */
+            info.size = 0;
+            break;
+
+        default:
+            return -EIO;
+        }
+    } else {
+        info.size = 0;
+        info.copied = 0;
     }
 
-    /* Special case: root directory - return empty list */
-    if (strcmp(path, "/") == 0) {
-        return 0;
-    }
-
-    /* Parse path into directory ID and basename */
-    ret = get_dirid(volume, path, basename, &dirid);
-
-    if (ret != 0) {
-        return ret;
-    }
-
-    /* Note: We don't call ll_get_directory_entry here to avoid file locking
-     * conflicts. The FUSE layer already verified the file exists via getattr.
-     * If the file doesn't exist, the AFP command will return kFPObjectNotFound. */
-    /* Same minimum-1024 rule as ml_getxattr, capped to the fixed reply buffer. */
-    info.maxsize = sizeof(info.data);
-    info.size = 0;
-    /* List extended attributes */
-    ret = afp_listextattr(volume, dirid, 0, basename, &info);
-
-    switch (ret) {
-    case kFPNoErr:
-        break;
-
-    case kFPAccessDenied:
-        return -EACCES;
-
-    case kFPObjectNotFound:
-        return -ENOENT;
-
-    case kFPParamErr:
-        /* TC returns kFPParamErr when MaxReplySize is too small; treat as
-         * empty list so callers see no attributes rather than a hard error. */
-        return 0;
-
-    default:
-        return -EIO;
+    if (info.copied < info.size) {
+        return -ERANGE;
     }
 
     /* Filter out internal server EAs from the list.
      * On Linux, prepend "user." namespace prefix (required by the kernel EA
      * interface).  On macOS, AFP xattr names are passed as-is; no prefix. */
     const char *src = info.data;
-    char *dst = list;
-    size_t remaining = info.size;
-    size_t filtered_size = 0;
+    size_t remaining = info.copied;
 
     while (remaining > 0) {
         size_t namelen = strnlen(src, remaining);
@@ -2225,36 +2367,12 @@ int ml_listxattr(struct afp_volume * volume, const char *path,
         }
 
         /* Only include this EA if it's not filtered */
-        if (!IS_INTERNAL_SERVER_EA(src)) {
-#ifdef __APPLE__
-            /* macOS: return the raw AFP name (e.g. "com.apple.FinderInfo") */
-            size_t output_namelen = namelen;
+        if (!IS_INTERNAL_SERVER_XATTR(src)) {
+            ret = append_listed_xattr_name(list, size, &filtered_size, src);
 
-            if (list && size > 0) {
-                if (filtered_size + output_namelen + 1 <= size) {
-                    memcpy(dst, src, namelen + 1);
-                    dst += output_namelen + 1;
-                } else {
-                    return -ERANGE;
-                }
+            if (ret < 0) {
+                return ret;
             }
-
-#else
-            /* Linux: prepend "user." namespace prefix */
-            size_t output_namelen = namelen + 5;  /* "user." + name */
-
-            if (list && size > 0) {
-                if (filtered_size + output_namelen + 1 <= size) {
-                    memcpy(dst, "user.", 5);
-                    memcpy(dst + 5, src, namelen + 1);
-                    dst += output_namelen + 1;
-                } else {
-                    return -ERANGE;
-                }
-            }
-
-#endif
-            filtered_size += output_namelen + 1;
         }
 
         src += namelen + 1;
@@ -2277,13 +2395,21 @@ int ml_removexattr(struct afp_volume * volume, const char *path,
         return -EINVAL;
     }
 
+    if (is_resourcefork_xattr(name)) {
+        return ml_removeresourcefork(volume, path);
+    }
+
+    if (is_finderinfo_xattr(name)) {
+        return ml_removefinderinfo(volume, path);
+    }
+
     /* Ignore EAs if server doesn't support them to allow file deletions */
     if (!(volume->attributes & kSupportsExtAttrs)) {
         return -ENOATTR;
     }
 
     /* Filter internal server EAs - deny removal */
-    if (IS_INTERNAL_SERVER_EA(name)) {
+    if (IS_INTERNAL_SERVER_XATTR(name)) {
         return -EACCES;
     }
 

--- a/lib/proto_attr.c
+++ b/lib/proto_attr.c
@@ -92,6 +92,7 @@ int afp_listextattrs_reply(__attribute__((unused)) struct afp_server * server,
     }
 
     i->size = 0;
+    i->copied = 0;
 
     if (size < sizeof(struct dsi_header)) {
         log_for_client(NULL, AFPFSD, LOG_WARNING,
@@ -120,7 +121,8 @@ int afp_listextattrs_reply(__attribute__((unused)) struct afp_server * server,
                        datalength, available);
     }
 
-    i->size = len;
+    i->size = datalength;
+    i->copied = len;
 
     if (len > 0) {
         memcpy(i->data, reply->data, len);
@@ -146,6 +148,7 @@ int afp_getextattr_reply(__attribute__((unused)) struct afp_server * server,
 
     if (i) {
         i->size = 0;
+        i->copied = 0;
     }
 
     if (size < sizeof(struct dsi_header)) {
@@ -176,7 +179,8 @@ int afp_getextattr_reply(__attribute__((unused)) struct afp_server * server,
                            datalength, available);
         }
 
-        i->size = len;
+        i->size = datalength;
+        i->copied = len;
 
         if (len > 0) {
             memcpy(i->data, reply->data, len);

--- a/test/test_protocol_replies.c
+++ b/test/test_protocol_replies.c
@@ -33,6 +33,13 @@ int main(void)
     uint64_t wire64;
     uint32_t written32 = 99;
     uint64_t written64 = 99;
+    struct afp_extattr_info xattr_info;
+    struct {
+        struct dsi_header header __attribute__((__packed__));
+        uint16_t bitmap;
+        uint32_t datalength;
+        char data[4];
+    } __attribute__((__packed__)) xattr_reply;
     memset(reply, 0, sizeof(reply));
     wire32 = htonl(1234);
     memcpy(reply + sizeof(reply) - sizeof(wire32), &wire32, sizeof(wire32));
@@ -55,5 +62,15 @@ int main(void)
     CHECK(written32 == 0);
     CHECK(afp_write_reply(NULL, (char *)reply, sizeof(reply), NULL) == 0);
     CHECK(afp_writeext_reply(NULL, (char *)reply, sizeof(reply), NULL) == 0);
+    memset(&xattr_reply, 0, sizeof(xattr_reply));
+    memset(&xattr_info, 0, sizeof(xattr_info));
+    xattr_info.maxsize = 2;
+    xattr_reply.datalength = htonl(sizeof(xattr_reply.data));
+    memcpy(xattr_reply.data, "abcd", sizeof(xattr_reply.data));
+    CHECK(afp_getextattr_reply(NULL, (char *)&xattr_reply,
+                               sizeof(xattr_reply), &xattr_info) == 0);
+    CHECK(xattr_info.size == sizeof(xattr_reply.data));
+    CHECK(xattr_info.copied == xattr_info.maxsize);
+    CHECK(memcmp(xattr_info.data, "ab", xattr_info.copied) == 0);
     return 0;
 }


### PR DESCRIPTION
Handle com.apple.FinderInfo and com.apple.ResourceFork in the midlevel xattr layer rather than the FUSE client so generic callers use the AppleDouble/fork metadata paths instead of FPGetExtAttr/FPSetExtAttr.

Honor create/replace semantics, report ENOATTR for absent special metadata removal, keep resource-fork offset writes from implicitly truncating, and centralize special-name listxattr handling.

Track declared generic xattr sizes separately from copied reply bytes to avoid silent truncation, and cover the parser behavior with a protocol reply test.

Introduce a global afp_xattr.h header with consolidated constants, data types and utility functions concerning extended attributes.