### PR TITLE
introduce a global text sanitizer utility function

### DIFF
--- a/fuse/daemon.c
+++ b/fuse/daemon.c
@@ -21,7 +21,6 @@
 #include <getopt.h>
 #include <limits.h>
 #include <signal.h>
-#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -74,9 +73,14 @@ void fuse_forced_ending_hook(void)
             for (int i = 0; i < s->num_volumes; i++) {
                 volume = &s->volumes[i];
 
-                if (volume->mounted == AFP_VOLUME_MOUNTED)
+                if (volume->mounted == AFP_VOLUME_MOUNTED) {
+                    char safe_mountpoint[PATH_MAX * 4];
+                    sanitize_text(volume->mountpoint,
+                                  safe_mountpoint,
+                                  sizeof(safe_mountpoint));
                     log_for_client(NULL, AFPFSD, LOG_NOTICE,
-                                   "Unmounting %s", volume->mountpoint);
+                                   "Unmounting %s", safe_mountpoint);
+                }
 
                 afp_unmount_volume(volume);
             }
@@ -93,9 +97,12 @@ int fuse_unmount_volume(struct afp_volume * volume)
     }
 
     if (!volume->priv) {
+        char safe_mountpoint[PATH_MAX * 4];
+        sanitize_text(volume->mountpoint, safe_mountpoint,
+                      sizeof(safe_mountpoint));
         log_for_client(NULL, AFPFSD, LOG_DEBUG,
                        "FUSE handle already cleared for %s - skipping unmount",
-                       volume->mountpoint);
+                       safe_mountpoint);
         return 0;
     }
 
@@ -103,8 +110,11 @@ int fuse_unmount_volume(struct afp_volume * volume)
     pthread_t self = pthread_self();
     pthread_t vol_thread = volume->thread;
     int is_same_thread = pthread_equal(self, vol_thread);
+    char safe_mountpoint[PATH_MAX * 4];
+    sanitize_text(volume->mountpoint, safe_mountpoint,
+                  sizeof(safe_mountpoint));
     log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                   "Unmounting FUSE filesystem at %s", volume->mountpoint);
+                   "Unmounting FUSE filesystem at %s", safe_mountpoint);
     fuse_unmount((struct fuse *)volume->priv);
 
     /* Wait for FUSE thread to complete (if called from external thread) */
@@ -113,7 +123,7 @@ int fuse_unmount_volume(struct afp_volume * volume)
                        "Waiting for FUSE thread to complete");
         pthread_join(volume->thread, NULL);
         log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                       "FUSE thread completed for %s", volume->mountpoint);
+                       "FUSE thread completed for %s", safe_mountpoint);
     }
 
     return 0;
@@ -172,6 +182,35 @@ struct manager_child {
 
 static struct manager_child *child_list = NULL;
 
+static int append_text(char *text, size_t size, int *pos, const char *src)
+{
+    size_t available;
+    size_t len;
+
+    if (*pos < 0 || (size_t) * pos >= size) {
+        if (size > 0) {
+            text[size - 1] = '\0';
+            *pos = (int)size - 1;
+        }
+
+        return -1;
+    }
+
+    available = size - (size_t) * pos;
+    len = strnlen(src, available);
+    memcpy(text + *pos, src, len);
+
+    if (len >= available) {
+        *pos = (int)size - 1;
+        text[*pos] = '\0';
+        return -1;
+    }
+
+    *pos += (int)len;
+    text[*pos] = '\0';
+    return 0;
+}
+
 /* Send exit command to a socket path */
 static void send_exit_to_socket(const char *socket_path)
 {
@@ -225,7 +264,11 @@ static struct manager_child *find_child_by_mountpoint(const char *mountpoint,
             pos = strlen(text);
         }
 
-        snprintf(text + pos, sizeof(text) - pos, "No mount found at %s\n", mountpoint);
+        char safe_mountpoint[PATH_MAX * 4];
+        sanitize_text(mountpoint, safe_mountpoint,
+                      sizeof(safe_mountpoint));
+        snprintf(text + pos, sizeof(text) - pos, "No mount found at %s\n",
+                 safe_mountpoint);
         response.result = AFP_SERVER_RESULT_ERROR;
         response.len = strlen(text);
         (void)write(client_fd, &response, sizeof(response));
@@ -263,7 +306,11 @@ static int connect_to_child_socket(const char *socket_path,
         if (client_fd >= 0) {
             struct afp_server_response response;
             char text[1024];
-            snprintf(text, sizeof(text), "Socket path too long for %s\n", mountpoint);
+            char safe_mountpoint[PATH_MAX * 4];
+            sanitize_text(mountpoint, safe_mountpoint,
+                          sizeof(safe_mountpoint));
+            snprintf(text, sizeof(text), "Socket path too long for %s\n",
+                     safe_mountpoint);
             response.result = AFP_SERVER_RESULT_ERROR;
             response.len = strlen(text);
             (void)write(client_fd, &response, sizeof(response));
@@ -286,8 +333,11 @@ static int connect_to_child_socket(const char *socket_path,
                 pos = strlen(text);
             }
 
+            char safe_mountpoint[PATH_MAX * 4];
+            sanitize_text(mountpoint, safe_mountpoint,
+                          sizeof(safe_mountpoint));
             snprintf(text + pos, sizeof(text) - pos,
-                     "Could not connect to daemon for %s\n", mountpoint);
+                     "Could not connect to daemon for %s\n", safe_mountpoint);
             response.result = AFP_SERVER_RESULT_ERROR;
             response.len = strlen(text);
             (void)write(client_fd, &response, sizeof(response));
@@ -359,10 +409,10 @@ static void add_child(pid_t pid, const char *socket_id, const char *mountpoint,
     }
 
     child->pid = pid;
-    snprintf(child->socket_id, sizeof(child->socket_id), "%s", socket_id);
-    snprintf(child->mountpoint, sizeof(child->mountpoint), "%s", mountpoint);
-    snprintf(child->volumename, sizeof(child->volumename), "%s",
-             volumename ? volumename : "");
+    strlcpy(child->socket_id, socket_id, sizeof(child->socket_id));
+    strlcpy(child->mountpoint, mountpoint, sizeof(child->mountpoint));
+    strlcpy(child->volumename, volumename ? volumename : "",
+            sizeof(child->volumename));
     child->next = child_list;
     child_list = child;
 }
@@ -626,9 +676,15 @@ static int handle_manager_command(int client_fd)
                     }
                 }
 
+                char safe_mountpoint[PATH_MAX * 4];
+                char safe_socket_id[PATH_MAX * 4];
+                sanitize_text(child->mountpoint, safe_mountpoint,
+                              sizeof(safe_mountpoint));
+                sanitize_text(child->socket_id, safe_socket_id,
+                              sizeof(safe_socket_id));
                 log_for_client(NULL, AFPFSD, LOG_DEBUG,
                                "Child check: pid=%d mount=%s socket=%s access=%d sock=%d conn=%d errno=%d alive=%d",
-                               child->pid, child->mountpoint, child->socket_id,
+                               child->pid, safe_mountpoint, safe_socket_id,
                                access_result, socket_result, connect_result, connect_errno, is_alive);
 
                 if (!is_alive) {
@@ -645,46 +701,62 @@ static int handle_manager_command(int client_fd)
             }
 
             if (count == 0) {
-                pos += snprintf(text + pos, len,
-                                "Manager daemon: no active mounts");
+                append_text(text, sizeof(text), &pos,
+                            "Manager daemon: no active mounts");
 
                 if (initial_count > 0) {
-                    pos += snprintf(text + pos, sizeof(text) - pos,
-                                    " (removed %d stale)", removed_count);
+                    char removed_text[64];
+                    snprintf(removed_text, sizeof(removed_text),
+                             " (removed %d stale)", removed_count);
+                    append_text(text, sizeof(text), &pos, removed_text);
                 }
             } else {
-                pos += snprintf(text + pos, len,
-                                "Manager daemon: %d active mount%s",
-                                count, count == 1 ? "" : "s");
+                char count_text[64];
+                snprintf(count_text, sizeof(count_text),
+                         "Manager daemon: %d active mount%s",
+                         count, count == 1 ? "" : "s");
+                append_text(text, sizeof(text), &pos, count_text);
 
                 if (removed_count > 0) {
-                    pos += snprintf(text + pos, sizeof(text) - pos,
-                                    " (removed %d stale)", removed_count);
+                    char removed_text[64];
+                    snprintf(removed_text, sizeof(removed_text),
+                             " (removed %d stale)", removed_count);
+                    append_text(text, sizeof(text), &pos, removed_text);
                 }
 
-                pos += snprintf(text + pos, sizeof(text) - pos, "\n");
+                append_text(text, sizeof(text), &pos, "\n");
 
                 /* List mountpoints with volume names */
                 for (child = child_list; child; child = child->next) {
+                    char safe_volumename[AFP_VOLUME_NAME_UTF8_LEN * 4];
+                    char safe_mountpoint[PATH_MAX * 4];
+                    sanitize_text(child->volumename, safe_volumename,
+                                  sizeof(safe_volumename));
+                    sanitize_text(child->mountpoint, safe_mountpoint,
+                                  sizeof(safe_mountpoint));
+
                     if (child->volumename[0] != '\0') {
-                        pos += snprintf(text + pos, sizeof(text) - pos,
-                                        "  %s: %s\n", child->volumename,
-                                        child->mountpoint);
+                        append_text(text, sizeof(text), &pos, "  ");
+                        append_text(text, sizeof(text), &pos, safe_volumename);
+                        append_text(text, sizeof(text), &pos, ": ");
+                        append_text(text, sizeof(text), &pos, safe_mountpoint);
+                        append_text(text, sizeof(text), &pos, "\n");
                     } else {
-                        pos += snprintf(text + pos, sizeof(text) - pos,
-                                        "  %s\n", child->mountpoint);
+                        append_text(text, sizeof(text), &pos, "  ");
+                        append_text(text, sizeof(text), &pos, safe_mountpoint);
+                        append_text(text, sizeof(text), &pos, "\n");
                     }
 
-                    if (pos >= (int)sizeof(text)) {
+                    if (pos >= (int)sizeof(text) - 1) {
                         break;
                     }
                 }
 
-                pos += snprintf(text + pos, sizeof(text) - pos,
-                                "\nRun 'afp_client status [mountpoint]' for details");
+                append_text(text, sizeof(text), &pos,
+                            "\nRun 'afp_client status [mountpoint]' for details");
             }
 
-            snprintf(text + pos, sizeof(text) - pos, "\n");
+            append_text(text, sizeof(text), &pos, "\n");
             response.result = AFP_SERVER_RESULT_OKAY;
             response.len = strlen(text);
 
@@ -762,8 +834,11 @@ static int run_manager_daemon(void)
 
     /* Install SIGCHLD handler to immediately reap child processes */
     daemon_install_sigchld_handler();
+    char safe_commandfilename[PATH_MAX * 4];
+    sanitize_text(commandfilename, safe_commandfilename,
+                  sizeof(safe_commandfilename));
     log_for_client(NULL, AFPFSD, LOG_NOTICE,
-                   "Starting manager daemon on %s", commandfilename);
+                   "Starting manager daemon on %s", safe_commandfilename);
 
     while (1) {
         fd_set rds;

--- a/include/utils.h
+++ b/include/utils.h
@@ -39,6 +39,8 @@ void trigger_exit(void);
 void afp_set_auto_shutdown_on_unmount(int enabled);
 int afp_get_auto_shutdown_on_unmount(void);
 
+void sanitize_text(const char *text, char *sanitized, size_t size);
+
 /* Log level conversion functions */
 const char *log_level_to_string(int level);
 int string_to_log_level(const char *str, int *level_out);

--- a/lib/log.c
+++ b/lib/log.c
@@ -11,49 +11,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include "libafpclient.h"
-
-static void escape_log_message(const char *in, char *out, size_t outsize)
-{
-    size_t used = 0;
-
-    if (outsize == 0) {
-        return;
-    }
-
-    while (*in && used + 1 < outsize) {
-        unsigned char ch = (unsigned char) * in++;
-
-        if (ch == '\r' || ch == '\n' || ch == '\t') {
-            char escaped;
-
-            if (ch == '\r') {
-                escaped = 'r';
-            } else if (ch == '\n') {
-                escaped = 'n';
-            } else {
-                escaped = 't';
-            }
-
-            if (used + 2 >= outsize) {
-                break;
-            }
-
-            out[used++] = '\\';
-            out[used++] = escaped;
-        } else if (ch < 0x20 || ch == 0x7f) {
-            if (used + 4 >= outsize) {
-                break;
-            }
-
-            used += (size_t)snprintf(out + used, outsize - used,
-                                     "\\x%02x", ch);
-        } else {
-            out[used++] = (char)ch;
-        }
-    }
-
-    out[used] = '\0';
-}
+#include "utils.h"
 
 void log_for_client(void * priv,
                     enum logtypes logtype, int loglevel, char *format, ...)
@@ -64,7 +22,7 @@ void log_for_client(void * priv,
     va_start(ap, format);
     vsnprintf(new_message, MAX_ERROR_LEN, format, ap);
     va_end(ap);
-    escape_log_message(new_message, escaped, sizeof(escaped));
+    sanitize_text(new_message, escaped, sizeof(escaped));
     libafpclient->log_for_client(priv, logtype, loglevel, escaped);
 }
 

--- a/lib/proto_directory.c
+++ b/lib/proto_directory.c
@@ -366,8 +366,10 @@ int afp_enumerateext2_reply(struct afp_server *server, char * buf,
     const char *p = buf + sizeof(*reply);
     const char *max = buf + size;
     int i;
-    struct afp_file_info * filebase = NULL, *filecur = NULL, *new_file = NULL,
-                           **x = (struct afp_file_info **) other;
+    struct afp_file_info *filebase = NULL;
+    struct afp_file_info *filecur = NULL;
+    struct afp_file_info *new_file = NULL;
+    struct afp_file_info **x = (struct afp_file_info **) other;
 
     if (size < sizeof(reply->dsi_header)) {
         return -1;

--- a/lib/utils.c
+++ b/lib/utils.c
@@ -268,6 +268,57 @@ int invalid_filename(struct afp_server * server, const char * filename)
     return 0;
 }
 
+void sanitize_text(const char *text, char *sanitized, size_t size)
+{
+    size_t pos = 0;
+
+    if (size == 0) {
+        return;
+    }
+
+    if (!text) {
+        sanitized[0] = '\0';
+        return;
+    }
+
+    while (*text && pos + 1 < size) {
+        unsigned char ch = (unsigned char) * text++;
+
+        if (ch == '\r' || ch == '\n' || ch == '\t') {
+            char escaped;
+
+            if (ch == '\r') {
+                escaped = 'r';
+            } else if (ch == '\n') {
+                escaped = 'n';
+            } else {
+                escaped = 't';
+            }
+
+            if (pos + 2 >= size) {
+                break;
+            }
+
+            sanitized[pos++] = '\\';
+            sanitized[pos++] = escaped;
+        } else if (ch < 0x20 || ch == 0x7f) {
+            if (pos + 4 >= size) {
+                break;
+            }
+
+            static const char hex[] = "0123456789abcdef";
+            sanitized[pos++] = '\\';
+            sanitized[pos++] = 'x';
+            sanitized[pos++] = hex[ch >> 4];
+            sanitized[pos++] = hex[ch & 0x0f];
+        } else {
+            sanitized[pos++] = (char)ch;
+        }
+    }
+
+    sanitized[pos] = '\0';
+}
+
 const char *log_level_to_string(int level)
 {
     switch (level) {

--- a/test/test_log.c
+++ b/test/test_log.c
@@ -2,6 +2,7 @@
 #include <string.h>
 
 #include "libafpclient.h"
+#include "utils.h"
 
 static char captured_message[MAX_ERROR_LEN * 4];
 
@@ -16,6 +17,7 @@ static void capture_log_message(
 
 int main(void)
 {
+    char sanitized[sizeof("line 1\\r\\nline\\t2\\x01\\x7f")];
     struct libafpclient test_client = {
         .unmount_volume = NULL,
         .log_for_client = capture_log_message,
@@ -25,6 +27,14 @@ int main(void)
     };
     const char input[] = "line 1\r\nline\t2\x01\x7f";
     const char expected[] = "line 1\\r\\nline\\t2\\x01\\x7f";
+    sanitize_text(input, sanitized, sizeof(sanitized));
+
+    if (strcmp(sanitized, expected) != 0) {
+        fprintf(stderr, "sanitize expected: %s\nactual:            %s\n",
+                expected, sanitized);
+        return 1;
+    }
+
     libafpclient_register(&test_client);
     log_for_client(NULL, AFPFSD, LOG_INFO, "%s", input);
     libafpclient_register(NULL);


### PR DESCRIPTION
replace the libafpclient logger's local sanitizer function with a global one located in the utils module, and apply it to particularly the FUSE daemon user logging for safety