### PR TITLE
full-featured logging interface over IPC for the Stateless library

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,11 @@ The names of tools and libraries will not be changed to signal continuity and co
 - Harden and bugfix libafpclient UAM handling code
 - We now detect 2000s era Mac OS X servers, Time Capsules, and Windows (SFM, PCMacLan) servers
 
+### Stateless Client Improvements
+
+- Allow library consumers to register a persistent logging callback with context and syslog severity. Local libafpsl
+  diagnostics and structured logs returned by every afpsld command use the same callback.
+
 ## afpfs-ng 0.9.4 (February 28, 2026)
 
 ### New Test Suite

--- a/cmdline/cmdline_afp.c
+++ b/cmdline/cmdline_afp.c
@@ -3717,8 +3717,14 @@ static void cmdline_log_for_client(__attribute__((unused)) void * priv,
         return; /* Filter out less-verbose messages */
     }
 
-    /* Log to syslog - priv is always NULL for cmdline */
+    fprintf(stderr, "%s\n", message);
     syslog(loglevel, "%s", message);
+}
+
+static void cmdline_stateless_log(__attribute__((unused)) void *user_data,
+                                  int loglevel, const char *message)
+{
+    cmdline_log_for_client(NULL, AFPFSD, loglevel, message);
 }
 
 static struct libafpclient afpclient = {
@@ -4029,6 +4035,7 @@ void cmdline_afp_setup_client(void)
 {
     openlog("afpcmd", LOG_PID | LOG_CONS, LOG_USER);
     libafpclient_register(&afpclient);
+    afp_sl_set_log_callback(cmdline_stateless_log, NULL);
 }
 
 

--- a/daemon/commands.c
+++ b/daemon/commands.c
@@ -7,34 +7,33 @@
  *  This file contains command handlers for the afpsld stateless daemon.
  */
 
-#include <stdio.h>
-#include <string.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <utime.h>
-#include <stdlib.h>
-#include <getopt.h>
-#include <sys/un.h>
-#include <unistd.h>
-#include <time.h>
-#include <stdarg.h>
 #include <getopt.h>
 #include <signal.h>
+#include <stdarg.h>
 #include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/un.h>
+#include <time.h>
+#include <unistd.h>
+#include <utime.h>
 
 #include "afp.h"
-#include "dsi.h"
 #include "afp_server.h"
-#include "utils.h"
-#include "daemon.h"
-#include "uams_def.h"
 #include "codepage.h"
-#include "libafpclient.h"
-#include "midlevel.h"
-#include "map_def.h"
-#include "lib/users.h"
-#include "daemon_client.h"
 #include "commands.h"
+#include "daemon.h"
+#include "daemon_client.h"
+#include "dsi.h"
+#include "lib/users.h"
+#include "libafpclient.h"
+#include "map_def.h"
+#include "midlevel.h"
+#include "uams_def.h"
+#include "utils.h"
 
 /* File handle table for mapping 32-bit IDs to 64-bit pointers */
 #define MAX_OPEN_FILES 1024
@@ -42,6 +41,20 @@ static struct afp_file_info *file_handle_table[MAX_OPEN_FILES];
 static pthread_mutex_t file_handle_mutex = PTHREAD_MUTEX_INITIALIZER;
 /* Serialize all AFP server operations to prevent concurrent DSI calls */
 static pthread_mutex_t server_op_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+static void finish_response(struct daemon_client *c, int send_result,
+                            int close_requested)
+{
+    if (send_result < 0) {
+        log_for_client(NULL, AFPFSD, LOG_ERR,
+                       "Failed to send response to stateless client");
+        close_client_connection(c);
+    } else if (close_requested) {
+        close_client_connection(c);
+    } else {
+        continue_client_connection(c);
+    }
+}
 
 static int register_file_handle(struct afp_file_info *fp)
 {
@@ -90,7 +103,11 @@ static int volopen(struct daemon_client * c, struct afp_volume * volume)
     unsigned int l = 0;
     memset(mesg, 0, 1024);
     int rc = afp_connect_volume(volume, volume->server, mesg, &l, 1024);
-    log_for_client((void *) c, AFPFSD, LOG_ERR, mesg);
+
+    if (mesg[0] != '\0') {
+        log_for_client((void *) c, AFPFSD, LOG_ERR, "%s", mesg);
+    }
+
     return rc;
 }
 
@@ -116,7 +133,8 @@ static unsigned char process_status(struct daemon_client * c)
     output_buffer = malloc(MAX_CLIENT_RESPONSE);
 
     if (!output_buffer) {
-        log_for_client((void *) c, AFPFSD, LOG_ERR, "Out of memory in process_status");
+        log_for_client((void *) c, AFPFSD, LOG_ERR,
+                       "Out of memory in process_status");
         return AFP_SERVER_RESULT_ERROR;
     }
 
@@ -171,16 +189,10 @@ static unsigned char process_status(struct daemon_client * c)
     /* Copy text after the header */
     memcpy((char*)response + sizeof(struct afp_server_status_response),
            output_buffer, output_len + 1);
-    send_command(c, response_len, (char *)response);
+    finish_response(c, send_command(c, response_len, (char *)response),
+                    req->header.close);
     free(output_buffer);
     free(response);
-
-    if (req->header.close) {
-        close_client_connection(c);
-    } else {
-        continue_client_connection(c);
-    }
-
     return 0;
 }
 
@@ -209,18 +221,14 @@ static unsigned char process_detach(struct daemon_client * c)
 
     afp_detach_volume(v);
     response.header.result = AFP_SERVER_RESULT_OKAY;
-    snprintf(response.detach_message, 1023,
-             "Detached volume %s.\n", v->volume_name);
+    snprintf(response.detach_message, 1023, "Detached volume %s.\n",
+             v->volume_name);
     goto done;
 done:
     response.header.len = sizeof(struct afp_server_detach_response);
-    send_command(c, response.header.len, (char *) &response);
-
-    if (req->header.close) {
-        close_client_connection(c);
-    } else {
-        continue_client_connection(c);
-    }
+    finish_response(c,
+                    send_command(c, response.header.len, (char *) &response),
+                    req->header.close);
 
     if (v) {
         afp_server_release(v->server);
@@ -231,8 +239,7 @@ done:
 
 static unsigned char process_ping(struct daemon_client * c)
 {
-    log_for_client((void *)c, AFPFSD, LOG_INFO,
-                   "Ping!");
+    log_for_client((void *) c, AFPFSD, LOG_INFO, "Ping!");
     return AFP_SERVER_RESULT_OKAY;
 }
 
@@ -246,8 +253,7 @@ static unsigned char process_exit(struct daemon_client * c)
                    "Exit requested but other clients active, staying up");
     response.result = AFP_SERVER_RESULT_OKAY;
     response.len = sizeof(response);
-    send_command(c, sizeof(response), (char *)&response);
-    close_client_connection(c);
+    finish_response(c, send_command(c, sizeof(response), (char *)&response), 1);
 
     if (last_client) {
         trigger_exit();
@@ -285,8 +291,7 @@ static unsigned char process_changepw(struct daemon_client * c)
         goto done;
     }
 
-    ret = ml_passwd(server, req->url.username,
-                    req->oldpasswd, req->newpasswd);
+    ret = ml_passwd(server, req->url.username, req->oldpasswd, req->newpasswd);
 
     if (ret == 0) {
         response.header.result = AFP_SERVER_RESULT_OKAY;
@@ -301,13 +306,8 @@ static unsigned char process_changepw(struct daemon_client * c)
 
 done:
     response.header.len = sizeof(struct afp_server_changepw_response);
-    send_command(c, response.header.len, (char *)&response);
-
-    if (req->header.close) {
-        close_client_connection(c);
-    } else {
-        continue_client_connection(c);
-    }
+    finish_response(c, send_command(c, response.header.len, (char *)&response),
+                    req->header.close);
 
     if (server) {
         afp_server_release(server);
@@ -346,13 +346,8 @@ static unsigned char process_disconnect(struct daemon_client * c)
     response.header.result = AFP_SERVER_RESULT_OKAY;
 done:
     response.header.len = sizeof(struct afp_server_disconnect_response);
-    send_command(c, response.header.len, (char *)&response);
-
-    if (req->header.close) {
-        close_client_connection(c);
-    } else {
-        continue_client_connection(c);
-    }
+    finish_response(c, send_command(c, response.header.len, (char *)&response),
+                    req->header.close);
 
     /* Release our held reference (afp_server_remove released the list ref) */
     if (server) {
@@ -417,13 +412,9 @@ static unsigned char process_getvolid(struct daemon_client * c)
 done:
     response.header.result = ret;
     response.header.len = sizeof(struct afp_server_getvolid_response);
-    send_command(c, response.header.len, (char *) &response);
-
-    if (req->header.close) {
-        close_client_connection(c);
-    } else {
-        continue_client_connection(c);
-    }
+    finish_response(c,
+                    send_command(c, response.header.len, (char *) &response),
+                    req->header.close);
 
     if (s) {
         afp_server_release(s);
@@ -469,8 +460,8 @@ static unsigned char process_serverinfo(struct daemon_client * c)
         /* We're already connected */
         memcpy(tmpserver->basic.server_name_printable,
                tmpserver->server_name_printable, AFP_SERVER_NAME_UTF8_LEN);
-        memcpy(&response.server_basic,
-               &tmpserver->basic, sizeof(struct afp_server_basic));
+        memcpy(&response.server_basic, &tmpserver->basic,
+               sizeof(struct afp_server_basic));
     } else {
         struct addrinfo *address;
 
@@ -487,8 +478,8 @@ static unsigned char process_serverinfo(struct daemon_client * c)
             goto error;
         }
 
-        memcpy(&response.server_basic,
-               &tmpserver->basic, sizeof(struct afp_server_basic));
+        memcpy(&response.server_basic, &tmpserver->basic,
+               sizeof(struct afp_server_basic));
         afp_server_remove(tmpserver);
         tmpserver = NULL;  /* Already freed by remove, don't release again */
     }
@@ -499,13 +490,9 @@ error:
     response.header.result = AFP_SERVER_RESULT_ERROR;
 done:
     response.header.len = sizeof(struct afp_server_serverinfo_response);
-    send_command(c, response.header.len, (char *) &response);
-
-    if (req->header.close) {
-        close_client_connection(c);
-    } else {
-        continue_client_connection(c);
-    }
+    finish_response(c,
+                    send_command(c, response.header.len, (char *) &response),
+                    req->header.close);
 
     if (tmpserver) {
         afp_server_release(tmpserver);
@@ -527,8 +514,7 @@ static unsigned char process_getvols(struct daemon_client * c)
     struct afp_volume_summary * sum;
 
     if (((size_t)(c->completed_packet_size) < sizeof(struct
-            afp_server_getvols_request)) ||
-            (request->start < 0)) {
+            afp_server_getvols_request)) || (request->start < 0)) {
         result = AFP_SERVER_RESULT_ERROR;
         goto error;
     }
@@ -591,8 +577,8 @@ static unsigned char process_getvols(struct daemon_client * c)
     for (int i = request->start; i < (int)(request->start + numvols); i++) {
         volume = &server->volumes[i];
         sum = (void *) p;
-        memcpy(sum->volume_name_printable,
-               volume->volume_name_printable, AFP_VOLUME_NAME_UTF8_LEN);
+        memcpy(sum->volume_name_printable, volume->volume_name_printable,
+               AFP_VOLUME_NAME_UTF8_LEN);
         sum->flags = volume->flags;
         p = p + sizeof(struct afp_volume_summary);
     }
@@ -603,8 +589,7 @@ error:
     response = malloc(len);
 
     if (!response) {
-        log_for_client((void *) c, AFPFSD, LOG_ERR,
-                       "Out of memory in error path");
+        log_for_client((void *) c, AFPFSD, LOG_ERR, "Out of memory in error path");
 
         if (server) {
             afp_server_release(server);
@@ -616,14 +601,10 @@ error:
 done:
     response->header.len = len;
     response->header.result = result;
-    send_command(c, response->header.len, (char *)response);
+    finish_response(c,
+                    send_command(c, response->header.len, (char *)response),
+                    request->header.close);
     free(response);
-
-    if (request->header.close) {
-        close_client_connection(c);
-    } else {
-        continue_client_connection(c);
-    }
 
     if (server) {
         afp_server_release(server);
@@ -655,8 +636,8 @@ static unsigned char process_open(struct daemon_client * c)
         goto done;
     }
 
-    log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                   "Opening file '%s' mode=%d", request->path, request->mode);
+    log_for_client((void *) c, AFPFSD, LOG_DEBUG, "Opening file '%s' mode=%d",
+                   request->path, request->mode);
     ret = ml_open(v, request->path, request->mode, &fp);
 
     if (ret) {
@@ -668,9 +649,9 @@ static unsigned char process_open(struct daemon_client * c)
             result = AFP_SERVER_RESULT_ERROR;
         }
 
-        log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                       "process_open: Failed to open file %s: %d (%s)", request->path, ret,
-                       strerror(-ret));
+        log_for_client((void *) c, AFPFSD, LOG_DEBUG,
+                       "process_open: Failed to open file %s: %d (%s)",
+                       request->path, ret, strerror(-ret));
         goto done;
     }
 
@@ -684,18 +665,13 @@ static unsigned char process_open(struct daemon_client * c)
     }
 
     response.fileid = handle;
-    log_for_client(NULL, AFPFSD, LOG_DEBUG,
+    log_for_client((void *) c, AFPFSD, LOG_DEBUG,
                    "File opened successfully, handle=%d", handle);
 done:
     response.header.len = sizeof(struct afp_server_open_response);
     response.header.result = result;
-    send_command(c, response.header.len, (char*) &response);
-
-    if (request->header.close) {
-        close_client_connection(c);
-    } else {
-        continue_client_connection(c);
-    }
+    finish_response(c, send_command(c, response.header.len, (char *) &response),
+                    request->header.close);
 
     if (v) {
         afp_server_release(v->server);
@@ -721,8 +697,7 @@ static unsigned char process_read(struct daemon_client * c)
         response = malloc(len);
 
         if (!response) {
-            log_for_client((void *) c, AFPFSD, LOG_ERR,
-                           "Out of memory in read");
+            log_for_client((void *) c, AFPFSD, LOG_ERR, "Out of memory in read");
             return AFP_SERVER_RESULT_ERROR;
         }
 
@@ -734,8 +709,7 @@ static unsigned char process_read(struct daemon_client * c)
         response = malloc(len);
 
         if (!response) {
-            log_for_client((void *) c, AFPFSD, LOG_ERR,
-                           "Out of memory in read");
+            log_for_client((void *) c, AFPFSD, LOG_ERR, "Out of memory in read");
             return AFP_SERVER_RESULT_ERROR;
         }
 
@@ -780,14 +754,9 @@ done:
     response->header.len = sizeof(struct afp_server_read_response) + received;
     response->header.result = result;
     response->received = received;
-    send_command(c, response->header.len, (char*) response);
+    finish_response(c, send_command(c, response->header.len, (char *) response),
+                    request->header.close);
     free(response);
-
-    if (request->header.close) {
-        close_client_connection(c);
-    } else {
-        continue_client_connection(c);
-    }
 
     if (v) {
         afp_server_release(v->server);
@@ -821,19 +790,22 @@ static unsigned char process_write(struct daemon_client * c)
 
     if (!data) {
         log_for_client((void *) c, AFPFSD, LOG_ERR,
-                       "Out of memory allocating %u bytes for write", request->size);
+                       "Out of memory allocating %u bytes for write",
+                       request->size);
         result = AFP_SERVER_RESULT_ERROR;
         goto done;
     }
 
-    /* Read the data payload from client - it follows immediately after the request header */
+    /* Read the data payload from client - it follows immediately after
+     * the request header */
     int bytes_read = 0;
     int bytes_remaining = request->size;
-    log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                   "Writing %u bytes at offset %llu, fileid=%u",
-                   request->size, request->offset, request->fileid);
+    log_for_client((void *) c, AFPFSD, LOG_DEBUG,
+                   "Writing %u bytes at offset %llu, fileid=%u", request->size,
+                   request->offset, request->fileid);
 
-    /* Consume any data already read into the incoming buffer by process_command */
+    /* Consume any data already read into the incoming buffer
+     * by process_command */
     if (c->incoming_size > 0) {
         int to_copy = min(bytes_remaining, c->incoming_size);
         memcpy(data + bytes_read, c->incoming_string, to_copy);
@@ -885,16 +857,11 @@ done:
     response.header.len = sizeof(struct afp_server_write_response);
     response.header.result = result;
     response.written = written;
-    send_command(c, response.header.len, (char*) &response);
+    finish_response(c, send_command(c, response.header.len, (char *) &response),
+                    request->header.close);
 
     if (data) {
         free(data);
-    }
-
-    if (request->header.close) {
-        close_client_connection(c);
-    } else {
-        continue_client_connection(c);
     }
 
     if (v) {
@@ -926,37 +893,33 @@ static unsigned char process_creat(struct daemon_client * c)
         goto done;
     }
 
-    log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                   "Creating file '%s' mode=%04o", request->path, request->mode);
+    log_for_client((void *) c, AFPFSD, LOG_DEBUG, "Creating file '%s' mode=%04o",
+                   request->path, request->mode);
     ret = ml_creat(v, request->path, request->mode);
 
     if (ret < 0) {
         if (ret == -EEXIST) {
             result = AFP_SERVER_RESULT_EXIST;
-            log_for_client(NULL, AFPFSD, LOG_DEBUG,
+            log_for_client((void *) c, AFPFSD, LOG_DEBUG,
                            "process_creat: File %s exists (EEXIST)", request->path);
         } else if (ret == -EACCES) {
             result = AFP_SERVER_RESULT_ACCESS;
             log_for_client((void *) c, AFPFSD, LOG_ERR,
-                           "process_creat: Permission denied creating %s (EACCES)", request->path);
+                           "process_creat: Permission denied creating %s (EACCES)",
+                           request->path);
         } else {
             result = AFP_SERVER_RESULT_ERROR;
             log_for_client((void *) c, AFPFSD, LOG_ERR,
-                           "process_creat: Failed to create file %s: %d (%s)", request->path, ret,
-                           strerror(-ret));
+                           "process_creat: Failed to create file %s: %d (%s)",
+                           request->path, ret, strerror(-ret));
         }
     }
 
 done:
     response.header.len = sizeof(struct afp_server_creat_response);
     response.header.result = result;
-    send_command(c, response.header.len, (char*) &response);
-
-    if (request->header.close) {
-        close_client_connection(c);
-    } else {
-        continue_client_connection(c);
-    }
+    finish_response(c, send_command(c, response.header.len, (char *) &response),
+                    request->header.close);
 
     if (v) {
         afp_server_release(v->server);
@@ -999,19 +962,15 @@ static unsigned char process_chmod(struct daemon_client * c)
         }
 
         log_for_client((void *) c, AFPFSD, LOG_ERR,
-                       "Failed to chmod file %s: %d (%s)", request->path, ret, strerror(-ret));
+                       "Failed to chmod file %s: %d (%s)", request->path, ret,
+                       strerror(-ret));
     }
 
 done:
     response.header.len = sizeof(struct afp_server_chmod_response);
     response.header.result = result;
-    send_command(c, response.header.len, (char*) &response);
-
-    if (request->header.close) {
-        close_client_connection(c);
-    } else {
-        continue_client_connection(c);
-    }
+    finish_response(c, send_command(c, response.header.len, (char *) &response),
+                    request->header.close);
 
     if (v) {
         afp_server_release(v->server);
@@ -1055,13 +1014,8 @@ static unsigned char process_rename(struct daemon_client * c)
 done:
     response.header.len = sizeof(struct afp_server_rename_response);
     response.header.result = result;
-    send_command(c, response.header.len, (char*) &response);
-
-    if (request->header.close) {
-        close_client_connection(c);
-    } else {
-        continue_client_connection(c);
-    }
+    finish_response(c, send_command(c, response.header.len, (char *) &response),
+                    request->header.close);
 
     if (v) {
         afp_server_release(v->server);
@@ -1097,29 +1051,27 @@ static unsigned char process_unlink(struct daemon_client * c)
     if (ret < 0) {
         if (ret == -ENOENT) {
             result = AFP_SERVER_RESULT_ENOENT;
-            log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                           "process_unlink: File %s not found (ENOENT)", request->path);
+            log_for_client((void *) c, AFPFSD, LOG_DEBUG,
+                           "process_unlink: File %s not found (ENOENT)",
+                           request->path);
         } else if (ret == -EACCES || ret == -EPERM) {
             result = AFP_SERVER_RESULT_ACCESS;
             log_for_client((void *) c, AFPFSD, LOG_ERR,
-                           "process_unlink: Permission denied for %s (EACCES/EPERM)", request->path);
+                           "process_unlink: Permission denied for %s (EACCES/EPERM)",
+                           request->path);
         } else {
             result = AFP_SERVER_RESULT_ERROR;
             log_for_client((void *) c, AFPFSD, LOG_ERR,
-                           "Failed to unlink file %s: %d (%s)", request->path, ret, strerror(-ret));
+                           "Failed to unlink file %s: %d (%s)", request->path, ret,
+                           strerror(-ret));
         }
     }
 
 done:
     response.header.len = sizeof(struct afp_server_unlink_response);
     response.header.result = result;
-    send_command(c, response.header.len, (char*) &response);
-
-    if (request->header.close) {
-        close_client_connection(c);
-    } else {
-        continue_client_connection(c);
-    }
+    finish_response(c, send_command(c, response.header.len, (char *) &response),
+                    request->header.close);
 
     if (v) {
         afp_server_release(v->server);
@@ -1155,29 +1107,27 @@ static unsigned char process_truncate(struct daemon_client * c)
     if (ret < 0) {
         if (ret == -ENOENT) {
             result = AFP_SERVER_RESULT_ENOENT;
-            log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                           "process_truncate: File %s not found (ENOENT)", request->path);
+            log_for_client((void *) c, AFPFSD, LOG_DEBUG,
+                           "process_truncate: File %s not found (ENOENT)",
+                           request->path);
         } else if (ret == -EACCES) {
             result = AFP_SERVER_RESULT_ACCESS;
             log_for_client((void *) c, AFPFSD, LOG_ERR,
-                           "process_truncate: Permission denied for %s (EACCES)", request->path);
+                           "process_truncate: Permission denied for %s (EACCES)",
+                           request->path);
         } else {
             result = AFP_SERVER_RESULT_ERROR;
             log_for_client((void *) c, AFPFSD, LOG_ERR,
-                           "Failed to truncate file %s: %d (%s)", request->path, ret, strerror(-ret));
+                           "Failed to truncate file %s: %d (%s)", request->path, ret,
+                           strerror(-ret));
         }
     }
 
 done:
     response.header.len = sizeof(struct afp_server_truncate_response);
     response.header.result = result;
-    send_command(c, response.header.len, (char*) &response);
-
-    if (request->header.close) {
-        close_client_connection(c);
-    } else {
-        continue_client_connection(c);
-    }
+    finish_response(c, send_command(c, response.header.len, (char *) &response),
+                    request->header.close);
 
     if (v) {
         afp_server_release(v->server);
@@ -1219,20 +1169,15 @@ static unsigned char process_utime(struct daemon_client * c)
             result = AFP_SERVER_RESULT_ERROR;
         }
 
-        log_for_client((void *) c, AFPFSD, LOG_ERR,
-                       "Failed to utime file %s: %d", request->path, ret);
+        log_for_client((void *) c, AFPFSD, LOG_ERR, "Failed to utime file %s: %d",
+                       request->path, ret);
     }
 
 done:
     response.header.len = sizeof(struct afp_server_utime_response);
     response.header.result = result;
-    send_command(c, response.header.len, (char*) &response);
-
-    if (request->header.close) {
-        close_client_connection(c);
-    } else {
-        continue_client_connection(c);
-    }
+    finish_response(c, send_command(c, response.header.len, (char *) &response),
+                    request->header.close);
 
     if (v) {
         afp_server_release(v->server);
@@ -1268,33 +1213,33 @@ static unsigned char process_mkdir(struct daemon_client * c)
     if (ret < 0) {
         if (ret == -EEXIST) {
             result = AFP_SERVER_RESULT_EXIST;
-            log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                           "process_mkdir: Directory %s already exists (EEXIST)", request->path);
+            log_for_client((void *) c, AFPFSD, LOG_DEBUG,
+                           "process_mkdir: Directory %s already exists (EEXIST)",
+                           request->path);
         } else if (ret == -EACCES) {
             result = AFP_SERVER_RESULT_ACCESS;
             log_for_client((void *) c, AFPFSD, LOG_ERR,
-                           "process_mkdir: Permission denied creating %s (EACCES)", request->path);
+                           "process_mkdir: Permission denied creating %s (EACCES)",
+                           request->path);
         } else if (ret == -ENOENT) {
             result = AFP_SERVER_RESULT_ENOENT;
-            log_for_client((void *) c, AFPFSD, LOG_ERR,
-                           "process_mkdir: Parent directory not found for %s (ENOENT)", request->path);
+            log_for_client(
+                (void *) c, AFPFSD, LOG_ERR,
+                "process_mkdir: Parent directory not found for %s (ENOENT)",
+                request->path);
         } else {
             result = AFP_SERVER_RESULT_ERROR;
             log_for_client((void *) c, AFPFSD, LOG_ERR,
-                           "Failed to create directory %s: %d (%s)", request->path, ret, strerror(-ret));
+                           "Failed to create directory %s: %d (%s)", request->path,
+                           ret, strerror(-ret));
         }
     }
 
 done:
     response.header.len = sizeof(struct afp_server_mkdir_response);
     response.header.result = result;
-    send_command(c, response.header.len, (char*) &response);
-
-    if (request->header.close) {
-        close_client_connection(c);
-    } else {
-        continue_client_connection(c);
-    }
+    finish_response(c, send_command(c, response.header.len, (char *) &response),
+                    request->header.close);
 
     if (v) {
         afp_server_release(v->server);
@@ -1330,33 +1275,32 @@ static unsigned char process_rmdir(struct daemon_client * c)
     if (ret < 0) {
         if (ret == -ENOENT) {
             result = AFP_SERVER_RESULT_ENOENT;
-            log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                           "process_rmdir: Directory %s not found (ENOENT)", request->path);
+            log_for_client((void *) c, AFPFSD, LOG_DEBUG,
+                           "process_rmdir: Directory %s not found (ENOENT)",
+                           request->path);
         } else if (ret == -EACCES) {
             result = AFP_SERVER_RESULT_ACCESS;
             log_for_client((void *) c, AFPFSD, LOG_ERR,
-                           "process_rmdir: Permission denied for %s (EACCES)", request->path);
+                           "process_rmdir: Permission denied for %s (EACCES)",
+                           request->path);
         } else if (ret == -ENOTEMPTY) {
             result = AFP_SERVER_RESULT_ENOTEMPTY;
             log_for_client((void *) c, AFPFSD, LOG_ERR,
-                           "process_rmdir: Directory %s is not empty (ENOTEMPTY)", request->path);
+                           "process_rmdir: Directory %s is not empty (ENOTEMPTY)",
+                           request->path);
         } else {
             result = AFP_SERVER_RESULT_ERROR;
             log_for_client((void *) c, AFPFSD, LOG_ERR,
-                           "Failed to remove directory %s: %d (%s)", request->path, ret, strerror(-ret));
+                           "Failed to remove directory %s: %d (%s)", request->path,
+                           ret, strerror(-ret));
         }
     }
 
 done:
     response.header.len = sizeof(struct afp_server_rmdir_response);
     response.header.result = result;
-    send_command(c, response.header.len, (char*) &response);
-
-    if (request->header.close) {
-        close_client_connection(c);
-    } else {
-        continue_client_connection(c);
-    }
+    finish_response(c, send_command(c, response.header.len, (char *) &response),
+                    request->header.close);
 
     if (v) {
         afp_server_release(v->server);
@@ -1388,27 +1332,29 @@ static unsigned char process_statfs(struct daemon_client * c)
         goto done;
     }
 
-    log_for_client(NULL, AFPFSD, LOG_DEBUG,
+    log_for_client((void *) c, AFPFSD, LOG_DEBUG,
                    "Querying filesystem stats for path '%s'", request->path);
     ret = ml_statfs(v, request->path, &response.stat);
 
     if (ret < 0) {
         if (ret == -ENOENT) {
             result = AFP_SERVER_RESULT_ENOENT;
-            log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                           "process_statfs: Path %s not found (ENOENT)", request->path);
+            log_for_client((void *) c, AFPFSD, LOG_DEBUG,
+                           "process_statfs: Path %s not found (ENOENT)",
+                           request->path);
         } else if (ret == -EACCES) {
             result = AFP_SERVER_RESULT_ACCESS;
             log_for_client((void *) c, AFPFSD, LOG_ERR,
-                           "process_statfs: Permission denied for %s (EACCES)", request->path);
+                           "process_statfs: Permission denied for %s (EACCES)",
+                           request->path);
         } else {
             result = AFP_SERVER_RESULT_ERROR;
             log_for_client((void *) c, AFPFSD, LOG_ERR,
-                           "Failed to get filesystem stats for %s: %d (%s)", request->path, ret,
-                           strerror(-ret));
+                           "Failed to get filesystem stats for %s: %d (%s)",
+                           request->path, ret, strerror(-ret));
         }
     } else {
-        log_for_client(NULL, AFPFSD, LOG_DEBUG,
+        log_for_client((void *) c, AFPFSD, LOG_DEBUG,
                        "Filesystem: blocks=%llu free=%llu avail=%llu",
                        (unsigned long long)response.stat.f_blocks,
                        (unsigned long long)response.stat.f_bfree,
@@ -1418,13 +1364,8 @@ static unsigned char process_statfs(struct daemon_client * c)
 done:
     response.header.len = sizeof(struct afp_server_statfs_response);
     response.header.result = result;
-    send_command(c, response.header.len, (char*) &response);
-
-    if (request->header.close) {
-        close_client_connection(c);
-    } else {
-        continue_client_connection(c);
-    }
+    finish_response(c, send_command(c, response.header.len, (char *) &response),
+                    request->header.close);
 
     if (v) {
         afp_server_release(v->server);
@@ -1464,13 +1405,8 @@ static unsigned char process_close(struct daemon_client * c)
 done:
     response.header.len = sizeof(struct afp_server_close_response);
     response.header.result = ret;
-    send_command(c, response.header.len, (char*) &response);
-
-    if (request->header.close) {
-        close_client_connection(c);
-    } else {
-        continue_client_connection(c);
-    }
+    finish_response(c, send_command(c, response.header.len, (char *) &response),
+                    request->header.close);
 
     if (v) {
         afp_server_release(v->server);
@@ -1486,7 +1422,7 @@ static unsigned char process_stat(struct daemon_client * c)
     struct afp_volume * v = NULL;
     int ret;
     int result = AFP_SERVER_RESULT_OKAY;
-    log_for_client(NULL, AFPFSD, LOG_DEBUG,
+    log_for_client((void *) c, AFPFSD, LOG_DEBUG,
                    "Getting attributes for path '%s'", request->path);
 
     if ((size_t)(c->completed_packet_size) < sizeof(struct
@@ -1506,9 +1442,9 @@ static unsigned char process_stat(struct daemon_client * c)
     ret = ml_getattr(v, request->path, &response.stat);
 
     if (ret < 0) {
-        log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                       "ml_getattr error for '%s': %d (%s)",
-                       request->path, ret, strerror(-ret));
+        log_for_client((void *) c, AFPFSD, LOG_DEBUG,
+                       "ml_getattr error for '%s': %d (%s)", request->path, ret,
+                       strerror(-ret));
     }
 
     if (ret == -ENOENT) {
@@ -1522,13 +1458,8 @@ static unsigned char process_stat(struct daemon_client * c)
 done:
     response.header.len = sizeof(struct afp_server_stat_response);
     response.header.result = result;
-    send_command(c, response.header.len, (char*) &response);
-
-    if (request->header.close) {
-        close_client_connection(c);
-    } else {
-        continue_client_connection(c);
-    }
+    finish_response(c, send_command(c, response.header.len, (char *) &response),
+                    request->header.close);
 
     if (v) {
         afp_server_release(v->server);
@@ -1559,9 +1490,9 @@ static void send_metadata_response(struct daemon_client *c, int error,
         memcpy(response->data, data, data_size);
     }
 
-    send_command(c, response->header.len, (char *)response);
+    finish_response(c,
+                    send_command(c, response->header.len, (char *) response), 0);
     free(response);
-    continue_client_connection(c);
 }
 
 static unsigned char process_metadata(struct daemon_client *c)
@@ -1632,8 +1563,8 @@ static unsigned char process_metadata(struct daemon_client *c)
             xattr_data = data;
         }
 
-        ret = ml_getxattr(volume, request->path, request->name,
-                          xattr_data, request->size);
+        ret = ml_getxattr(volume, request->path, request->name, xattr_data,
+                          request->size);
     }
     break;
 
@@ -1644,8 +1575,7 @@ static unsigned char process_metadata(struct daemon_client *c)
             listxattr_data = data;
         }
 
-        ret = ml_listxattr(volume, request->path,
-                           listxattr_data, request->size);
+        ret = ml_listxattr(volume, request->path, listxattr_data, request->size);
     }
     break;
 
@@ -1656,8 +1586,7 @@ static unsigned char process_metadata(struct daemon_client *c)
             finderinfo_data = data;
         }
 
-        ret = ml_getfinderinfo(volume, request->path,
-                               finderinfo_data, request->size);
+        ret = ml_getfinderinfo(volume, request->path, finderinfo_data, request->size);
     }
     break;
 
@@ -1726,11 +1655,9 @@ static unsigned char process_metadata(struct daemon_client *c)
     }
 
     if (response_data_size > 0) {
-        send_metadata_response(c, ret, data, response_data_size,
-                               response_size);
+        send_metadata_response(c, ret, data, response_data_size, response_size);
     } else {
-        send_metadata_response(c, ret, NULL, response_data_size,
-                               response_size);
+        send_metadata_response(c, ret, NULL, response_data_size, response_size);
     }
 
     afp_server_release(volume->server);
@@ -1756,13 +1683,12 @@ static unsigned char process_readdir(struct daemon_client * c)
     unsigned int numfiles = 0;
     int i;
     int ret;
-    log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                   "Reading directory '%s' (start=%d, count=%d)",
-                   req->path, req->start, req->count);
+    log_for_client((void *) c, AFPFSD, LOG_DEBUG,
+                   "Reading directory '%s' (start=%d, count=%d)", req->path,
+                   req->start, req->count);
 
     if (((size_t)(c->completed_packet_size) < sizeof(struct
-            afp_server_readdir_request)) ||
-            (req->start < 0)) {
+            afp_server_readdir_request)) || (req->start < 0)) {
         result = AFP_SERVER_RESULT_ERROR;
         goto error;
     }
@@ -1810,7 +1736,8 @@ static unsigned char process_readdir(struct daemon_client * c)
             file_array[numfiles - 1]->next = NULL;
             free(file_array);
         } else {
-            log_for_client((void *) c, AFPFSD, LOG_ERR, "Out of memory sorting file list");
+            log_for_client((void *) c, AFPFSD, LOG_ERR,
+                           "Out of memory sorting file list");
         }
     }
 
@@ -1922,18 +1849,14 @@ error:
     response->numfiles = 0;
     p = (char *)response + len;
 done:
-    log_for_client(NULL, AFPFSD, LOG_DEBUG,
+    log_for_client((void *) c, AFPFSD, LOG_DEBUG,
                    "Directory read completed: %d files returned", response->numfiles);
     response->header.len = (p - (char *)response);
     response->header.result = result;
-    send_command(c, response->header.len, (char *)response);
+    finish_response(c,
+                    send_command(c, response->header.len, (char *) response),
+                    req->header.close);
     free(response);
-
-    if (req->header.close) {
-        close_client_connection(c);
-    } else {
-        continue_client_connection(c);
-    }
 
     if (v) {
         afp_server_release(v->server);
@@ -1947,15 +1870,12 @@ static int process_connect(struct daemon_client * c)
     struct afp_server_connect_request * req;
     struct afp_server  * s = NULL;
     struct afp_connection_request conn_req;
-    int response_len;
-    struct afp_server_connect_response * response;
-    char *r;
+    struct afp_server_connect_response response;
     int ret = 0;
     int response_result;
     int error = 0;
     char loginmesg_copy[AFP_LOGINMESG_LEN];
     struct afp_server *server_copy = NULL;
-    int send_ret;
 
     if ((size_t)(c->completed_packet_size) < sizeof(struct
             afp_server_connect_request)) {
@@ -1973,8 +1893,7 @@ static int process_connect(struct daemon_client * c)
     req->url.zone[AFP_ZONE_LEN - 1] = '\0';
     req->url.volpassword[AFP_VOLPASS_LEN] = '\0';
     memset(loginmesg_copy, 0, AFP_LOGINMESG_LEN);
-    log_for_client(NULL, AFPFSD, LOG_INFO,
-                   "Connecting to server %s",
+    log_for_client((void *) c, AFPFSD, LOG_INFO, "Connecting to server %s",
                    (char *) req->url.servername);
 
     if ((s = afp_server_find_by_name_hold(req->url.servername))) {
@@ -2035,21 +1954,21 @@ static int process_connect(struct daemon_client * c)
     * Sets connect_error:
     * 0:
     *      No error
-    * -ENONET:
+    * ENONET:
     *      could not get the address of the server
-    * -ENOMEM:
+    * ENOMEM:
     *      could not allocate memory
-    * -ETIMEDOUT:
+    * ETIMEDOUT:
     *      timed out waiting for connection
-    * -ENETUNREACH:
+    * ENETUNREACH:
     *      Server unreachable
-    * -EISCONN:
+    * EISCONN:
     *      Connection already established
-    * -ECONNREFUSED:
+    * ECONNREFUSED:
     *     Remote server has refused the connection
-    * -EACCES, -EPERM, -EADDRINUSE, -EAFNOSUPPORT, -EAGAIN, -EALREADY, -EBADF,
-    * -EFAULT, -EINPROGRESS, -EINTR, -ENOTSOCK, -EINVAL, -EMFILE, -ENFILE,
-    * -ENOBUFS, -EPROTONOSUPPORT:
+    * EACCES, EPERM, EADDRINUSE, EAFNOSUPPORT, EAGAIN, EALREADY, EBADF,
+    * EFAULT, EINPROGRESS, EINTR, ENOTSOCK, EINVAL, EMFILE, ENFILE,
+    * ENOBUFS, EPROTONOSUPPORT:
     *     Internal error
     *
     * Returns:
@@ -2073,50 +1992,42 @@ static int process_connect(struct daemon_client * c)
     response_result = AFP_SERVER_RESULT_OKAY;
     goto done;
 error:
-    response_result = AFP_SERVER_RESULT_ERROR;
+
+    switch (error) {
+    case EACCES:
+    case EPERM:
+        response_result = AFP_SERVER_RESULT_NOAUTHENT;
+        break;
+
+    case ETIMEDOUT:
+        response_result = AFP_SERVER_RESULT_TIMEDOUT;
+        break;
+#ifdef ENONET
+
+    case ENONET: /* Linux-specific */
+#endif
+    case ENETUNREACH:
+    case EHOSTUNREACH:
+    case ECONNREFUSED:
+        response_result = AFP_SERVER_RESULT_NOSERVER;
+        break;
+
+    default:
+        response_result = AFP_SERVER_RESULT_ERROR;
+        break;
+    }
+
     ret = 0;
 done:
-    /* Build response - mutex protects log data access */
-    pthread_mutex_lock(&c->command_string_mutex);
-    size_t log_len = c->outgoing_string_len;
-    response_len = sizeof(struct afp_server_connect_response) + log_len;
-    response = malloc(response_len);
-
-    if (!response) {
-        pthread_mutex_unlock(&c->command_string_mutex);
-        log_for_client((void *) c, AFPFSD, LOG_ERR,
-                       "Out of memory allocating connect response");
-        close_client_connection(c);
-        return 0;  /* Return 0, not error code, to prevent double-close */
-    }
-
-    memset(response, 0, response_len);
+    memset(&response, 0, sizeof(response));
     /* Use copied data instead of potentially freed server pointer */
-    memcpy(response->loginmesg, loginmesg_copy, AFP_LOGINMESG_LEN);
-    response->header.result = response_result;
-    response->header.len = response_len;
-    response->connect_error = error;
-    memset(&response->serverid, 0, sizeof(serverid_t));
-    memcpy(&response->serverid, &server_copy, sizeof(server_copy));
-    r = ((char *) response) + sizeof(struct afp_server_connect_response);
-    memcpy(r, c->outgoing_string, log_len);
-    pthread_mutex_unlock(&c->command_string_mutex);
-    send_ret = send_command(c, response_len, (char *) response);
-    free(response);
-
-    if (send_ret < 0) {
-        log_for_client((void *) c, AFPFSD, LOG_ERR,
-                       "Failed to send connect response to client");
-        close_client_connection(c);
-        return 0;  /* Return 0, not -1, to prevent double-close in process_command_thread */
-    }
-
-    if (req->header.close || response_result == AFP_SERVER_RESULT_ERROR) {
-        close_client_connection(c);
-    } else {
-        continue_client_connection(c);
-    }
-
+    memcpy(response.loginmesg, loginmesg_copy, AFP_LOGINMESG_LEN);
+    response.header.result = (char) response_result;
+    response.header.len = sizeof(response);
+    response.connect_error = error;
+    memcpy(&response.serverid, &server_copy, sizeof(server_copy));
+    finish_response(c, send_command(c, sizeof(response), (char *) &response),
+                    req->header.close);
     return ret;
 }
 
@@ -2125,10 +2036,8 @@ static int process_attach(struct daemon_client * c)
     struct afp_server_attach_request * req = (void *) c->complete_packet;
     struct afp_server * s = NULL;
     struct afp_volume * volume = NULL;
-    unsigned int response_len;
     int response_result = AFP_SERVER_RESULT_ERROR;
-    char *r;
-    struct afp_server_attach_response * response;
+    struct afp_server_attach_response response;
     struct addrinfo * address = NULL;
 
     if ((size_t)(c->completed_packet_size) < sizeof(struct
@@ -2145,7 +2054,7 @@ static int process_attach(struct daemon_client * c)
     req->url.path[AFP_MAX_PATH - 1] = '\0';
     req->url.zone[AFP_ZONE_LEN - 1] = '\0';
     req->url.volpassword[AFP_VOLPASS_LEN] = '\0';
-    log_for_client(NULL, AFPFSD, LOG_INFO,
+    log_for_client((void *) c, AFPFSD, LOG_INFO,
                    "Attaching volume %s on server %s",
                    (char *) req->url.volumename,
                    (char *) req->url.servername);
@@ -2198,52 +2107,24 @@ static int process_attach(struct daemon_client * c)
 
     volume->extra_flags |= req->volume_options;
     response_result = AFP_SERVER_RESULT_OKAY;
-    log_for_client(NULL, AFPFSD, LOG_DEBUG,
+    log_for_client((void *) c, AFPFSD, LOG_DEBUG,
                    "Volume '%s' attached successfully",
                    volume->volume_name_printable);
     goto done;
 error:
 done:
     signal_main_thread();
-    /* Build response - mutex protects log data access */
-    pthread_mutex_lock(&c->command_string_mutex);
-    size_t log_len = c->outgoing_string_len;
-    response_len = sizeof(struct afp_server_attach_response) + log_len;
-    r = malloc(response_len);
-
-    if (!r) {
-        pthread_mutex_unlock(&c->command_string_mutex);
-        log_for_client((void *) c, AFPFSD, LOG_ERR,
-                       "Out of memory allocating attach response");
-
-        if (s) {
-            afp_server_release(s);
-        }
-
-        return AFP_SERVER_RESULT_ERROR;
-    }
-
-    memset(r, 0, response_len);
-    response = (void *) r;
-    response->header.result = response_result;
-    response->header.len = response_len;
+    memset(&response, 0, sizeof(response));
+    response.header.result = (char) response_result;
+    response.header.len = sizeof(response);
 
     if (volume) {
-        response->volumeid = (volumeid_t) volume;
+        response.volumeid = (volumeid_t) volume;
     }
 
-    r = ((char *)response) + sizeof(struct afp_server_attach_response);
-    memcpy(r, c->outgoing_string, log_len);
-    pthread_mutex_unlock(&c->command_string_mutex);
-    send_command(c, response_len, (char *) response);
-    free(response);
-
-    if ((size_t)c->completed_packet_size >= sizeof(struct afp_server_request_header)
-            && req->header.close) {
-        close_client_connection(c);
-    } else {
-        continue_client_connection(c);
-    }
+    finish_response(c, send_command(c, sizeof(response), (char *) &response),
+                    (size_t) c->completed_packet_size >= sizeof(struct
+                            afp_server_request_header) && req->header.close);
 
     if (s) {
         afp_server_release(s);
@@ -2258,11 +2139,13 @@ static void *process_command_thread(void * other)
     struct daemon_client * c = other;
     int ret = 0;
     const struct afp_server_request_header * req = (void *) c->complete_packet;
-    log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                   "******* processing command %d", req->command);
     /* Clear the outgoing log buffer from any previous command on this connection */
+    pthread_mutex_lock(&c->command_string_mutex);
     c->outgoing_string[0] = '\0';
     c->outgoing_string_len = 0;
+    pthread_mutex_unlock(&c->command_string_mutex);
+    log_for_client((void *) c, AFPFSD, LOG_DEBUG,
+                   "******* processing command %d", req->command);
     pthread_mutex_lock(&server_op_mutex);
 
     switch (req->command) {
@@ -2407,13 +2290,12 @@ static void *process_command_thread(void * other)
     }
 
     pthread_mutex_unlock(&server_op_mutex);
-    remove_command(c);
     return NULL;
 }
 
 int process_command(struct daemon_client * c)
 {
-    int ret;
+    ssize_t ret;
     const struct afp_server_request_header * header;
     pthread_attr_t attr;
 
@@ -2432,15 +2314,22 @@ int process_command(struct daemon_client * c)
             return -1;
         }
 
-        c->incoming_size += ret;
-        c->a += ret;
+        c->incoming_size += (int) ret;
+        c->a += (size_t) ret;
 
         if ((size_t)ret < sizeof(struct afp_server_request_header)) {
             /* incomplete header, continue to read */
             return 2;
         }
 
-        header = (struct afp_server_request_header *) &c->incoming_string;
+        header = (const struct afp_server_request_header *) c->incoming_string;
+
+        if (header->len < sizeof(*header)
+                || header->len > sizeof(c->incoming_string)) {
+            log_for_client((void *) c, AFPFSD, LOG_ERR,
+                           "Invalid command length %u", header->len);
+            return -1;
+        }
 
         if ((unsigned int)c->incoming_size == header->len) {
             goto havefullone;
@@ -2451,17 +2340,29 @@ int process_command(struct daemon_client * c)
     }
 
     /* Okay, we're continuing to read */
-    header = (struct afp_server_request_header *) &c->incoming_string;
-    ret = read(c->fd, c->a,
-               AFP_CLIENT_INCOMING_BUF - c->incoming_size);
+    ret = read(c->fd, c->a, AFP_CLIENT_INCOMING_BUF - c->incoming_size);
 
     if (ret <= 0) {
         perror("reading command 2");
         return -1;
     }
 
-    c->a += ret;
-    c->incoming_size += ret;
+    c->a += (size_t) ret;
+    c->incoming_size += (int) ret;
+
+    if ((size_t)c->incoming_size < sizeof(*header)) {
+        /* incomplete header, continue to read */
+        return 0;
+    }
+
+    header = (const struct afp_server_request_header *) c->incoming_string;
+
+    if (header->len < sizeof(*header)
+            || header->len > sizeof(c->incoming_string)) {
+        log_for_client((void *) c, AFPFSD, LOG_ERR,
+                       "Invalid command length %u", header->len);
+        return -1;
+    }
 
     if ((unsigned int)c->incoming_size < header->len) {
         return 0;
@@ -2469,7 +2370,7 @@ int process_command(struct daemon_client * c)
 
 havefullone:
     /* Okay, so we have a full one.  Copy the buffer. */
-    header = (struct afp_server_request_header *) &c->incoming_string;
+    header = (const struct afp_server_request_header *) c->incoming_string;
     /* do the copy */
     c->completed_packet_size = header->len;
     memcpy(c->complete_packet, c->incoming_string, c->completed_packet_size);
@@ -2484,8 +2385,8 @@ havefullone:
     pthread_attr_init(&attr);
     pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
 
-    if (pthread_create(&c->processing_thread, &attr,
-                       process_command_thread, c) < 0) {
+    if (pthread_create(&c->processing_thread, &attr, process_command_thread,
+                       c) < 0) {
         perror("pthread_create");
         return -1;
     }
@@ -2543,8 +2444,8 @@ struct afp_volume *command_sub_attach_volume(struct daemon_client *c,
         if (server->num_volumes) {
             char names[1024];
             afp_list_volnames(server, names, 1024);
-            log_for_client((void *)c, AFPFSD, LOG_ERR,
-                           "Choose a volume from: %s", names);
+            log_for_client((void *) c, AFPFSD, LOG_ERR, "Choose a volume from: %s",
+                           names);
         } else {
             log_for_client((void *)c, AFPFSD, LOG_ERR,
                            "No volumes available on server %s.",
@@ -2558,9 +2459,9 @@ struct afp_volume *command_sub_attach_volume(struct daemon_client *c,
         log_for_client((void *)c, AFPFSD, LOG_DEBUG,
                        "Volume %s is already attached", volname);
 
-        if (response_result)
-            *response_result =
-                AFP_SERVER_RESULT_ALREADY_ATTACHED;
+        if (response_result) {
+            *response_result = AFP_SERVER_RESULT_ALREADY_ATTACHED;
+        }
 
         goto error;
     }
@@ -2569,9 +2470,9 @@ struct afp_volume *command_sub_attach_volume(struct daemon_client *c,
         if (!volpassword || volpassword[0] == '\0') {
             log_for_client((void *) c, AFPFSD, LOG_ERR, "Volume password needed");
 
-            if (response_result)
-                *response_result =
-                    AFP_SERVER_RESULT_VOLPASS_NEEDED;
+            if (response_result) {
+                *response_result = AFP_SERVER_RESULT_VOLPASS_NEEDED;
+            }
 
             goto error;
         }
@@ -2587,16 +2488,16 @@ struct afp_volume *command_sub_attach_volume(struct daemon_client *c,
         log_for_client((void *) c, AFPFSD, LOG_ERR, "Could not attach volume %s",
                        volname);
 
-        if (response_result)
-            *response_result =
-                AFP_SERVER_RESULT_ERROR_UNKNOWN;
+        if (response_result) {
+            *response_result = AFP_SERVER_RESULT_ERROR_UNKNOWN;
+        }
 
         goto error;
     }
 
     afp_detect_mapping(using_volume);
-    log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                   "Volume mapping detected: %d", using_volume->mapping);
+    log_for_client((void *) c, AFPFSD, LOG_DEBUG, "Volume mapping detected: %d",
+                   using_volume->mapping);
     return using_volume;
 error:
     return NULL;

--- a/daemon/daemon.c
+++ b/daemon/daemon.c
@@ -7,30 +7,29 @@
  *  This is the main loop for afpsld (stateless daemon).
  */
 
-#include <sys/types.h>
-#include <sys/param.h>
-#include <stdio.h>
-#include <string.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <utime.h>
-#include <stdlib.h>
-#include <getopt.h>
-#include <sys/un.h>
-#include <unistd.h>
-#include <time.h>
-#include <stdarg.h>
 #include <getopt.h>
 #include <signal.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/param.h>
 #include <sys/socket.h>
+#include <sys/types.h>
+#include <sys/un.h>
+#include <time.h>
+#include <unistd.h>
+#include <utime.h>
 
 #include "afp.h"
-#include "dsi.h"
 #include "afp_server.h"
-#include "utils.h"
-#include "daemon.h"
 #include "commands.h"
+#include "daemon.h"
 #include "daemon_socket.h"
+#include "dsi.h"
+#include "utils.h"
 
 #define MAX_ERROR_LEN 1024
 #define STATUS_LEN 1024
@@ -65,11 +64,13 @@ static void daemon_log_for_client(void * priv,
     struct daemon_client * c = priv;
     int type_rank = loglevel_to_rank(loglevel);
 
-    if (type_rank < daemon_log_min_rank) {
+    if (!c && type_rank < daemon_log_min_rank) {
         return; /* Filter out less-verbose messages */
     }
 
     if (c) {
+        struct afp_server_log_record record;
+        size_t message_len = strlen(message);
         /* Thread-safe access to outgoing_string */
         pthread_mutex_lock(&c->command_string_mutex);
 
@@ -81,30 +82,22 @@ static void daemon_log_for_client(void * priv,
 
         size_t available = sizeof(c->outgoing_string) - c->outgoing_string_len;
 
-        if (available > 1) {
-            int written = snprintf(c->outgoing_string + c->outgoing_string_len,
-                                   available,
-                                   "%s\n", message);
-
-            if (written > 0) {
-                /* snprintf returns the number it tried to write, not what actually fit.
-                 * We need to cap it to the available space (minus null terminator). */
-                size_t actual_written;
-
-                if ((size_t)written >= available) {
-                    /* Truncation occurred - only (available-1) bytes were written */
-                    actual_written = available - 1;
-                } else {
-                    actual_written = (size_t)written;
-                }
-
-                c->outgoing_string_len += actual_written;
-            }
+        if (message_len > UINT32_MAX) {
+            message_len = UINT32_MAX;
         }
 
-        /* Always ensure null termination at the tracked position */
-        if (c->outgoing_string_len < sizeof(c->outgoing_string)) {
-            c->outgoing_string[c->outgoing_string_len] = '\0';
+        if (available > sizeof(record)) {
+            if (message_len > available - sizeof(record)) {
+                message_len = available - sizeof(record);
+            }
+
+            record.level = loglevel;
+            record.message_len = (uint32_t) message_len;
+            memcpy(c->outgoing_string + c->outgoing_string_len, &record,
+                   sizeof(record));
+            c->outgoing_string_len += sizeof(record);
+            memcpy(c->outgoing_string + c->outgoing_string_len, message, message_len);
+            c->outgoing_string_len += message_len;
         }
 
         pthread_mutex_unlock(&c->command_string_mutex);
@@ -129,8 +122,7 @@ void daemon_forced_ending_hook(void)
 
                 if (volume->attached == AFP_VOLUME_ATTACHED) {
                     log_for_client(NULL, AFPFSD, LOG_NOTICE,
-                                   "Disconnecting from volume %s",
-                                   volume->volume_name);
+                                   "Disconnecting from volume %s", volume->volume_name);
                     afp_unmount_volume(volume);
                 }
             }
@@ -150,7 +142,6 @@ int daemon_unmount_volume(struct afp_volume * volume)
      * The actual AFP disconnect will be handled elsewhere. */
     return 0;
 }
-
 
 static int startup_listener(void)
 {
@@ -217,8 +208,7 @@ int main(int argc, char *argv[])
     signal(SIGPIPE, SIG_IGN);
 
     while (1) {
-        c = getopt_long(argc, argv, "dfhl:v:",
-                        long_options, &option_index);
+        c = getopt_long(argc, argv, "dfhl:v:", long_options, &option_index);
 
         if (c == -1) {
             break;
@@ -311,8 +301,8 @@ int main(int argc, char *argv[])
             goto error;
         }
 
-        log_for_client(NULL, AFPFSD, LOG_NOTICE,
-                       "Starting up AFPFS version %s", AFPFS_VERSION);
+        log_for_client(NULL, AFPFSD, LOG_NOTICE, "Starting up AFPFS version %s",
+                       AFPFS_VERSION);
         afp_main_loop(command_fd);
         close_commands(command_fd);
     }

--- a/daemon/daemon_client.c
+++ b/daemon/daemon_client.c
@@ -6,32 +6,31 @@
  *
  */
 
-#include <stdio.h>
-#include <string.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <utime.h>
-#include <stdlib.h>
-#include <getopt.h>
-#include <sys/socket.h>
-#include <sys/un.h>
-#include <unistd.h>
-#include <time.h>
-#include <stdarg.h>
 #include <getopt.h>
 #include <signal.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <time.h>
+#include <unistd.h>
+#include <utime.h>
 
 #include "afp.h"
-#include "dsi.h"
 #include "afp_server.h"
-#include "utils.h"
-#include "daemon.h"
-#include "uams_def.h"
 #include "codepage.h"
+#include "commands.h"
+#include "daemon.h"
+#include "daemon_client.h"
+#include "dsi.h"
 #include "libafpclient.h"
 #include "map_def.h"
-#include "daemon_client.h"
-#include "commands.h"
+#include "uams_def.h"
+#include "utils.h"
 
 static struct daemon_client client_pool[DAEMON_NUM_CLIENTS];
 
@@ -103,8 +102,7 @@ int close_client_connection(struct daemon_client * c)
     c->a = &c->incoming_string[0];
     c->incoming_size = 0;
 
-    if ((!c) ||
-            (c->fd == 0)) {
+    if ((!c) || (c->fd == 0)) {
         return -1;
     }
 
@@ -113,7 +111,6 @@ int close_client_connection(struct daemon_client * c)
     remove_client(&c);
     return 0;
 }
-
 
 static int add_client(int fd)
 {
@@ -195,9 +192,7 @@ int daemon_scan_extra_fds(int command_fd, fd_set * set, int *max_fd)
     int ret;
 
     if (FD_ISSET(command_fd, set)) {
-        int new_fd =
-            accept(command_fd,
-                   (struct sockaddr *) &new_addr, &new_len);
+        int new_fd = accept(command_fd, (struct sockaddr *) &new_addr, &new_len);
 
         if (new_fd >= 0) {
             if (add_client(new_fd) < 0) {
@@ -248,30 +243,75 @@ int daemon_scan_extra_fds(int command_fd, fd_set * set, int *max_fd)
     }
 }
 
-
-unsigned int send_command(struct daemon_client * c,
-                          unsigned int len, const char *data)
+int send_command(struct daemon_client *c, unsigned int len, const char *data)
 {
-    unsigned int total = 0;
-    int ret;
+    struct afp_server_response_header header;
+    struct afp_server_log_footer footer;
+    size_t total = 0;
+    size_t response_len;
+    size_t log_len;
+    char *response;
+    ssize_t ret;
 
-    while (total < len) {
-        ret = write(c->fd, data + total, len - total);
+    if (!c || !data || len < sizeof(header)) {
+        return -1;
+    }
+
+    pthread_mutex_lock(&c->command_string_mutex);
+    log_len = c->outgoing_string_len;
+
+    if (log_len > sizeof(c->outgoing_string) || log_len > UINT32_MAX
+            || log_len > UINT_MAX - sizeof(footer)
+            || len > UINT_MAX - log_len - sizeof(footer)) {
+        pthread_mutex_unlock(&c->command_string_mutex);
+        return -1;
+    }
+
+    response_len = len + log_len + sizeof(footer);
+    response = malloc(response_len);
+
+    if (!response) {
+        pthread_mutex_unlock(&c->command_string_mutex);
+        return -1;
+    }
+
+    memcpy(response, data, len);
+    memcpy(response + len, c->outgoing_string, log_len);
+    footer.magic = AFP_SERVER_LOG_MAGIC;
+    footer.log_len = (uint32_t) log_len;
+    memcpy(response + len + log_len, &footer, sizeof(footer));
+    memcpy(&header, response, sizeof(header));
+    header.len = (unsigned int) response_len;
+    memcpy(response, &header, sizeof(header));
+    pthread_mutex_unlock(&c->command_string_mutex);
+
+    while (total < response_len) {
+        ret = write(c->fd, response + total, response_len - total);
 
         if (ret < 0) {
-            perror("Writing");
+            if (errno == EINTR) {
+                continue;
+            }
+
+            log_for_client((void *) c, AFPFSD, LOG_ERR,
+                           "Failed to write response to client: %s",
+                           strerror(errno));
+            free(response);
             return -1;
         }
 
-        total += ret;
+        if (ret == 0) {
+            log_for_client((void *) c, AFPFSD, LOG_ERR,
+                           "Short write sending response to client");
+            free(response);
+            return -1;
+        }
+
+        total += (size_t) ret;
     }
 
-    return total;
-}
-
-void remove_command(struct daemon_client * c)
-{
-    pthread_mutex_unlock(&c->command_string_mutex);
+    free(response);
+    return 0;
 }
 
 int count_active_clients(void)

--- a/daemon/daemon_client.h
+++ b/daemon/daemon_client.h
@@ -17,7 +17,7 @@ struct daemon_client {
     int completed_packet_size;
     pthread_mutex_t command_string_mutex;
 
-    char outgoing_string[1000 + MAX_CLIENT_RESPONSE];
+    char outgoing_string[AFP_SERVER_LOG_BUFFER_SIZE];
     size_t outgoing_string_len;
     int fd;
     int lock;
@@ -29,13 +29,11 @@ struct daemon_client {
     int used;
 };
 
-unsigned int send_command(struct daemon_client * c,
-                          unsigned int len, const char *data);
+int send_command(struct daemon_client *c, unsigned int len, const char *data);
 
 int continue_client_connection(struct daemon_client * c);
 int close_client_connection(struct daemon_client * c);
 int remove_client(struct daemon_client ** toremove);
-void remove_command(struct daemon_client *c);
 int count_active_clients(void);
 void remove_all_clients(void);
 int daemon_scan_extra_fds(int command_fd, fd_set *set, int *max_fd);

--- a/daemon/stateless.c
+++ b/daemon/stateless.c
@@ -6,20 +6,23 @@
  *
  */
 
-#include <sys/types.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <getopt.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <sys/param.h>
+#include <sys/shm.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
-#include <string.h>
-#include <stdio.h>
+#include <sys/types.h>
 #include <sys/un.h>
-#include <getopt.h>
-#include <stdlib.h>
-#include <unistd.h>
-#include <errno.h>
-#include <sys/shm.h>
+#include <sys/wait.h>
+#include <syslog.h>
 #include <time.h>
-#include <stddef.h>
+#include <unistd.h>
 
 #ifdef HAVE_LIBBSD
 #include <bsd/string.h>
@@ -27,10 +30,12 @@
 
 #include "afp.h"
 #include "afp_server.h"
-#include "uams_def.h"
-#include "map_def.h"
-#include "libafpclient.h"
 #include "afpsl.h"
+#include "libafpclient.h"
+#include "map_def.h"
+#include "stateless_internal.h"
+#include "uams_def.h"
+#include "utils.h"
 
 #ifndef MSG_NOSIGNAL
 #define MSG_NOSIGNAL 0
@@ -39,28 +44,218 @@
 #define default_uam "Cleartxt Passwrd"
 #define AFPSLD_FILENAME "afpsld"
 
-static struct afpfsd_connect connection;
+static struct afpfsd_connect connection = { .fd = -1 };
+
+static void close_connection(void)
+{
+    if (connection.fd >= 0) {
+        close(connection.fd);
+        connection.fd = -1;
+    }
+}
+
+static void default_log_callback(void *user_data, int loglevel,
+                                 const char *message)
+{
+    (void) user_data;
+    (void) loglevel;
+    fprintf(stderr, "%s\n", message);
+}
+
+static afp_sl_log_callback log_callback = default_log_callback;
+static void *log_callback_data;
+static int read_bytes_with_timeout(int fd, char *buf, size_t len);
+
+static void stateless_log_message(int loglevel, const char *message)
+{
+    char escaped[MAX_ERROR_LEN * 4];
+    sanitize_text(message, escaped, sizeof(escaped));
+
+    if (log_callback) {
+        log_callback(log_callback_data, loglevel, escaped);
+    }
+}
+
+static void stateless_log_errno(int loglevel, const char *context,
+                                int error_number)
+{
+    char message[MAX_ERROR_LEN];
+    snprintf(message, sizeof(message), "%s: %s", context,
+             strerror(error_number));
+    stateless_log_message(loglevel, message);
+}
+
+static void stateless_log_command_errno(int loglevel, unsigned int command,
+                                        int error_number)
+{
+    char message[MAX_ERROR_LEN];
+    snprintf(message, sizeof(message),
+             "Write to afpsld failed for command %u: %s", command,
+             strerror(error_number));
+    stateless_log_message(loglevel, message);
+}
+
+void afp_sl_set_log_callback(afp_sl_log_callback callback, void *user_data)
+{
+    log_callback = callback;
+    log_callback_data = user_data;
+}
+
+int afp_sl_response_content_length(const char *response, size_t len,
+                                   size_t *content_len)
+{
+    struct afp_server_log_footer footer;
+
+    if (len < sizeof(footer)) {
+        return -1;
+    }
+
+    memcpy(&footer, response + len - sizeof(footer), sizeof(footer));
+
+    if (footer.magic != AFP_SERVER_LOG_MAGIC
+            || footer.log_len > AFP_SERVER_LOG_BUFFER_SIZE
+            || footer.log_len > len - sizeof(footer)) {
+        return -1;
+    }
+
+    *content_len = len - sizeof(footer) - footer.log_len;
+    return 0;
+}
+
+int afp_sl_dispatch_response_logs(const char *response, size_t len)
+{
+    struct afp_server_log_footer footer;
+    size_t content_len;
+    size_t pos;
+
+    if (afp_sl_response_content_length(response, len, &content_len) < 0) {
+        stateless_log_message(LOG_ERR,
+                              "Response from afpsld has no valid log trailer");
+        return -1;
+    }
+
+    memcpy(&footer, response + len - sizeof(footer), sizeof(footer));
+    pos = content_len;
+
+    while (pos < len - sizeof(footer)) {
+        struct afp_server_log_record record;
+        char message[AFP_SERVER_LOG_BUFFER_SIZE + 1];
+
+        if (len - sizeof(footer) - pos < sizeof(record)) {
+            stateless_log_message(LOG_ERR,
+                                  "Malformed log record from afpsld");
+            return -1;
+        }
+
+        memcpy(&record, response + pos, sizeof(record));
+        pos += sizeof(record);
+
+        if (record.message_len > AFP_SERVER_LOG_BUFFER_SIZE
+                || record.message_len > len - sizeof(footer) - pos) {
+            stateless_log_message(LOG_ERR,
+                                  "Malformed log message from afpsld");
+            return -1;
+        }
+
+        memcpy(message, response + pos, record.message_len);
+        message[record.message_len] = '\0';
+        stateless_log_message(record.level, message);
+        pos += record.message_len;
+    }
+
+    return 0;
+}
+
+static int read_response_tail(unsigned int total_len, size_t prefix_len,
+                              char **tail, size_t *content_len)
+{
+    size_t tail_len;
+
+    if (total_len < prefix_len + sizeof(struct afp_server_log_footer)) {
+        return -1;
+    }
+
+    tail_len = total_len - prefix_len;
+    *tail = malloc(tail_len);
+
+    if (!*tail) {
+        return -1;
+    }
+
+    if (read_bytes_with_timeout(connection.fd, *tail, tail_len) < 0
+            || afp_sl_response_content_length(*tail, tail_len, content_len) < 0
+            || afp_sl_dispatch_response_logs(*tail, tail_len) < 0) {
+        free(*tail);
+        *tail = NULL;
+        return -1;
+    }
+
+    return 0;
+}
 
 static int start_afpsld(void)
 {
+    int error_pipe[2];
+    int child_errno = 0;
+    ssize_t bytes_read;
+    pid_t child;
     char *argv[2];
     argv[0] = AFPSLD_FILENAME;
     argv[1] = NULL;
 
-    if (fork() == 0) {
+    if (pipe(error_pipe) < 0) {
+        stateless_log_errno(LOG_ERR, "Could not create afpsld startup pipe",
+                            errno);
+        return -1;
+    }
+
+    if (fcntl(error_pipe[0], F_SETFD, FD_CLOEXEC) < 0
+            || fcntl(error_pipe[1], F_SETFD, FD_CLOEXEC) < 0) {
+        stateless_log_errno(LOG_ERR,
+                            "Could not configure afpsld startup pipe", errno);
+        close(error_pipe[0]);
+        close(error_pipe[1]);
+        return -1;
+    }
+
+    child = fork();
+
+    if (child < 0) {
+        stateless_log_errno(LOG_ERR, "Could not fork afpsld", errno);
+        close(error_pipe[0]);
+        close(error_pipe[1]);
+        return -1;
+    }
+
+    if (child == 0) {
         char filename[PATH_MAX];
+        close(error_pipe[0]);
         snprintf(filename, PATH_MAX, "%s/%s", BINDIR, AFPSLD_FILENAME);
-
-        if (access(filename, X_OK)) {
-            fprintf(stderr, "Could not find afpsld daemon (%s)\n",
-                    filename);
-            _exit(1);
-        }
-
-        execvp(filename, argv);
+        execv(filename, argv);
         /* exec failed */
-        perror("execvp afpsld");
+        child_errno = errno;
+        (void) write(error_pipe[1], &child_errno, sizeof(child_errno));
         _exit(1);
+    }
+
+    close(error_pipe[1]);
+
+    do {
+        bytes_read = read(error_pipe[0], &child_errno, sizeof(child_errno));
+    } while (bytes_read < 0 && errno == EINTR);
+
+    close(error_pipe[0]);
+
+    if (bytes_read < 0) {
+        stateless_log_errno(LOG_ERR, "Could not read afpsld startup status",
+                            errno);
+        return -1;
+    }
+
+    if (bytes_read > 0) {
+        (void) waitpid(child, NULL, 0);
+        stateless_log_errno(LOG_ERR, "Could not execute afpsld", child_errno);
+        return -1;
     }
 
     return 0;
@@ -74,13 +269,14 @@ int daemon_connect(unsigned int daemon_uid)
     int ret;
 
     /* Check if we already have a valid connection */
-    if (connection.fd > 0) {
+    if (connection.fd >= 0) {
         /* Reuse existing connection */
+        stateless_log_message(LOG_DEBUG, "Reusing connection to afpsld");
         return 0;
     }
 
     if ((sock = socket(AF_UNIX, SOCK_STREAM, 0)) < 0) {
-        perror("Could not create socket\n");
+        stateless_log_errno(LOG_ERR, "Could not create socket", errno);
         return -1;
     }
 
@@ -98,11 +294,14 @@ int daemon_connect(unsigned int daemon_uid)
     ret = connect(sock, (struct sockaddr*) &servaddr, sizeof(servaddr));
 
     if (ret >= 0) {
+        stateless_log_message(LOG_DEBUG, "Connected to running afpsld");
         goto done;
     }
 
+    stateless_log_message(LOG_DEBUG, "Starting afpsld");
+
     if (start_afpsld() != 0) {
-        printf("Error in starting up afpsld daemon\n");
+        stateless_log_message(LOG_ERR, "Error starting afpsld daemon");
         close(sock);
         return -1;
     }
@@ -114,13 +313,15 @@ int daemon_connect(unsigned int daemon_uid)
         ret = connect(sock, (struct sockaddr*) &servaddr, sizeof(servaddr));
 
         if (ret >= 0) {
+            stateless_log_message(LOG_DEBUG,
+                                  "Connected to newly started afpsld");
             goto done;
         }
 
         retries--;
     }
 
-    perror("Could not connect to afpsld daemon");
+    stateless_log_errno(LOG_ERR, "Could not connect to afpsld daemon", errno);
     close(sock);
     return -1;
 done:
@@ -128,71 +329,146 @@ done:
     return 0;
 }
 
-/* read_answer()
- *
- * Reads the answer from afpsld.
- * Returns:
- * -1: timeout or select error
- * >0: afpfsd header error
- */
-
-static int read_answer(void)
+/* Read one complete length-prefixed response from afpsld. */
+int afp_sl_read_framed_response(int fd, char *data, size_t capacity,
+                                size_t *response_len)
 {
-    unsigned int expected_len = 0, packetlen;
+    struct afp_server_response_header header;
+    unsigned int expected_len = 0;
+    size_t received = 0;
+    ssize_t packetlen;
     struct timeval tv;
     fd_set rds, ords;
     int ret;
-    memset(connection.data, 0, MAX_CLIENT_RESPONSE);
-    connection.len = 0;
+
+    if (!response_len) {
+        return -1;
+    }
+
+    *response_len = 0;
+
+    if (!data || fd < 0 || fd >= FD_SETSIZE
+            || capacity < sizeof(header)
+            + sizeof(struct afp_server_log_footer)) {
+        return -1;
+    }
+
+    memset(data, 0, capacity);
     FD_ZERO(&rds);
-    FD_SET(connection.fd, &rds);
+    FD_SET(fd, &rds);
 
     while (1) {
         tv.tv_sec = 30;
         tv.tv_usec = 0;
         ords = rds;
-        ret = select(connection.fd + 1, &ords, NULL, NULL, &tv);
+        ret = select(fd + 1, &ords, NULL, NULL, &tv);
 
         if (ret == 0) {
-            printf("No response from server, timed out.\n");
-            close(connection.fd);
-            connection.fd = 0;
+            stateless_log_message(LOG_ERR,
+                                  "No response from afpsld, timed out");
             return -1;
         }
 
-        if (FD_ISSET(connection.fd, &ords)) {
-            packetlen = read(connection.fd,
-                             connection.data + connection.len,
-                             MAX_CLIENT_RESPONSE - connection.len);
-
-            if (packetlen <= 0) {
-                printf("Dropped connection\n");
-                close(connection.fd);
-                connection.fd = 0;
-                goto done;
+        if (ret < 0) {
+            if (errno == EINTR) {
+                continue;
             }
 
-            if (connection.len == 0) { /* This is our first read */
-                expected_len =
-                    ((struct afp_server_response_header *)
-                     connection.data)->len;
+            stateless_log_errno(LOG_ERR,
+                                "Error waiting for response from afpsld",
+                                errno);
+            return -1;
+        }
+
+        if (FD_ISSET(fd, &ords)) {
+            if (received >= capacity) {
+                stateless_log_message(LOG_ERR,
+                                      "Response from afpsld exceeds buffer");
+                return -1;
             }
 
-            connection.len += packetlen;
+            packetlen = read(fd, data + received, capacity - received);
 
-            if (connection.len == expected_len) {
-                goto done;
+            if (packetlen < 0) {
+                if (errno == EINTR) {
+                    continue;
+                }
+
+                stateless_log_errno(LOG_ERR,
+                                    "Error reading response from afpsld",
+                                    errno);
+                return -1;
             }
 
-            if (ret < 0) {
-                goto error;
+            if (packetlen == 0) {
+                stateless_log_message(
+                    LOG_WARNING,
+                    "afpsld closed connection before completing response");
+                return -1;
+            }
+
+            received += (size_t) packetlen;
+
+            if (received >= sizeof(header) && expected_len == 0) {
+                memcpy(&header, data, sizeof(header));
+                expected_len = header.len;
+
+                if (expected_len < sizeof(header)
+                        + sizeof(struct afp_server_log_footer)) {
+                    stateless_log_message(
+                        LOG_ERR, "Invalid response length from afpsld");
+                    return -1;
+                }
+            }
+
+            if (expected_len > capacity) {
+                stateless_log_message(LOG_ERR,
+                                      "Oversized response from afpsld");
+                return -1;
+            }
+
+            if (received == expected_len) {
+                *response_len = received;
+                return 0;
+            }
+
+            if (expected_len > 0 && received > expected_len) {
+                stateless_log_message(LOG_ERR,
+                                      "Overlong response from afpsld");
+                return -1;
             }
         }
     }
+}
 
-done:
-    return ((struct afp_server_response_header *) connection.data)->result;
+/* Read, validate, and dispatch one complete response from afpsld. */
+static int read_answer(void)
+{
+    struct afp_server_response_header header;
+    size_t response_len;
+    connection.len = 0;
+
+    if (afp_sl_read_framed_response(connection.fd, connection.data,
+                                    sizeof(connection.data),
+                                    &response_len) < 0) {
+        goto error;
+    }
+
+    if (response_len > UINT_MAX) {
+        goto error;
+    }
+
+    connection.len = (unsigned int) response_len;
+
+    if (afp_sl_dispatch_response_logs(connection.data, connection.len) < 0) {
+        goto error;
+    }
+
+    memcpy(&header, connection.data, sizeof(header));
+    return header.result;
 error:
+    close_connection();
+    connection.len = 0;
     return -1;
 }
 
@@ -259,10 +535,8 @@ static int send_command(unsigned int len, char * data, unsigned int num)
     int ret = write_bytes(connection.fd, data, len);
 
     if (ret < 0) {
-        fprintf(stderr, "send_command: write failed for command %u: %s\n",
-                num, strerror(errno));
-        close(connection.fd);
-        connection.fd = 0;
+        stateless_log_command_errno(LOG_ERR, num, errno);
+        close_connection();
     }
 
     return  ret;
@@ -286,26 +560,22 @@ static int send_to_daemon(char * request, int req_len, char * reply,
         return AFP_SERVER_RESULT_DAEMON_ERROR;
     }
 
-    ret = read_bytes_with_timeout(connection.fd, reply, reply_len);
+    ret = read_answer();
 
-    if (ret < 0) {
-        printf("Error reading response\n");
-        close(connection.fd);
-        connection.fd = 0;
-        return -1;
+    if (ret < 0 || connection.len < (unsigned int) reply_len) {
+        stateless_log_message(LOG_ERR, "Error reading response from afpsld");
+        close_connection();
+        return AFP_SERVER_RESULT_DAEMON_ERROR;
     }
 
+    memcpy(reply, connection.data, reply_len);
     return 0;
-}
-
-static void conn_print(const char * text)
-{
-    printf("%s", text);
 }
 
 void afp_sl_conn_setup(void)
 {
-    connection.print = conn_print;
+    /* Retained for source compatibility. Static state is initialized above,
+     * and callback registration must survive every afp_sl_* call. */
 }
 
 int afp_sl_exit(void)
@@ -333,8 +603,8 @@ int afp_sl_exit(void)
  * AFP_SERVER_RESULT_DAEMON_ERROR: could not connect to afpsld
  */
 
-int afp_sl_status(const char * volumename, const char * servername,
-                  char *text, unsigned int *remaining)
+int afp_sl_status(const char *volumename, const char *servername, char *text,
+                  unsigned int *remaining)
 {
     struct afp_server_status_request req;
     int ret;
@@ -366,8 +636,8 @@ int afp_sl_status(const char * volumename, const char * servername,
         return ret;
     }
 
-    strlcpy(text, connection.data +
-            sizeof(struct afp_server_status_response), *remaining);
+    strlcpy(text, connection.data + sizeof(struct afp_server_status_response),
+            *remaining);
     return ret;
 }
 
@@ -418,8 +688,8 @@ int afp_sl_getvolid(struct afp_url * url, volumeid_t *volid)
     return response.header.result;
 }
 
-int afp_sl_stat(volumeid_t * volid, const char * path,
-                struct afp_url * url, struct stat * stat)
+int afp_sl_stat(volumeid_t *volid, const char *path, struct afp_url *url,
+                struct stat *stat)
 {
     struct afp_server_stat_request request;
     struct afp_server_stat_response response;
@@ -456,9 +726,8 @@ int afp_sl_stat(volumeid_t * volid, const char * path,
     return response.header.result;
 }
 
-int afp_sl_open(volumeid_t * volid, const char * path,
-                struct afp_url * url, unsigned int *fileid,
-                unsigned int mode)
+int afp_sl_open(volumeid_t *volid, const char *path, struct afp_url *url,
+                unsigned int *fileid, unsigned int mode)
 {
     struct afp_server_open_request request;
     struct afp_server_open_response response;
@@ -504,6 +773,8 @@ int afp_sl_read(volumeid_t * volid, unsigned int fileid, unsigned int resource,
 {
     struct afp_server_read_request request;
     struct afp_server_read_response response;
+    char *tail = NULL;
+    size_t payload_size = 0;
     int ret;
 
     if (afp_sl_setup()) {
@@ -529,30 +800,37 @@ int afp_sl_read(volumeid_t * volid, unsigned int fileid, unsigned int resource,
                                   sizeof(response));
 
     if (ret < 0) {
-        printf("Error reading read response header\n");
-        close(connection.fd);
-        connection.fd = 0;
+        stateless_log_message(LOG_ERR,
+                              "Error reading read response header");
+        close_connection();
+        return AFP_SERVER_RESULT_ERROR;
+    }
+
+    if (read_response_tail(response.header.len, sizeof(response), &tail,
+                           &payload_size)
+            < 0) {
+        stateless_log_message(LOG_ERR,
+                              "Error reading read response payload");
+        close_connection();
         return AFP_SERVER_RESULT_ERROR;
     }
 
     if (response.header.result != AFP_SERVER_RESULT_OKAY) {
+        free(tail);
         *received = 0;
         *eof = 0;
         return response.header.result;
     }
 
-    *received = response.received;
-    *eof = response.eof;
-    /* Read the data directly into the user buffer */
-    ret = read_bytes_with_timeout(connection.fd, data, *received);
-
-    if (ret < 0) {
-        printf("Error reading read data payload\n");
-        close(connection.fd);
-        connection.fd = 0;
+    if (payload_size != response.received || payload_size > length) {
+        free(tail);
         return AFP_SERVER_RESULT_ERROR;
     }
 
+    *received = response.received;
+    *eof = response.eof;
+    memcpy(data, tail, payload_size);
+    free(tail);
     return response.header.result;
 }
 
@@ -562,6 +840,8 @@ int afp_sl_write(volumeid_t * volid, unsigned int fileid, unsigned int resource,
 {
     struct afp_server_write_request request;
     struct afp_server_write_response response;
+    char *tail = NULL;
+    size_t payload_size = 0;
     int ret;
 
     if (afp_sl_setup()) {
@@ -587,9 +867,9 @@ int afp_sl_write(volumeid_t * volid, unsigned int fileid, unsigned int resource,
     ret = write_bytes(connection.fd, data, size);
 
     if (ret < 0) {
-        printf("Error writing data payload\n");
-        close(connection.fd);
-        connection.fd = 0;
+        stateless_log_message(LOG_ERR,
+                              "Error writing data payload to afpsld");
+        close_connection();
         return AFP_SERVER_RESULT_ERROR;
     }
 
@@ -598,11 +878,21 @@ int afp_sl_write(volumeid_t * volid, unsigned int fileid, unsigned int resource,
                                   sizeof(response));
 
     if (ret < 0) {
-        printf("Error reading write response\n");
-        close(connection.fd);
-        connection.fd = 0;
+        stateless_log_message(LOG_ERR, "Error reading write response");
+        close_connection();
         return AFP_SERVER_RESULT_ERROR;
     }
+
+    if (read_response_tail(response.header.len, sizeof(response), &tail,
+                           &payload_size)
+            < 0
+            || payload_size != 0) {
+        free(tail);
+        close_connection();
+        return AFP_SERVER_RESULT_ERROR;
+    }
+
+    free(tail);
 
     if (response.header.result != AFP_SERVER_RESULT_OKAY) {
         *written = 0;
@@ -614,9 +904,8 @@ int afp_sl_write(volumeid_t * volid, unsigned int fileid, unsigned int resource,
 }
 
 static int metadata_call(unsigned int command, volumeid_t *volid,
-                         const char *path, const char *name,
-                         void *value, size_t size,
-                         unsigned long long offset, int flags,
+                         const char *path, const char *name, void *value,
+                         size_t size, unsigned long long offset, int flags,
                          int send_value)
 {
     struct afp_server_metadata_request *request;
@@ -625,18 +914,19 @@ static int metadata_call(unsigned int command, volumeid_t *volid,
     size_t request_len = base + (send_value ? size : 0);
     int ret;
     size_t payload_size;
+    size_t tail_content_size;
+    size_t tail_size;
+    char *tail = NULL;
 
     if (!volid || !path
             || strnlen(path, sizeof(request->path)) >= sizeof(request->path)
-            || size > AFP_SL_METADATA_CHUNK
-            || (name
-                && strnlen(name, sizeof(request->name)) >= sizeof(request->name))
+            || size > AFP_SL_METADATA_CHUNK || (name
+                    && strnlen(name, sizeof(request->name)) >= sizeof(request->name))
             || ((command == AFP_SERVER_COMMAND_GETXATTR
                  || command == AFP_SERVER_COMMAND_SETXATTR
-                 || command == AFP_SERVER_COMMAND_REMOVEXATTR)
-                && (!name || name[0] == '\0'))
-            || (command == AFP_SERVER_COMMAND_SETFINDERINFO && size != 32)
-            || (!value && size > 0 && send_value)) {
+                 || command == AFP_SERVER_COMMAND_REMOVEXATTR) && (!name || name[0] == '\0'))
+            || (command == AFP_SERVER_COMMAND_SETFINDERINFO && size != 32) || (!value
+                    && size > 0 && send_value)) {
         return -EINVAL;
     }
 
@@ -678,45 +968,47 @@ static int metadata_call(unsigned int command, volumeid_t *volid,
                                   sizeof(response));
 
     if (ret < 0) {
-        close(connection.fd);
-        connection.fd = 0;
+        close_connection();
         return -ECONNRESET;
     }
 
-    if (response.header.len < sizeof(response)
-            || response.header.len > sizeof(response) + AFP_SL_METADATA_CHUNK) {
-        close(connection.fd);
-        connection.fd = 0;
+    if (response.header.len < sizeof(response) + sizeof(struct
+            afp_server_log_footer)
+            || response.header.len > sizeof(response) + AFP_SL_METADATA_CHUNK +
+            AFP_SERVER_LOG_BUFFER_SIZE + sizeof(struct afp_server_log_footer)) {
+        close_connection();
         return -EPROTO;
     }
 
-    payload_size = response.header.len - sizeof(response);
+    tail_size = response.header.len - sizeof(response);
+    tail = malloc(tail_size);
+
+    if (!tail || read_bytes_with_timeout(connection.fd, tail, tail_size) < 0
+            || afp_sl_response_content_length(tail, tail_size, &tail_content_size) < 0
+            || afp_sl_dispatch_response_logs(tail, tail_size) < 0) {
+        free(tail);
+        close_connection();
+        return -ECONNRESET;
+    }
+
+    payload_size = tail_content_size;
 
     if (payload_size > 0 && response.size != payload_size) {
-        close(connection.fd);
-        connection.fd = 0;
+        close_connection();
+        free(tail);
         return -EPROTO;
     }
 
     if (payload_size > 0) {
         if (!value || payload_size > size) {
-            char discard[AFP_SL_METADATA_CHUNK];
-
-            if (read_bytes_with_timeout(connection.fd, discard, payload_size) < 0) {
-                close(connection.fd);
-                connection.fd = 0;
-                return -ECONNRESET;
-            }
-
+            free(tail);
             return -ERANGE;
         }
 
-        if (read_bytes_with_timeout(connection.fd, value, payload_size) < 0) {
-            close(connection.fd);
-            connection.fd = 0;
-            return -ECONNRESET;
-        }
+        memcpy(value, tail, payload_size);
     }
+
+    free(tail);
 
     if (response.error < 0) {
         return response.error;
@@ -728,8 +1020,8 @@ static int metadata_call(unsigned int command, volumeid_t *volid,
 int afp_sl_getxattr(volumeid_t *volid, const char *path, const char *name,
                     void *value, size_t size)
 {
-    return metadata_call(AFP_SERVER_COMMAND_GETXATTR, volid, path, name,
-                         value, size, 0, 0, 0);
+    return metadata_call(AFP_SERVER_COMMAND_GETXATTR, volid, path, name, value,
+                         size, 0, 0, 0);
 }
 
 int afp_sl_setxattr(volumeid_t *volid, const char *path, const char *name,
@@ -742,25 +1034,25 @@ int afp_sl_setxattr(volumeid_t *volid, const char *path, const char *name,
 int afp_sl_listxattr(volumeid_t *volid, const char *path, char *list,
                      size_t size)
 {
-    return metadata_call(AFP_SERVER_COMMAND_LISTXATTR, volid, path, NULL,
-                         list, size, 0, 0, 0);
+    return metadata_call(AFP_SERVER_COMMAND_LISTXATTR, volid, path, NULL, list,
+                         size, 0, 0, 0);
 }
 
 int afp_sl_removexattr(volumeid_t *volid, const char *path, const char *name)
 {
-    return metadata_call(AFP_SERVER_COMMAND_REMOVEXATTR, volid, path, name,
-                         NULL, 0, 0, 0, 0);
+    return metadata_call(AFP_SERVER_COMMAND_REMOVEXATTR, volid, path, name, NULL,
+                         0, 0, 0, 0);
 }
 
-int afp_sl_getfinderinfo(volumeid_t *volid, const char *path,
-                         void *value, size_t size)
+int afp_sl_getfinderinfo(volumeid_t *volid, const char *path, void *value,
+                         size_t size)
 {
     return metadata_call(AFP_SERVER_COMMAND_GETFINDERINFO, volid, path, NULL,
                          value, size, 0, 0, 0);
 }
 
-int afp_sl_setfinderinfo(volumeid_t *volid, const char *path,
-                         const void *value, size_t size)
+int afp_sl_setfinderinfo(volumeid_t *volid, const char *path, const void *value,
+                         size_t size)
 {
     return metadata_call(AFP_SERVER_COMMAND_SETFINDERINFO, volid, path, NULL,
                          (void *)value, size, 0, 0, 1);
@@ -772,8 +1064,8 @@ int afp_sl_removefinderinfo(volumeid_t *volid, const char *path)
                          NULL, 0, 0, 0, 0);
 }
 
-int afp_sl_getresourcefork(volumeid_t *volid, const char *path,
-                           void *value, size_t size, unsigned long long offset)
+int afp_sl_getresourcefork(volumeid_t *volid, const char *path, void *value,
+                           size_t size, unsigned long long offset)
 {
     return metadata_call(AFP_SERVER_COMMAND_GETRESOURCEFORK, volid, path, NULL,
                          value, size, offset, 0, 0);
@@ -789,12 +1081,12 @@ int afp_sl_setresourcefork(volumeid_t *volid, const char *path,
 
 int afp_sl_removeresourcefork(volumeid_t *volid, const char *path)
 {
-    return metadata_call(AFP_SERVER_COMMAND_REMOVERESOURCEFORK, volid, path,
-                         NULL, NULL, 0, 0, 0, 0);
+    return metadata_call(AFP_SERVER_COMMAND_REMOVERESOURCEFORK, volid, path, NULL,
+                         NULL, 0, 0, 0, 0);
 }
 
-int afp_sl_creat(volumeid_t * volid, const char * path,
-                 struct afp_url * url, mode_t mode)
+int afp_sl_creat(volumeid_t *volid, const char *path, struct afp_url *url,
+                 mode_t mode)
 {
     struct afp_server_creat_request request;
     struct afp_server_creat_response response;
@@ -831,8 +1123,8 @@ int afp_sl_creat(volumeid_t * volid, const char * path,
     return response.header.result;
 }
 
-int afp_sl_chmod(volumeid_t * volid, const char * path,
-                 struct afp_url * url, mode_t mode)
+int afp_sl_chmod(volumeid_t *volid, const char *path, struct afp_url *url,
+                 mode_t mode)
 {
     struct afp_server_chmod_request request;
     struct afp_server_chmod_response response;
@@ -869,8 +1161,8 @@ int afp_sl_chmod(volumeid_t * volid, const char * path,
     return response.header.result;
 }
 
-int afp_sl_rename(volumeid_t * volid, const char * path_from,
-                  const char *path_to, struct afp_url * url)
+int afp_sl_rename(volumeid_t *volid, const char *path_from, const char *path_to,
+                  struct afp_url *url)
 {
     struct afp_server_rename_request request;
     struct afp_server_rename_response response;
@@ -905,8 +1197,7 @@ int afp_sl_rename(volumeid_t * volid, const char * path_from,
     return response.header.result;
 }
 
-int afp_sl_unlink(volumeid_t * volid, const char * path,
-                  struct afp_url * url)
+int afp_sl_unlink(volumeid_t *volid, const char *path, struct afp_url *url)
 {
     struct afp_server_unlink_request request;
     struct afp_server_unlink_response response;
@@ -942,8 +1233,8 @@ int afp_sl_unlink(volumeid_t * volid, const char * path,
     return response.header.result;
 }
 
-int afp_sl_truncate(volumeid_t * volid, const char * path,
-                    struct afp_url * url, unsigned long long offset)
+int afp_sl_truncate(volumeid_t *volid, const char *path, struct afp_url *url,
+                    unsigned long long offset)
 {
     struct afp_server_truncate_request request;
     struct afp_server_truncate_response response;
@@ -980,8 +1271,8 @@ int afp_sl_truncate(volumeid_t * volid, const char * path,
     return response.header.result;
 }
 
-int afp_sl_utime(volumeid_t * volid, const char * path,
-                 struct afp_url * url, struct utimbuf * times)
+int afp_sl_utime(volumeid_t *volid, const char *path, struct afp_url *url,
+                 struct utimbuf *times)
 {
     struct afp_server_utime_request request;
     struct afp_server_utime_response response;
@@ -1018,8 +1309,8 @@ int afp_sl_utime(volumeid_t * volid, const char * path,
     return response.header.result;
 }
 
-int afp_sl_mkdir(volumeid_t * volid, const char * path,
-                 struct afp_url * url, mode_t mode)
+int afp_sl_mkdir(volumeid_t *volid, const char *path, struct afp_url *url,
+                 mode_t mode)
 {
     struct afp_server_mkdir_request request;
     struct afp_server_mkdir_response response;
@@ -1056,8 +1347,7 @@ int afp_sl_mkdir(volumeid_t * volid, const char * path,
     return response.header.result;
 }
 
-int afp_sl_rmdir(volumeid_t * volid, const char * path,
-                 struct afp_url * url)
+int afp_sl_rmdir(volumeid_t *volid, const char *path, struct afp_url *url)
 {
     struct afp_server_rmdir_request request;
     struct afp_server_rmdir_response response;
@@ -1093,8 +1383,8 @@ int afp_sl_rmdir(volumeid_t * volid, const char * path,
     return response.header.result;
 }
 
-int afp_sl_statfs(volumeid_t * volid, const char * path,
-                  struct afp_url * url, struct statvfs * stat)
+int afp_sl_statfs(volumeid_t *volid, const char *path, struct afp_url *url,
+                  struct statvfs *stat)
 {
     struct afp_server_statfs_request request;
     struct afp_server_statfs_response response;
@@ -1161,8 +1451,7 @@ int afp_sl_close(volumeid_t *volid, unsigned int fileid)
 
 int afp_sl_readdir(volumeid_t * volid, const char * path, struct afp_url * url,
                    int start, int count, unsigned int *numfiles,
-                   struct afp_file_info_basic **data,
-                   int *eod)
+                   struct afp_file_info_basic **data, int *eod)
 {
     struct afp_server_readdir_request req;
     struct afp_server_readdir_response * mainrep;
@@ -1196,7 +1485,8 @@ int afp_sl_readdir(volumeid_t * volid, const char * path, struct afp_url * url,
         tmppath = "/";
     }
 
-    /* Ensure we request at least 256 files if the user asks for fewer (but > 0) */
+    /* Ensure we request at least 256 files
+     * if the user asks for fewer (but > 0) */
     requested_count = (count > 0 && count < 256) ? 256 : count;
 
     /* Loop to fetch all requested files or until EOD */
@@ -1290,7 +1580,8 @@ int afp_sl_readdir(volumeid_t * volid, const char * path, struct afp_url * url,
             eod_flag = 1;
         }
 
-        /* Safety break if daemon returns 0 files but no EOD to prevent infinite loop */
+        /* Safety break if daemon returns 0 files
+         * but no EOD to prevent infinite loop */
         if (batch_received == 0 && !eod_flag) {
             break;
         }
@@ -1306,9 +1597,8 @@ int afp_sl_readdir(volumeid_t * volid, const char * path, struct afp_url * url,
     return 0;
 }
 
-int afp_sl_getvols(struct afp_url * url, unsigned int start,
-                   unsigned int count, unsigned int *numvols,
-                   struct afp_volume_summary * vols)
+int afp_sl_getvols(struct afp_url *url, unsigned int start, unsigned int count,
+                   unsigned int *numvols, struct afp_volume_summary *vols)
 {
     struct afp_server_getvols_request req;
     int ret;
@@ -1336,8 +1626,7 @@ int afp_sl_getvols(struct afp_url * url, unsigned int start,
     }
 
     response = (void *) connection.data;
-    memcpy(vols,
-           ((char *)response) + sizeof(struct afp_server_getvols_response),
+    memcpy(vols, ((char *) response) + sizeof(struct afp_server_getvols_response),
            response->num * sizeof(struct afp_volume_summary));
     *numvols = response->num;
     return response->header.result;
@@ -1350,21 +1639,21 @@ int afp_sl_getvols(struct afp_url * url, unsigned int start,
  * Sets error to:
  * 0:
  *      No error
- * -ENONET:
+ * ENONET:
  *      could not get the address of the server
- * -ENOMEM:
+ * ENOMEM:
  *      could not allocate memory
- * -ETIMEDOUT:
+ * ETIMEDOUT:
  *      timed out waiting for connection
- * -ENETUNREACH:
+ * ENETUNREACH:
  *      Server unreachable
- * -EISCONN:
+ * EISCONN:
  *      Connection already established
- * -ECONNREFUSED:
+ * ECONNREFUSED:
  *     Remote server has refused the connection
- * -EACCES, -EPERM, -EADDRINUSE, -EAFNOSUPPORT, -EAGAIN, -EALREADY, -EBADF,
- * -EFAULT, -EINPROGRESS, -EINTR, -ENOTSOCK, -EINVAL, -EMFILE, -ENFILE,
- * -ENOBUFS, -EPROTONOSUPPORT:
+ * EACCES, EPERM, EADDRINUSE, EAFNOSUPPORT, EAGAIN, EALREADY, EBADF,
+ * EFAULT, EINPROGRESS, EINTR, ENOTSOCK, EINVAL, EMFILE, ENFILE,
+ * ENOBUFS, EPROTONOSUPPORT:
  *     Internal error
  *
  * Returns:
@@ -1372,12 +1661,11 @@ int afp_sl_getvols(struct afp_url * url, unsigned int start,
  * -1: An error occurred
  */
 
-int afp_sl_connect(struct afp_url * url, unsigned int uam_mask,
-                   serverid_t *id, char *loginmesg, int *error)
+int afp_sl_connect(struct afp_url *url, unsigned int uam_mask, serverid_t *id,
+                   char *loginmesg, int *error)
 {
     struct afp_server_connect_request req;
     const struct afp_server_connect_response *resp;
-    const char *t;
     int ret;
 
     if (afp_sl_setup()) {
@@ -1416,21 +1704,13 @@ int afp_sl_connect(struct afp_url * url, unsigned int uam_mask,
         *error = resp->connect_error;
     }
 
-    /* If there's additional data (log messages), print it */
-    if (connection.len > sizeof(struct afp_server_connect_response)) {
-        t = connection.data + sizeof(struct afp_server_connect_response);
-
-        if (connection.print) {
-            connection.print(t);
-        }
-    }
-
-    /* Treat "already connected" as success */
-    if (resp->header.result == AFP_SERVER_RESULT_OKAY ||
-            resp->header.result == AFP_SERVER_RESULT_ALREADY_CONNECTED) {
+    /* Treat "already connected" as success. For failures, return the
+     * protocol result while preserving the errno-style detail in *error. */
+    if (resp->header.result == AFP_SERVER_RESULT_OKAY
+            || resp->header.result == AFP_SERVER_RESULT_ALREADY_CONNECTED) {
         return 0;
     } else {
-        return resp->connect_error;
+        return resp->header.result;
     }
 }
 
@@ -1439,7 +1719,6 @@ int afp_sl_attach(struct afp_url * url, unsigned int volume_options,
 {
     struct afp_server_attach_request req;
     struct afp_server_attach_response * response;
-    const char *t;
     int ret;
 
     if (afp_sl_setup()) {
@@ -1467,12 +1746,6 @@ int afp_sl_attach(struct afp_url * url, unsigned int volume_options,
         return 0;
     }
 
-    t = connection.data + sizeof(struct afp_server_attach_response);
-
-    if (connection.print) {
-        connection.print(t);
-    }
-
     if (volumeid) {
         memcpy(volumeid, &response->volumeid, sizeof(volumeid_t));
     }
@@ -1489,7 +1762,6 @@ int afp_sl_attach(struct afp_url * url, unsigned int volume_options,
 int afp_sl_detach(volumeid_t *volumeid, struct afp_url * url)
 {
     struct afp_server_detach_request req;
-    const char *t;
     int ret;
     volumeid_t tmpvolid;
     volumeid_t *volid_p = volumeid;
@@ -1525,26 +1797,11 @@ int afp_sl_detach(volumeid_t *volumeid, struct afp_url * url)
 
     /* DETACH uses header.close=1, so daemon closed its side.
      * Close our side too to avoid reusing a stale connection. */
-    if (connection.fd > 0) {
-        close(connection.fd);
-        connection.fd = 0;
-    }
-
-    if (connection.len <= sizeof(struct afp_server_detach_response)) {
-        return 0;
-    }
-
-    t = connection.data + sizeof(struct afp_server_detach_response);
-
-    if (connection.print) {
-        connection.print(t);
-    }
-
+    close_connection();
     return ret;
 }
 
-int afp_sl_changepw(struct afp_url * url,
-                    const char *old_password,
+int afp_sl_changepw(struct afp_url *url, const char *old_password,
                     const char *new_password)
 {
     struct afp_server_changepw_request req;
@@ -1618,17 +1875,12 @@ int afp_sl_disconnect(serverid_t *id)
     /* Close socket after this command */
     req.header.close = 1;
     req.serverid = *id;
-    ret = send_to_daemon((char *) &req, sizeof(req),
-                         (char *) &response, sizeof(response));
+    ret = send_to_daemon((char *) &req, sizeof(req), (char *) &response,
+                         sizeof(response));
 
     if (ret == 0 && response.header.result == AFP_SERVER_RESULT_OKAY) {
         *id = NULL;
-
-        if (connection.fd > 0) {
-            close(connection.fd);
-            connection.fd = 0;
-        }
-
+        close_connection();
         return 0;
     }
 

--- a/daemon/stateless_internal.h
+++ b/daemon/stateless_internal.h
@@ -1,0 +1,12 @@
+#ifndef _STATELESS_INTERNAL_H_
+#define _STATELESS_INTERNAL_H_
+
+#include <stddef.h>
+
+int afp_sl_response_content_length(const char *response, size_t len,
+                                   size_t *content_len);
+int afp_sl_dispatch_response_logs(const char *response, size_t len);
+int afp_sl_read_framed_response(int fd, char *data, size_t capacity,
+                                size_t *response_len);
+
+#endif

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -305,6 +305,19 @@ the stateless library delegates connection management to a daemon process.
 - **Daemon-managed state**: Server and volume connections persist in the daemon, not the client process
 - **One-shot operations**: Each API call sends a request to the daemon via Unix socket and receives a response
 - **Process isolation**: Client process crashes don't affect active AFP connections managed by the daemon
+- **Consumer-owned logging**: Applications can route library and daemon messages into their own logging framework
+
+Register a logger before making stateless calls:
+
+    static void app_log(void *context, int level, const char *message)
+    {
+        /* level is one of the syslog LOG_* values. */
+    }
+
+    afp_sl_set_log_callback(app_log, application_context);
+
+The callback runs synchronously on the calling thread. Passing a null callback disables log delivery. Registration is
+process-global, matching the stateless library's process-global connection state.
 
 **Use cases:**
 
@@ -316,6 +329,10 @@ the stateless library delegates connection management to a daemon process.
 ### Stateless Protocol Communication
 
 The stateless library communicates with afpsld using a request/response protocol over Unix sockets:
+
+Every daemon response ends with a structured log trailer. Each record preserves its syslog severity, and libafpsl
+delivers the records through the registered callback after validating the complete response. This applies to fixed and
+streaming operations, including reads, writes, metadata calls, and directory listings.
 
 **Connection model:**
 

--- a/docs/manpages/afpcmd.1
+++ b/docs/manpages/afpcmd.1
@@ -67,7 +67,7 @@ and
 .Cm error .
 Default is
 .Cm notice .
-Logs are written to syslog.
+Logs are written to standard error and syslog.
 .It Fl M , Fl -metadata Ar mode
 Preserves FinderInfo, resource forks, generic extended attributes, modes,
 and modification times during transfers.

--- a/include/afp_ipc.h
+++ b/include/afp_ipc.h
@@ -1,6 +1,22 @@
 #ifndef _AFP_IPC_H_
 #define _AFP_IPC_H_
 
+#include <stdint.h>
+
+/* Structured logging trailer appended to stateless daemon responses. */
+#define AFP_SERVER_LOG_MAGIC UINT32_C(0x4146504c)
+#define AFP_SERVER_LOG_BUFFER_SIZE 4096
+
+struct afp_server_log_record {
+    int32_t level;
+    uint32_t message_len;
+};
+
+struct afp_server_log_footer {
+    uint32_t magic;
+    uint32_t log_len;
+};
+
 /* IPC command codes shared between daemon, FUSE, and client components */
 
 #define AFP_SERVER_COMMAND_MOUNT 1

--- a/include/afpsl.h
+++ b/include/afpsl.h
@@ -1,9 +1,11 @@
 #ifndef __AFPSL_H_
 #define __AFPSL_H_
 
+#include <syslog.h>
 #include <utime.h>
 
 #include "afp.h"
+#include "afp_ipc.h"
 #include "errno.h"
 
 /* Socket path for stateless daemon */
@@ -28,7 +30,7 @@ struct afp_file_info_basic {
 struct afpfsd_connect {
     int fd;
     unsigned int len;
-    char data[MAX_CLIENT_RESPONSE + 200];
+    char data[MAX_CLIENT_RESPONSE + AFP_SERVER_LOG_BUFFER_SIZE + 200];
     void (*print)(const char * text);
     char *shmem;
 };
@@ -41,7 +43,13 @@ struct afp_volume_summary {
 typedef void   *serverid_t;
 typedef void   *volumeid_t;
 
+/* loglevel uses the LOG_* values from syslog.h. The callback runs
+ * synchronously on the thread making the afp_sl_* call. */
+typedef void (*afp_sl_log_callback)(void *user_data, int loglevel,
+                                    const char *message);
+
 void afp_sl_conn_setup(void);
+void afp_sl_set_log_callback(afp_sl_log_callback callback, void *user_data);
 
 int afp_sl_exit(void);
 int afp_sl_status(const char * volumename, const char * servername,
@@ -108,17 +116,16 @@ int afp_sl_getxattr(volumeid_t *volid, const char *path, const char *name,
                     void *value, size_t size);
 int afp_sl_setxattr(volumeid_t *volid, const char *path, const char *name,
                     const void *value, size_t size, int flags);
-int afp_sl_listxattr(volumeid_t *volid, const char *path,
-                     char *list, size_t size);
+int afp_sl_listxattr(volumeid_t *volid, const char *path, char *list,
+                     size_t size);
 int afp_sl_removexattr(volumeid_t *volid, const char *path, const char *name);
-int afp_sl_getfinderinfo(volumeid_t *volid, const char *path,
-                         void *value, size_t size);
-int afp_sl_setfinderinfo(volumeid_t *volid, const char *path,
-                         const void *value, size_t size);
+int afp_sl_getfinderinfo(volumeid_t *volid, const char *path, void *value,
+                         size_t size);
+int afp_sl_setfinderinfo(volumeid_t *volid, const char *path, const void *value,
+                         size_t size);
 int afp_sl_removefinderinfo(volumeid_t *volid, const char *path);
-int afp_sl_getresourcefork(volumeid_t *volid, const char *path,
-                           void *value, size_t size,
-                           unsigned long long offset);
+int afp_sl_getresourcefork(volumeid_t *volid, const char *path, void *value,
+                           size_t size, unsigned long long offset);
 int afp_sl_setresourcefork(volumeid_t *volid, const char *path,
                            const void *value, size_t size,
                            unsigned long long offset);

--- a/include/meson.build
+++ b/include/meson.build
@@ -3,6 +3,7 @@ public_headers = files(
     'afp_ipc.h',
     'afp_protocol.h',
     'afp_server.h',
+    'afp_xattr.h',
     'afpfsd.h',
     'afpsl.h',
     'libafpclient.h',

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -92,6 +92,8 @@ struct afp_server *afp_server_full_connect(void * priv,
     }
 
     if ((ret = afp_server_connect(tmpserver, 1)) < 0) {
+        int connect_error = -ret;
+
         if (ret == -ETIMEDOUT) {
             log_for_client(priv, AFPFSD, LOG_ERR,
                            "Could not connect, never got a response to getstatus, %s", strerror(-ret));
@@ -101,6 +103,7 @@ struct afp_server *afp_server_full_connect(void * priv,
         }
 
         afp_server_remove(tmpserver);
+        errno = connect_error;
         goto error;
     }
 
@@ -122,11 +125,13 @@ struct afp_server *afp_server_full_connect(void * priv,
     if (!s) {
         s = afp_server_init(address);
 
-        if (afp_server_connect(s, 0) != 0) {
+        if ((ret = afp_server_connect(s, 0)) != 0) {
+            int connect_error = -ret;
             log_for_client(priv, AFPFSD, LOG_ERR,
                            "Connection to server failed with error: %s",
-                           strerror(errno));
+                           strerror(connect_error));
             afp_server_remove(s);
+            errno = connect_error;
             s = NULL;
             goto error;
         }

--- a/lib/dsi.c
+++ b/lib/dsi.c
@@ -778,9 +778,9 @@ void *dsi_incoming_attention(void * other)
                        ntohs(packet->header.requestid), mins);
         loop_disconnect(server);
         server->connect_state = SERVER_STATE_DISCONNECTED;
-        return NULL;
     }
 
+    afp_server_release(server);
     return NULL;
 }
 
@@ -1075,8 +1075,13 @@ process_packet:
                server->incoming_buffer,
                server->data_read);
         server->attention_len = server->data_read;
-        pthread_create(&thread, NULL,
-                       dsi_incoming_attention, server);
+        afp_server_hold(server);
+
+        if (pthread_create(&thread, NULL, dsi_incoming_attention, server) == 0) {
+            pthread_detach(thread);
+        } else {
+            afp_server_release(server);
+        }
     }
     break;
 

--- a/lib/log.c
+++ b/lib/log.c
@@ -17,11 +17,24 @@ void log_for_client(void * priv,
                     enum logtypes logtype, int loglevel, char *format, ...)
 {
     va_list ap;
+    size_t message_len;
     char new_message[MAX_ERROR_LEN];
     char escaped[MAX_ERROR_LEN * 4];
     va_start(ap, format);
     vsnprintf(new_message, MAX_ERROR_LEN, format, ap);
     va_end(ap);
+    message_len = strlen(new_message);
+
+    while (message_len > 0
+            && (new_message[message_len - 1] == '\r'
+                || new_message[message_len - 1] == '\n')) {
+        new_message[--message_len] = '\0';
+    }
+
+    if (message_len == 0) {
+        return;
+    }
+
     sanitize_text(new_message, escaped, sizeof(escaped));
     libafpclient->log_for_client(priv, logtype, loglevel, escaped);
 }

--- a/lib/server.c
+++ b/lib/server.c
@@ -5,6 +5,7 @@
  *
  */
 
+#include <errno.h>
 #include <string.h>
 #include <sys/time.h>
 #include <time.h>
@@ -32,6 +33,7 @@ struct afp_server *afp_server_complete_connection(
 {
     char loginmsg[AFP_LOGINMESG_LEN];
     int using_uam;
+    int connection_error;
     char mesg[MAX_ERROR_LEN];
     unsigned int len = 0;
     memset(loginmsg, 0, AFP_LOGINMESG_LEN);
@@ -50,6 +52,7 @@ struct afp_server *afp_server_complete_connection(
         log_for_client(priv, AFPFSD, LOG_ERR,
                        "Server cannot handle AFP version %d",
                        requested_version);
+        errno = EPROTONOSUPPORT;
         goto error;
     }
 
@@ -58,6 +61,7 @@ struct afp_server *afp_server_complete_connection(
     if (using_uam == -1) {
         log_for_client(priv, AFPFSD, LOG_ERR,
                        "Could not pick a matching UAM");
+        errno = EPROTONOSUPPORT;
         goto error;
     }
 
@@ -66,12 +70,14 @@ struct afp_server *afp_server_complete_connection(
     if (afp_server_login(server, mesg, &len, MAX_ERROR_LEN)) {
         log_for_client(priv, AFPFSD, LOG_ERR,
                        "Login error: %s", mesg);
+        errno = EACCES;
         goto error;
     }
 
     if (afp_getsrvrparms(server)) {
         log_for_client(priv, AFPFSD, LOG_ERR,
                        "Could not get server parameters");
+        errno = EPROTO;
         goto error;
     }
 
@@ -94,6 +100,8 @@ struct afp_server *afp_server_complete_connection(
     server->connect_state = SERVER_STATE_CONNECTED;
     return server;
 error:
+    connection_error = errno;
     afp_server_remove(server);
+    errno = connection_error;
     return NULL;
 }

--- a/test/meson.build
+++ b/test/meson.build
@@ -29,3 +29,14 @@ log_test = executable(
 )
 
 test('log message escaping', log_test)
+
+stateless_log_test = executable(
+    'test_stateless_log',
+    sources: ['test_stateless_log.c'],
+    include_directories: [incdir, include_directories('../daemon')],
+    link_with: libafpsl,
+    dependencies: root_dependencies,
+    c_args: cflags,
+)
+
+test('stateless log callback and framing', stateless_log_test)

--- a/test/test_log.c
+++ b/test/test_log.c
@@ -17,7 +17,7 @@ static void capture_log_message(
 
 int main(void)
 {
-    char sanitized[sizeof("line 1\\r\\nline\\t2\\x01\\x7f")];
+    char sanitized[sizeof("line 1\\r\\nline\\t2\\x01\\x7f\\r\\n")];
     struct libafpclient test_client = {
         .unmount_volume = NULL,
         .log_for_client = capture_log_message,
@@ -25,13 +25,15 @@ int main(void)
         .scan_extra_fds = NULL,
         .loop_started = NULL,
     };
-    const char input[] = "line 1\r\nline\t2\x01\x7f";
-    const char expected[] = "line 1\\r\\nline\\t2\\x01\\x7f";
+    const char input[] = "line 1\r\nline\t2\x01\x7f\r\n";
+    const char expected_sanitized[] =
+        "line 1\\r\\nline\\t2\\x01\\x7f\\r\\n";
+    const char expected_log[] = "line 1\\r\\nline\\t2\\x01\\x7f";
     sanitize_text(input, sanitized, sizeof(sanitized));
 
-    if (strcmp(sanitized, expected) != 0) {
+    if (strcmp(sanitized, expected_sanitized) != 0) {
         fprintf(stderr, "sanitize expected: %s\nactual:            %s\n",
-                expected, sanitized);
+                expected_sanitized, sanitized);
         return 1;
     }
 
@@ -39,9 +41,9 @@ int main(void)
     log_for_client(NULL, AFPFSD, LOG_INFO, "%s", input);
     libafpclient_register(NULL);
 
-    if (strcmp(captured_message, expected) != 0) {
+    if (strcmp(captured_message, expected_log) != 0) {
         fprintf(stderr, "expected: %s\nactual:   %s\n",
-                expected, captured_message);
+                expected_log, captured_message);
         return 1;
     }
 

--- a/test/test_stateless_log.c
+++ b/test/test_stateless_log.c
@@ -1,0 +1,196 @@
+#include <fcntl.h>
+#include <signal.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <sys/wait.h>
+#include <syslog.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "afp_ipc.h"
+#include "afp_server.h"
+#include "afpsl.h"
+#include "stateless_internal.h"
+
+#define CHECK(condition)                                                       \
+    do {                                                                       \
+        if (!(condition)) {                                                    \
+            fprintf(stderr, "check failed at %s:%d: %s\n", __FILE__, __LINE__, \
+                #condition);                                                   \
+            return 1;                                                          \
+        }                                                                      \
+    } while (0)
+
+struct capture {
+    int calls;
+    int level;
+    char message[64];
+};
+
+static void capture_log(void *user_data, int loglevel, const char *message)
+{
+    struct capture *capture = user_data;
+    capture->calls++;
+    capture->level = loglevel;
+    snprintf(capture->message, sizeof(capture->message), "%s", message);
+}
+
+static size_t make_response(char *response, size_t capacity)
+{
+    struct afp_server_response_header header = { 0 };
+    struct afp_server_log_footer footer = {
+        .magic = AFP_SERVER_LOG_MAGIC,
+        .log_len = 0,
+    };
+    size_t len = sizeof(header) + sizeof(footer);
+
+    if (capacity < len) {
+        return 0;
+    }
+
+    header.len = (unsigned int) len;
+    memcpy(response, &header, sizeof(header));
+    memcpy(response + sizeof(header), &footer, sizeof(footer));
+    return len;
+}
+
+static int check_framed_read_errors(void)
+{
+    struct afp_server_response_header header = { 0 };
+    char response[64];
+    size_t response_len = 123;
+    int sockets[2];
+    int directory;
+    CHECK(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) == 0);
+    header.len = sizeof(header) + sizeof(struct afp_server_log_footer);
+    CHECK(write(sockets[1], &header, sizeof(header))
+          == (ssize_t) sizeof(header));
+    close(sockets[1]);
+    CHECK(afp_sl_read_framed_response(sockets[0], response, sizeof(response),
+                                      &response_len) == -1);
+    CHECK(response_len == 0);
+    close(sockets[0]);
+    CHECK(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) == 0);
+    header.len = sizeof(response) + 1;
+    CHECK(write(sockets[1], &header, sizeof(header))
+          == (ssize_t) sizeof(header));
+    CHECK(afp_sl_read_framed_response(sockets[0], response, sizeof(response),
+                                      &response_len) == -1);
+    CHECK(response_len == 0);
+    close(sockets[0]);
+    close(sockets[1]);
+    directory = open(".", O_RDONLY);
+    CHECK(directory >= 0);
+    CHECK(afp_sl_read_framed_response(directory, response, sizeof(response),
+                                      &response_len) == -1);
+    CHECK(response_len == 0);
+    close(directory);
+    return 0;
+}
+
+static volatile sig_atomic_t alarm_received;
+
+static void handle_alarm(int signal_number)
+{
+    (void) signal_number;
+    alarm_received = 1;
+}
+
+static int check_interrupted_framed_read(void)
+{
+    struct sigaction action = { 0 };
+    struct sigaction old_action;
+    struct itimerval timer = { 0 };
+    struct timespec delay = { .tv_nsec = 200000000 };
+    char expected[64];
+    char response[64];
+    size_t expected_len;
+    size_t response_len;
+    pid_t child;
+    int sockets[2];
+    int status;
+    expected_len = make_response(expected, sizeof(expected));
+    CHECK(expected_len > 0);
+    CHECK(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) == 0);
+    child = fork();
+    CHECK(child >= 0);
+
+    if (child == 0) {
+        close(sockets[0]);
+        nanosleep(&delay, NULL);
+
+        if (write(sockets[1], expected, expected_len)
+                != (ssize_t) expected_len) {
+            _exit(1);
+        }
+
+        close(sockets[1]);
+        _exit(0);
+    }
+
+    close(sockets[1]);
+    action.sa_handler = handle_alarm;
+    sigemptyset(&action.sa_mask);
+    CHECK(sigaction(SIGALRM, &action, &old_action) == 0);
+    timer.it_value.tv_usec = 50000;
+    CHECK(setitimer(ITIMER_REAL, &timer, NULL) == 0);
+    CHECK(afp_sl_read_framed_response(sockets[0], response, sizeof(response),
+                                      &response_len) == 0);
+    timer.it_value.tv_usec = 0;
+    CHECK(setitimer(ITIMER_REAL, &timer, NULL) == 0);
+    CHECK(sigaction(SIGALRM, &old_action, NULL) == 0);
+    CHECK(alarm_received == 1);
+    CHECK(response_len == expected_len);
+    CHECK(memcmp(response, expected, expected_len) == 0);
+    close(sockets[0]);
+    CHECK(waitpid(child, &status, 0) == child);
+    CHECK(WIFEXITED(status) && WEXITSTATUS(status) == 0);
+    return 0;
+}
+
+int main(void)
+{
+    const char payload[] = "DATA";
+    const char message[] = "daemon\nwarning";
+    const char expected_message[] = "daemon\\nwarning";
+    char response[sizeof(payload) - 1 + sizeof(struct afp_server_log_record) +
+                  sizeof(message) - 1 + sizeof(struct afp_server_log_footer)];
+    struct afp_server_log_record record = {
+        .level = LOG_WARNING,
+        .message_len = sizeof(message) - 1,
+    };
+    struct afp_server_log_footer footer = {
+        .magic = AFP_SERVER_LOG_MAGIC,
+        .log_len = sizeof(record) + sizeof(message) - 1,
+    };
+    struct capture capture = { 0 };
+    size_t pos = 0;
+    size_t content_len = 0;
+    memcpy(response + pos, payload, sizeof(payload) - 1);
+    pos += sizeof(payload) - 1;
+    memcpy(response + pos, &record, sizeof(record));
+    pos += sizeof(record);
+    memcpy(response + pos, message, sizeof(message) - 1);
+    pos += sizeof(message) - 1;
+    memcpy(response + pos, &footer, sizeof(footer));
+    afp_sl_set_log_callback(capture_log, &capture);
+    afp_sl_conn_setup();
+    CHECK(afp_sl_response_content_length(response, sizeof(response),
+                                         &content_len)
+          == 0);
+    CHECK(content_len == sizeof(payload) - 1);
+    CHECK(afp_sl_dispatch_response_logs(response, sizeof(response)) == 0);
+    CHECK(capture.calls == 1);
+    CHECK(capture.level == LOG_WARNING);
+    CHECK(strcmp(capture.message, expected_message) == 0);
+    footer.magic = 0;
+    memcpy(response + sizeof(response) - sizeof(footer), &footer, sizeof(footer));
+    CHECK(afp_sl_response_content_length(response, sizeof(response),
+                                         &content_len)
+          == -1);
+    CHECK(check_framed_read_errors() == 0);
+    CHECK(check_interrupted_framed_read() == 0);
+    return 0;
+}


### PR DESCRIPTION
Allow stateless-library consumers to install a process-wide callback with an opaque context pointer and syslog severity. Route both local diagnostics and daemon-generated messages through that callback, while retaining a stderr default and teaching afpcmd to mirror its messages to stderr and syslog.

Replace the daemon's appended text diagnostics with bounded, structured log records and a validated trailer on every response. Preserve message severity, associate command logs with the requesting client, strip trailing newlines, and sanitize messages at the consumer boundary.

Make stateless IPC reads honor the response length rather than individual read boundaries. Retry interrupted reads and writes, reject truncated, oversized, or malformed responses, and account for log trailers in fixed-size, streaming, and metadata operations so payload data cannot be mistaken for diagnostics.

Report daemon startup failures reliably through a close-on-exec pipe and keep the callback registration intact across connection setup. Correct connection failure reporting by preserving errno through server teardown and by returning the protocol result separately from the detailed connection error.

Hold a server reference while an asynchronous DSI attention handler is active, detach successfully created handler threads, and release the reference on both thread creation failure and completion. This prevents the handler from using a freed server or leaking joinable-thread resources.

Install afp_xattr.h with the other public headers, document the new logging contract and wire format, and add coverage for callback dispatch, framing, malformed replies, interrupted reads, and newline normalization.

Touch up code formatting in surrounding code, including normalized linebreaks for long lines, and alphabetical header include order.