### PR TITLE
harden client logging format handling

### DIFF
--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -65,6 +65,26 @@ The major subcomponents of libafpclient are all in the lib/ directory.
 
 They are:
 
+### Logging
+
+`log_for_client()` is the shared logging entry point. Public consumers pass it a complete message string; it trims
+trailing newlines, escapes control characters, and forwards the sanitized text to the registered client logger.
+If the message pointer is null, it is logged as `(null)`.
+
+Inside the netatalk-client build, `log_for_client()` is also available as a checked printf-style convenience macro.
+Internal callers may use literal format strings:
+
+    log_for_client(priv, AFPFSD, LOG_WARNING, "Could not open %s", path);
+
+Do not pass runtime or remote-controlled text as the format string. If a message is already composed, log it through a
+literal `%s` format:
+
+    log_for_client(priv, AFPFSD, LOG_ERR, "%s", message);
+
+The underlying exported function remains the plain-message API for external users. Internal code that deliberately needs
+to call that function directly can use the parenthesized form `(log_for_client)(priv, AFPFSD, level, message)` to bypass
+the internal macro, but that should stay rare and explicit.
+
 ### Midlevel
 
 This is an API that simplifies the AFP functions that does some simplification

--- a/fuse/commands.c
+++ b/fuse/commands.c
@@ -423,7 +423,7 @@ static int volopen(struct fuse_client * c, struct afp_volume * volume)
     int rc = afp_connect_volume(volume, volume->server, mesg, &l, MAX_ERROR_LEN);
 
     if (mesg[0] != '\0') {
-        log_for_client((void *) c, AFPFSD, LOG_ERR, mesg);
+        (log_for_client)((void *) c, AFPFSD, LOG_ERR, mesg);
     }
 
     return rc;

--- a/fuse/fuse_error.c
+++ b/fuse/fuse_error.c
@@ -2,7 +2,7 @@
  *  fuse_error.c
  *
  *  Copyright (C) 2008 Alex deVries <alexthepuffin@gmail.com>
- *  Copyright (C) 2025 Daniel Markstedt <daniel@mindani.net>
+ *  Copyright (C) 2025-2026 Daniel Markstedt <daniel@mindani.net>
  *
  */
 
@@ -20,14 +20,18 @@
 
 /* Simple global capture state (not thread-safe, but adequate for mount startup) */
 static int captured_fd = -1;
-static int captured_stderr_fd = -1;  /* FD for captured stderr temp file */
+/* FD for captured stderr temp file */
+static int captured_stderr_fd = -1;
 static FILE *captured_stream = NULL;
 static fpos_t pos;
 
+#define FUSE_ERROR_PREFIX "FUSE error: "
+
 void report_fuse_errors(struct fuse_client * c)
 {
-    char buf[MAX_ERROR_LEN];
-    int len;
+    char buf[MAX_ERROR_LEN - sizeof(FUSE_ERROR_PREFIX)];
+    char message[MAX_ERROR_LEN];
+    ssize_t len;
 
     if (captured_stderr_fd < 0) {
         return;  /* No capture was started */
@@ -52,14 +56,16 @@ void report_fuse_errors(struct fuse_client * c)
         return;
     }
 
-    memset(buf, 0, MAX_ERROR_LEN);
-    len = read(captured_stderr_fd, buf, MAX_ERROR_LEN);
+    memset(buf, 0, sizeof(buf));
+    len = read(captured_stderr_fd, buf, sizeof(buf) - 1);
     close(captured_stderr_fd);
     captured_stderr_fd = -1;
 
     if (len > 0) {
-        log_for_client((void *)c, AFPFSD, LOG_ERR,
-                       "FUSE reported the following error: %s", buf);
+        buf[len] = '\0';
+        snprintf(message, sizeof(message),
+                 "%s%s", FUSE_ERROR_PREFIX, buf);
+        (log_for_client)((void *)c, AFPFSD, LOG_ERR, message);
     }
 }
 

--- a/include/libafpclient.h
+++ b/include/libafpclient.h
@@ -6,6 +6,11 @@
 #include <syslog.h>
 #include <sys/select.h>
 
+#ifdef AFPCLIENT_INTERNAL
+#include <stdarg.h>
+#include <stdio.h>
+#endif
+
 #define MAX_CLIENT_RESPONSE 16384
 
 
@@ -41,8 +46,40 @@ void signal_main_thread(void);
 
 void set_log_method(int m);
 
+/* Public logging API: message is complete text, not a printf format. */
 void log_for_client(void * priv,
-                    enum logtypes logtype, int loglevel, char *message, ...);
+                    enum logtypes logtype, int loglevel,
+                    const char *message);
+
+#ifdef AFPCLIENT_INTERNAL
+/* Internal convenience for literal printf-style formats. */
+static inline void log_for_clientf(void * priv,
+                                   enum logtypes logtype, int loglevel,
+                                   const char *format, ...)
+__attribute__((format(printf, 4, 5)));
+
+static inline void log_for_clientf(void * priv,
+                                   enum logtypes logtype, int loglevel,
+                                   const char *format, ...)
+{
+    va_list ap;
+    char message[MAX_ERROR_LEN];
+
+    if (format == NULL) {
+        log_for_client(priv, logtype, loglevel, "(null)");
+        return;
+    }
+
+    va_start(ap, format);
+    vsnprintf(message, sizeof(message), format, ap);
+    va_end(ap);
+    log_for_client(priv, logtype, loglevel, message);
+}
+
+#ifndef AFPCLIENT_NO_LOG_MACRO
+#define log_for_client(...) log_for_clientf(__VA_ARGS__)
+#endif
+#endif
 
 void stdout_log_for_client(void * priv,
                            enum logtypes logtype, int loglevel, const char *message);

--- a/lib/afp.c
+++ b/lib/afp.c
@@ -468,7 +468,7 @@ void afp_free_server(struct afp_server ** sp)
     for (p = server->command_requests; p;) {
         log_for_client(NULL, AFPFSD, LOG_NOTICE,
                        "FSLeft in queue: %p, id: %d command: %d",
-                       p, p->requestid, p->subcommand);
+                       (void *)p, p->requestid, p->subcommand);
         next = p->next;
         free(p);
         p = next;
@@ -899,7 +899,7 @@ int afp_server_connect(struct afp_server *server, int full)
             log_msg[LOG_MSG_SIZE - 1] = '\0';
         }
 
-        log_for_client(NULL, AFPFSD, LOG_NOTICE, log_msg);
+        (log_for_client)(NULL, AFPFSD, LOG_NOTICE, log_msg);
         server->fd = socket(address->ai_family,
                             address->ai_socktype, address->ai_protocol);
 

--- a/lib/log.c
+++ b/lib/log.c
@@ -7,22 +7,25 @@
  */
 
 #include <stdio.h>
-#include <stdarg.h>
 #include <string.h>
 #include <stdlib.h>
+#define AFPCLIENT_NO_LOG_MACRO
 #include "libafpclient.h"
 #include "utils.h"
 
 void log_for_client(void * priv,
-                    enum logtypes logtype, int loglevel, char *format, ...)
+                    enum logtypes logtype, int loglevel,
+                    const char *message)
 {
-    va_list ap;
     size_t message_len;
     char new_message[MAX_ERROR_LEN];
     char escaped[MAX_ERROR_LEN * 4];
-    va_start(ap, format);
-    vsnprintf(new_message, MAX_ERROR_LEN, format, ap);
-    va_end(ap);
+
+    if (message == NULL) {
+        message = "(null)";
+    }
+
+    snprintf(new_message, MAX_ERROR_LEN, "%s", message);
     message_len = strlen(new_message);
 
     while (message_len > 0
@@ -45,5 +48,9 @@ void stdout_log_for_client(
     __attribute__((unused)) int loglevel,
     const char *message)
 {
+    if (message == NULL) {
+        message = "(null)";
+    }
+
     printf("%s\n", message);
 }

--- a/meson.build
+++ b/meson.build
@@ -26,6 +26,7 @@ cflags = [
     '-DAFPFS_VERSION="' + afpfsng_version + '"',
     '-DBINDIR="' + bindir + '"',
     '-D_FILE_OFFSET_BITS=64',
+    '-DAFPCLIENT_INTERNAL',
 ]
 
 if 'afp' in get_option('enable-debugging')

--- a/test/test_log.c
+++ b/test/test_log.c
@@ -35,7 +35,11 @@ int main(int argc, char **argv)
     CHECK(strcmp(sanitized, expected_sanitized) == 0);
     libafpclient_register(&test_client);
     log_for_client(NULL, AFPFSD, LOG_INFO, "%s", input);
-    libafpclient_register(NULL);
     CHECK(strcmp(captured_message, expected_log) == 0);
+    (log_for_client)(NULL, AFPFSD, LOG_INFO, input);
+    CHECK(strcmp(captured_message, expected_log) == 0);
+    (log_for_client)(NULL, AFPFSD, LOG_INFO, NULL);
+    libafpclient_register(NULL);
+    CHECK(strcmp(captured_message, "(null)") == 0);
     return test_tap_finish();
 }


### PR DESCRIPTION
Expose log_for_client as a plain-message API while keeping an internal checked printf-style macro for existing project call sites.

Avoid dynamic format strings for preformatted messages, terminate captured FUSE stderr safely, and document the logging rules for contributors.