### PR TITLE
afpcmd: add per-command recursive operations

### DIFF
--- a/cmdline/cmdline_afp.c
+++ b/cmdline/cmdline_afp.c
@@ -76,11 +76,36 @@ int full_url = 0;
 static volumeid_t vol_id = NULL;
 static serverid_t server_id = NULL;
 static int connected = 0;
-static int recursive_mode = 0;
 static enum metadata_mode transfer_metadata_mode = METADATA_AUTO;
 static int metadata_warning_emitted = 0;
 
 static int write_all_fd(int fd, const void *data, size_t size);
+
+/* Consume the command-local recursive option.  Command handlers receive the
+ * text following the command name, so this deliberately only recognizes -r
+ * as the first argument (for example, "get -r directory"). */
+static int command_recursive_option(char **arg)
+{
+    char *p = *arg;
+
+    while (isspace((unsigned char) * p)) {
+        p++;
+    }
+
+    if (p[0] != '-' || p[1] != 'r'
+            || (p[2] != '\0' && !isspace((unsigned char)p[2]))) {
+        return 0;
+    }
+
+    p += 2;
+
+    while (isspace((unsigned char) * p)) {
+        p++;
+    }
+
+    *arg = p;
+    return 1;
+}
 
 #ifndef ENOATTR
 #ifdef ENODATA
@@ -1508,6 +1533,59 @@ int com_touch(char * arg)
     return -1;
 }
 
+static int chmod_remote_tree(const char *server_path, mode_t mode)
+{
+    struct afp_file_info_basic *entries = NULL;
+    unsigned int count = 0;
+    int ret = 0;
+
+    if (remote_readdir_all(server_path, &entries, &count) != 0) {
+        printf("Could not read directory %s\n", server_path);
+        return -1;
+    }
+
+    for (unsigned int i = 0; i < count; i++) {
+        struct afp_file_info_basic *entry = &entries[i];
+        char child[AFP_MAX_PATH];
+
+        if (strcmp(entry->name, ".") == 0 || strcmp(entry->name, "..") == 0) {
+            continue;
+        }
+
+        int length = snprintf(child, sizeof(child), "%s/%s",
+                              server_path, entry->name);
+
+        if (length < 0 || (size_t)length >= sizeof(child)) {
+            printf("Path too long: %s/%s\n", server_path, entry->name);
+            ret = -1;
+            continue;
+        }
+
+        if (S_ISLNK(entry->unixprivs.permissions)) {
+            printf("Symlinks are not supported: %s\n", child);
+            ret = -1;
+        } else if (S_ISDIR(entry->unixprivs.permissions)
+                   && chmod_remote_tree(child, mode) < 0) {
+            ret = -1;
+        } else if (!S_ISDIR(entry->unixprivs.permissions)
+                   && afp_sl_chmod(&vol_id, child, NULL, mode)
+                   != AFP_SERVER_RESULT_OKAY) {
+            printf("Could not chmod %s\n", child);
+            ret = -1;
+        }
+    }
+
+    free(entries);
+
+    if (afp_sl_chmod(&vol_id, server_path, NULL, mode)
+            != AFP_SERVER_RESULT_OKAY) {
+        printf("Could not chmod %s\n", server_path);
+        ret = -1;
+    }
+
+    return ret;
+}
+
 int com_chmod(char * arg)
 {
     char mode_str[AFP_MAX_PATH];
@@ -1516,6 +1594,7 @@ int com_chmod(char * arg)
     mode_t mode;
     char *endptr;
     int ret;
+    int recursive = command_recursive_option(&arg);
 
     if (!vol_id) {
         printf("You're not attached to a volume\n");
@@ -1523,7 +1602,7 @@ int com_chmod(char * arg)
     }
 
     if (escape_paths(mode_str, filename, arg)) {
-        printf("expecting format: chmod <mode> <filename>\n");
+        printf("expecting format: chmod [-r] <mode> <filename>\n");
         return -1;
     }
 
@@ -1537,6 +1616,20 @@ int com_chmod(char * arg)
     if (get_server_path(filename, server_fullname) < 0) {
         printf("Invalid path\n");
         return -1;
+    }
+
+    if (recursive) {
+        struct stat st;
+
+        if (afp_sl_stat(&vol_id, server_fullname, NULL, &st)
+                != AFP_SERVER_RESULT_OKAY) {
+            printf("File not found: %s\n", filename);
+            return -1;
+        }
+
+        if (S_ISDIR(st.st_mode)) {
+            return chmod_remote_tree(server_fullname, mode);
+        }
     }
 
     ret = afp_sl_chmod(&vol_id, server_fullname, NULL, mode);
@@ -1834,7 +1927,7 @@ int com_put(char *arg)
     char server_fullname[AFP_MAX_PATH];
     char *basename_ptr;
     struct stat st;
-    int recursive = recursive_mode;
+    int recursive = command_recursive_option(&arg);
     unsigned long long bytes_transferred = 0;
     int ret = -1;
     metadata_warning_emitted = 0;
@@ -1842,15 +1935,6 @@ int com_put(char *arg)
     if (!vol_id) {
         printf("You're not attached to a volume\n");
         goto error;
-    }
-
-    if ((arg[0] == '-') && (arg[1] == 'r') && (arg[2] == ' ')) {
-        recursive = 1;
-        arg += 3;
-
-        while (arg && isspace((unsigned char)arg[0])) {
-            arg++;
-        }
     }
 
     if (escape_paths(local_filename, NULL, arg)) {
@@ -1876,7 +1960,7 @@ int com_put(char *arg)
             ret = upload_directory(local_filename, server_fullname, &bytes_transferred);
             goto out;
         } else {
-            printf("%s is a directory (start afpcmd with -r to upload recursively)\n",
+            printf("%s is a directory (use put -r to upload recursively)\n",
                    local_filename);
             goto error;
         }
@@ -2165,22 +2249,13 @@ int com_get(char *arg)
     char filename[AFP_MAX_PATH];
     char server_path[AFP_MAX_PATH];
     struct stat st;
-    int recursive = recursive_mode;
+    int recursive = command_recursive_option(&arg);
     int ret = -1;
     metadata_warning_emitted = 0;
 
     if (!vol_id) {
         printf("You're not attached to a volume\n");
         goto error;
-    }
-
-    if ((arg[0] == '-') && (arg[1] == 'r') && (arg[2] == ' ')) {
-        recursive = 1;
-        arg += 3;
-
-        while (arg && isspace((unsigned char)arg[0])) {
-            arg++;
-        }
     }
 
     if (escape_paths(filename, NULL, arg)) {
@@ -2201,7 +2276,7 @@ int com_get(char *arg)
             ret = download_directory(server_path, local_name, &amount_written);
             goto out;
         } else {
-            printf("%s is a directory (start afpcmd with -r to download recursively)\n",
+            printf("%s is a directory (use get -r to download recursively)\n",
                    filename);
             goto error;
         }
@@ -2756,6 +2831,170 @@ usage:
     return -1;
 }
 
+static int quote_copy_argument(char *output, size_t output_size,
+                               const char *path)
+{
+    size_t used = 0;
+
+    if (output_size < 3) {
+        return -1;
+    }
+
+    output[used++] = '"';
+
+    for (const char *p = path; *p; p++) {
+        if ((*p == '"' || *p == '\\') && used + 1 >= output_size) {
+            return -1;
+        }
+
+        if (*p == '"' || *p == '\\') {
+            output[used++] = '\\';
+        }
+
+        if (used + 1 >= output_size) {
+            return -1;
+        }
+
+        output[used++] = *p;
+    }
+
+    if (used + 2 > output_size) {
+        return -1;
+    }
+
+    output[used++] = '"';
+    output[used] = '\0';
+    return 0;
+}
+
+static int copy_remote_tree(const char *source, const char *target,
+                            const struct stat *source_stat)
+{
+    struct afp_file_info_basic *entries = NULL;
+    unsigned int count = 0;
+    int ret = 0;
+    int mkdir_ret = afp_sl_mkdir(&vol_id, target, NULL,
+                                 source_stat->st_mode & 0777);
+
+    if (mkdir_ret != AFP_SERVER_RESULT_OKAY
+            && mkdir_ret != AFP_SERVER_RESULT_EXIST) {
+        printf("Could not create directory %s (error: %d)\n", target, mkdir_ret);
+        return -1;
+    }
+
+    if (mkdir_ret == AFP_SERVER_RESULT_EXIST) {
+        struct stat target_stat;
+        int stat_ret = afp_sl_stat(&vol_id, target, NULL, &target_stat);
+
+        if (stat_ret != AFP_SERVER_RESULT_OKAY) {
+            printf("Could not stat existing copy target %s (error: %d)\n",
+                   target, stat_ret);
+            return -1;
+        }
+
+        if (!S_ISDIR(target_stat.st_mode)) {
+            printf("Copy target exists and is not a directory: %s\n", target);
+            return -1;
+        }
+    }
+
+    if (remote_readdir_all(source, &entries, &count) != 0) {
+        printf("Could not read directory %s\n", source);
+        return -1;
+    }
+
+    for (unsigned int i = 0; i < count; i++) {
+        struct afp_file_info_basic *entry = &entries[i];
+        char child_source[AFP_MAX_PATH];
+        char child_target[AFP_MAX_PATH];
+
+        if (strcmp(entry->name, ".") == 0 || strcmp(entry->name, "..") == 0) {
+            continue;
+        }
+
+        int source_len = snprintf(child_source, sizeof(child_source), "%s/%s",
+                                  source, entry->name);
+        int target_len = snprintf(child_target, sizeof(child_target), "%s/%s",
+                                  target, entry->name);
+
+        if (source_len < 0 || (size_t)source_len >= sizeof(child_source)
+                || target_len < 0 || (size_t)target_len >= sizeof(child_target)) {
+            printf("Path too long while copying %s\n", entry->name);
+            ret = -1;
+            continue;
+        }
+
+        if (S_ISLNK(entry->unixprivs.permissions)) {
+            printf("Symlinks are not supported: %s\n", child_source);
+            ret = -1;
+        } else if (S_ISDIR(entry->unixprivs.permissions)) {
+            struct stat child_stat;
+
+            if (afp_sl_stat(&vol_id, child_source, NULL, &child_stat) != 0
+                    || copy_remote_tree(child_source, child_target,
+                                        &child_stat) < 0) {
+                ret = -1;
+            }
+        } else {
+            char quoted_source[2 * AFP_MAX_PATH + 3];
+            char quoted_target[2 * AFP_MAX_PATH + 3];
+            char arguments[4 * AFP_MAX_PATH + 7];
+
+            if (quote_copy_argument(quoted_source, sizeof(quoted_source),
+                                    child_source) < 0
+                    || quote_copy_argument(quoted_target, sizeof(quoted_target),
+                                           child_target) < 0) {
+                ret = -1;
+                continue;
+            }
+
+            int argument_len = snprintf(arguments, sizeof(arguments), "%s %s",
+                                        quoted_source, quoted_target);
+
+            if (argument_len < 0
+                    || (size_t)argument_len >= sizeof(arguments)) {
+                printf("Could not format copy arguments for %s\n", child_source);
+                ret = -1;
+                continue;
+            }
+
+            if (com_copy(arguments) < 0) {
+                ret = -1;
+            }
+        }
+    }
+
+    free(entries);
+
+    if (copy_remote_metadata(source, target, source_stat) < 0) {
+        printf("Could not preserve copied metadata for %s\n", source);
+        ret = -1;
+    }
+
+    return ret;
+}
+
+static int path_is_same_or_descendant(const char *parent, const char *candidate)
+{
+    size_t parent_len = strnlen(parent, AFP_MAX_PATH);
+
+    if (parent_len == AFP_MAX_PATH) {
+        return 0;
+    }
+
+    /* Ignore trailing separators when finding the component boundary. */
+    while (parent_len > 1 && parent[parent_len - 1] == '/') {
+        parent_len--;
+    }
+
+    if (parent_len == 1 && parent[0] == '/') {
+        return candidate[0] == '/';
+    }
+
+    return strncmp(parent, candidate, parent_len) == 0
+           && (candidate[parent_len] == '\0' || candidate[parent_len] == '/');
+}
+
 int com_copy(char * arg)
 {
     char source_path[AFP_MAX_PATH];
@@ -2769,6 +3008,7 @@ int com_copy(char * arg)
     unsigned long long offset = 0;
     unsigned int received, written;
     unsigned int eof = 0;
+    int recursive = command_recursive_option(&arg);
 #define COPY_BUFSIZE 102400
     char buf[COPY_BUFSIZE];
     metadata_warning_emitted = 0;
@@ -2779,7 +3019,7 @@ int com_copy(char * arg)
     }
 
     if (escape_paths(source_path, target_path, arg)) {
-        printf("expecting format: cp <source> <target>\n");
+        printf("expecting format: cp [-r] <source> <target>\n");
         goto out;
     }
 
@@ -2799,7 +3039,34 @@ int com_copy(char * arg)
     }
 
     if (S_ISDIR(source_stat.st_mode)) {
-        printf("Source is a directory (recursive copy not supported)\n");
+        if (!recursive) {
+            printf("Source is a directory (use cp -r to copy recursively)\n");
+            goto out;
+        }
+
+        int target_stat_ret = afp_sl_stat(&vol_id, server_target, NULL,
+                                          &target_stat);
+
+        if (target_stat_ret == AFP_SERVER_RESULT_OKAY) {
+            if (!S_ISDIR(target_stat.st_mode)) {
+                printf("Target exists and is not a directory: %s\n", target_path);
+                goto out;
+            }
+
+            const char *base = basename(source_path);
+
+            if (append_basename_to_path(server_target, base, AFP_MAX_PATH) < 0) {
+                printf("Target path too long\n");
+                goto out;
+            }
+        }
+
+        if (path_is_same_or_descendant(server_source, server_target)) {
+            printf("Cannot copy a directory into itself\n");
+            goto out;
+        }
+
+        ret = copy_remote_tree(server_source, server_target, &source_stat);
         goto out;
     }
 
@@ -2969,20 +3236,11 @@ int com_delete(char *arg)
     char server_fullname[AFP_MAX_PATH];
     struct stat st;
     int ret;
-    int recursive = recursive_mode;
+    int recursive = command_recursive_option(&arg);
 
     if (!vol_id) {
         printf("You're not attached to a volume\n");
         return -1;
-    }
-
-    if ((arg[0] == '-') && (arg[1] == 'r') && (arg[2] == ' ')) {
-        recursive = 1;
-        arg += 3;
-
-        while (arg && isspace((unsigned char)arg[0])) {
-            arg++;
-        }
     }
 
     if (escape_paths(filename, NULL, arg)) {
@@ -3010,7 +3268,7 @@ int com_delete(char *arg)
 
             return ret;
         } else {
-            printf("%s is a directory (start afpcmd with -r to delete recursively)\n",
+            printf("%s is a directory (use rm -r to delete recursively)\n",
                    filename);
             return -1;
         }
@@ -3774,9 +4032,8 @@ void cmdline_afp_setup_client(void)
 }
 
 
-int cmdline_afp_setup(int recursive, int batch_mode, char * url_string)
+int cmdline_afp_setup(int batch_mode, char * url_string)
 {
-    recursive_mode = recursive;
     snprintf(curdir, AFP_MAX_PATH, "%s", DEFAULT_DIRECTORY);
     memset(connect_servername, 0, sizeof(connect_servername));
 

--- a/cmdline/cmdline_afp.h
+++ b/cmdline/cmdline_afp.h
@@ -28,7 +28,7 @@ int com_disconnect(char *unused);
 int com_exit(char *unused);
 
 void cmdline_afp_exit(void);
-int cmdline_afp_setup(int recursive, int batch_mode, char * url_string);
+int cmdline_afp_setup(int batch_mode, char * url_string);
 void cmdline_afp_setup_client(void);
 void cmdline_set_log_level(int loglevel);
 void cmdline_set_verbose(int verbose);

--- a/cmdline/cmdline_main.c
+++ b/cmdline/cmdline_main.c
@@ -225,13 +225,13 @@ static int com_help(char *arg);
 COMMAND commands[] = {
     { "cat", com_view, "View the contents of FILE", 1 },
     { "cd", com_cd, "Change to directory DIR", 1 },
-    { "chmod", com_chmod, "Change mode to MODE on FILE", 1 },
-    { "cp", com_copy, "Copy FILE to NEWFILE", 1 },
+    { "chmod", com_chmod, "Change mode to MODE on FILE (-r for directories)", 1 },
+    { "cp", com_copy, "Copy FILE to NEWFILE (-r for directories)", 1 },
     { "disconnect", com_close, "Close server connection and shut down afpcmd", 0 },
     { "df", com_statvfs, "Get volume space information", 1 },
     { "exit", com_exit, "Detach from the current volume", 0 },
     { "finderinfo", com_finderinfo, "Get, set, or remove FinderInfo", 1 },
-    { "get", com_get, "Retrieve the file FILE and store them locally", 1 },
+    { "get", com_get, "Retrieve FILE (-r for directories)", 1 },
     { "help", com_help, "Display this text", 0 },
     { "lcd", com_lcd, "Change local directory to DIR", 1 },
     { "lpwd", com_lpwd, "Print the current local working directory", 0 },
@@ -239,10 +239,10 @@ COMMAND commands[] = {
     { "mkdir", com_mkdir, "Make directory DIRECTORY", 1 },
     { "mv", com_rename, "Rename FILE to NEWNAME", 1 },
     { "passwd", com_pass, "Change the password of the current user", 1 },
-    { "put", com_put, "Send FILE to the server", 1 },
+    { "put", com_put, "Send FILE to the server (-r for directories)", 1 },
     { "pwd", com_pwd, "Print the current working directory on the server", 0 },
     { "quit", com_quit, "Shut down afpcmd (leaves server connections intact)", 0 },
-    { "rm", com_delete, "Delete FILE", 1 },
+    { "rm", com_delete, "Delete FILE (-r for directories)", 1 },
     { "rmdir", com_rmdir, "Remove directory DIRECTORY", 1 },
     { "resourcefork", com_resourcefork, "Get, set, or remove a resource fork", 1 },
     { "status", com_status, "Get some server status", 1 },
@@ -453,11 +453,11 @@ static void usage(void)
 {
     printf(
         "Netatalk Client %s - Apple Filing Protocol CLI client application\n"
-        "afpcmd [-h] [-r] [-V] [-v loglevel] [-M mode] <afp url>\n"
+        "afpcmd [-h] [-V] [-v loglevel] [-M mode] <afp url>\n"
         "Options:\n"
         "\t-h:          show this help message and exit\n"
         "\t-M mode:     preserve metadata using auto, sys, macos, netatalk, or none\n"
-        "\t-r:          set the recursive flag\n"
+        "\t-r:          recursively transfer directories in batch mode\n"
         "\t-V:          verbose mode (show detailed transfer messages)\n"
         "\t-v loglevel: set log verbosity (debug, info, notice, warning, error)\n"
         "\turl:         an AFP url, in the form of:\n"
@@ -587,10 +587,17 @@ int main(int argc, char *argv[])
         exit(1);
     }
 
+    if (recursive && !batch_mode) {
+        printf("The invocation-level -r option is only valid for batch transfers; "
+               "use -r after an interactive command instead.\n");
+        usage();
+        exit(1);
+    }
+
     tcgetattr(STDIN_FILENO, &save_termios);
     initialize_readline();
 
-    if (cmdline_afp_setup(recursive, batch_mode, url) != 0) {
+    if (cmdline_afp_setup(batch_mode, url) != 0) {
         cmdline_afp_exit();
         tty_reset(STDIN_FILENO);
         exit(1);

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -76,6 +76,9 @@ Examples of available commands:
 
 - get _filename_: retrieves the filename
 - put _filename_: send the file
+- get -r _directory_ / put -r _directory_: recursively transfer a directory
+- cp -r _source_ _target_: recursively copy a remote directory
+- chmod -r _mode_ _directory_ / rm -r _directory_: recursively change or remove a tree
 - ls: show directory listings
 - xattr / finderinfo / resourcefork: inspect and modify AFP metadata
 

--- a/docs/manpages/afpcmd.1
+++ b/docs/manpages/afpcmd.1
@@ -6,7 +6,7 @@
 .Nd Transfer files over the network using the Apple Filing Protocol (AFP)
 .Sh SYNOPSIS
 .Nm
-.Op Fl rV
+.Op Fl V
 .Op Fl v Ar loglevel
 .Op Fl M Ar mode
 .Ar afp_url
@@ -47,7 +47,10 @@ and commands. If not already running, afpcmd will attempt to start it.
 .It Fl h , Fl -help
 Shows the help message.
 .It Fl r , Fl -recursive
-Sets the recursive flag.
+Recursively transfers directories in batch mode.
+This invocation-level option is not accepted in interactive mode; use
+.Fl r
+after an interactive command name instead.
 .It Fl V , Fl -verbose
 Enables verbose mode for file transfers.
 When enabled, displays detailed messages during upload and download operations,
@@ -131,12 +134,16 @@ completion is enabled.
 Show files in current directory
 .It Cm cd
 Change directories on the server
-.It Cm get Ar filename
-Retrieve file (or directory, if afpcmd is launched with the
--r flag)
-.It Cm put Ar filename
-Upload file (or directory, if afpcmd is launched with the
--r flag)
+.It Cm get Oo Fl r Oc Ar filename
+Retrieve a file.
+With
+.Fl r ,
+recursively retrieve a directory.
+.It Cm put Oo Fl r Oc Ar filename
+Upload a file.
+With
+.Fl r ,
+recursively upload a directory.
 .It Cm exit
 Detach from current volume
 .It Cm quit
@@ -160,20 +167,29 @@ Remove directory
 Rename
 .Ar old_file
 to
-.Ar new_file
-.It Cm cp Ar source_file Ar dest_file
-Copy
-.Ar source_file
+.Ar new_file .
+.It Cm cp Oo Fl r Oc Ar source Ar destination
+Copy a file from
+.Ar source
 to
-.Ar dest_file
+.Ar destination .
+With
+.Fl r ,
+recursively copy a directory.
 .It Cm touch Ar filename
 Create a blank file or update time stamp on existing file
 .It Cm cat Ar filename
 Show the contents of file
-.It Cm chmod Ar mode Ar file
-Change the mode of a file on the server
-.It Cm rm Ar file
-Remove file from the server
+.It Cm chmod Oo Fl r Oc Ar mode Ar file
+Change the mode of a file on the server.
+With
+.Fl r ,
+recursively change the mode of a directory tree.
+.It Cm rm Oo Fl r Oc Ar file
+Remove a file from the server.
+With
+.Fl r ,
+recursively remove a directory tree.
 .El
 .Ss Metadata commands
 .Bl -tag -width Ds

--- a/test/test_afpcmd_interactive.t
+++ b/test/test_afpcmd_interactive.t
@@ -178,6 +178,41 @@ sub afpcmd_pipe {
 }
 
 # -----------------------------------------------------------------------
+# test_command_recursive_flag: -r is accepted after interactive commands
+# -----------------------------------------------------------------------
+{
+    my $out = afpcmd_pipe($AFP_URL,
+        'mkdir rflag-src',
+        'mkdir rflag-src/subdir',
+        'touch rflag-src/subdir/file.txt',
+        'chmod -r 755 rflag-src',
+        'cp -r rflag-src/ rflag-src/subdir/copy',
+        'mkdir rflag-collision',
+        'mkdir rflag-collision/rflag-src',
+        'touch rflag-collision/rflag-src/subdir',
+        'cp -r rflag-src rflag-collision',
+        'cp -r rflag-src rflag-copy',
+        'ls rflag-copy/subdir',
+        'mv rflag-copy rflag-moved',
+        'rm -r rflag-src',
+        'rm -r rflag-collision',
+        'rm -r rflag-moved',
+        'quit');
+    unlike($out, qr/expecting format:/,
+        'test_command_recursive_flag: command-local -r parses');
+    like($out, qr/Cannot copy a directory into itself/,
+        'test_command_recursive_flag: trailing slash self-copy is rejected');
+    like($out, qr/Copy target exists and is not a directory:/,
+        'test_command_recursive_flag: directory-to-file collision is rejected');
+    like($out, qr/file\.txt/,
+        'test_command_recursive_flag: cp recursively copied nested file');
+    like($out, qr/Deleted directory: rflag-src/,
+        'test_command_recursive_flag: rm recursively removed source');
+    like($out, qr/Deleted directory: rflag-moved/,
+        'test_command_recursive_flag: moved destination removed recursively');
+}
+
+# -----------------------------------------------------------------------
 # test_get_put: put a local file, verify with cat, get it back, check content
 # -----------------------------------------------------------------------
 {


### PR DESCRIPTION
Accept -r after interactive cp, chmod, get, put, and rm commands.

Add recursive remote copy and chmod implementations, and keep invocation-level recursion scoped to batch transfers.

Update command help, documentation, and interactive client test coverage accordingly.