### PR TITLE
introduce compatibility macro for unused attribute

### DIFF
--- a/cmdline/cmdline_afp.c
+++ b/cmdline/cmdline_afp.c
@@ -28,6 +28,7 @@
 #include "afp.h"
 #include "afpsl.h"
 #include "afp_server.h"
+#include "compat.h"
 #include "map_def.h"
 
 #include <string.h>
@@ -781,7 +782,7 @@ static void list_volumes(void)
     free(vols);
 }
 
-int com_pass(__attribute__((unused)) char *unused)
+int com_pass(char *unused _U_)
 {
     const char *old_password;
     const char *new_password;
@@ -2881,7 +2882,7 @@ int com_rmdir(char *arg)
     return 0;
 }
 
-int com_status(__attribute__((unused)) char *unused)
+int com_status(char *unused _U_)
 {
     char text[40960];
     unsigned int len = sizeof(text);
@@ -2897,7 +2898,7 @@ int com_status(__attribute__((unused)) char *unused)
     return 0;
 }
 
-int com_statvfs(__attribute__((unused)) char *unused)
+int com_statvfs(char *unused _U_)
 {
     struct statvfs stat;
     char server_path[AFP_MAX_PATH];
@@ -3112,7 +3113,7 @@ error:
 }
 
 /* Disconnect command - explicitly detach volume and terminate server connection */
-int com_disconnect(__attribute__((unused)) char *unused)
+int com_disconnect(char *unused _U_)
 {
     if (!connected) {
         printf("You're not connected to a server\n");
@@ -3137,7 +3138,7 @@ int com_disconnect(__attribute__((unused)) char *unused)
 }
 
 /* Exit command - detach from volume but remain connected */
-int com_exit(__attribute__((unused)) char *unused)
+int com_exit(char *unused _U_)
 {
     if (!connected) {
         printf("You're not connected to a server\n");
@@ -3156,7 +3157,7 @@ int com_exit(__attribute__((unused)) char *unused)
 }
 
 /* Print out the current working directory locally. */
-int com_lpwd(__attribute__((unused)) char *unused)
+int com_lpwd(char *unused _U_)
 {
     char dir[PATH_MAX];
 
@@ -3170,7 +3171,7 @@ int com_lpwd(__attribute__((unused)) char *unused)
 }
 
 /* Print out the current working directory. */
-int com_pwd(__attribute__((unused)) char *unused)
+int com_pwd(char *unused _U_)
 {
     if (!vol_id) {
         printf("You're not attached to a volume\n");
@@ -3196,8 +3197,7 @@ int cmdline_set_metadata_mode(const char *mode)
     return afp_metadata_mode_parse(mode, &transfer_metadata_mode);
 }
 
-static void cmdline_log_for_client(__attribute__((unused)) void * priv,
-                                   __attribute__((unused)) enum logtypes logtype,
+static void cmdline_log_for_client(void *priv _U_, enum logtypes logtype _U_,
                                    int loglevel, const char *message)
 {
     int type_rank = loglevel_to_rank(loglevel);
@@ -3210,7 +3210,7 @@ static void cmdline_log_for_client(__attribute__((unused)) void * priv,
     syslog(loglevel, "%s", message);
 }
 
-static void cmdline_stateless_log(__attribute__((unused)) void *user_data,
+static void cmdline_stateless_log(void *user_data _U_,
                                   int loglevel, const char *message)
 {
     cmdline_log_for_client(NULL, AFPFSD, loglevel, message);

--- a/cmdline/cmdline_main.c
+++ b/cmdline/cmdline_main.c
@@ -50,6 +50,7 @@
 #include "libafpclient.h"
 #include "utils.h"
 #include "cmdline_afp.h"
+#include "compat.h"
 
 static int running = 1;
 static int loop_started = 0;
@@ -144,7 +145,7 @@ static int char_is_quoted(char *string, int eindex)
    in case we want to do some simple parsing.  Return the array of matches,
    or NULL if there aren't any. */
 static char **filename_completion(const char *text,
-                                  int start, __attribute__((unused)) int end)
+                                  int start, int end _U_)
 {
     char **matches = NULL;
 
@@ -205,7 +206,7 @@ static void initialize_readline(void)
 }
 
 /* The user wishes to quit using this program.  Just set DONE non-zero. */
-static int com_quit(__attribute__((unused)) char *arg)
+static int com_quit(char *arg _U_)
 {
     cmdline_afp_exit();
     running = 0;
@@ -213,7 +214,7 @@ static int com_quit(__attribute__((unused)) char *arg)
 }
 
 /* Explicitly detach volume and terminate server connection, then exit. */
-static int com_close(__attribute__((unused)) char *arg)
+static int com_close(char *arg _U_)
 {
     com_disconnect(NULL);
     running = 0;
@@ -377,7 +378,7 @@ static int execute_line(char * line)
     return 0;
 }
 
-void *cmdline_ui(__attribute__((unused)) void * other)
+void *cmdline_ui(void * other _U_)
 {
     char *line;
     char *s, s2[ARG_LEN];
@@ -424,7 +425,7 @@ void cmdline_forced_ending_hook(void)
 
 static volatile int interrupt_count = 0;
 
-void earlyexit_handler(__attribute__((unused)) int signum)
+void earlyexit_handler(int signum _U_)
 {
     sigset_t mask;
 

--- a/cmdline/getstatus.c
+++ b/cmdline/getstatus.c
@@ -21,6 +21,7 @@
 
 #include "afp.h"
 #include "afp_protocol.h"
+#include "compat.h"
 #include "uams_def.h"
 #include "utils.h"
 
@@ -29,10 +30,9 @@
 static bool show_icon = false;
 static int log_min_rank;
 
-static void getstatus_log_for_client(
-    __attribute__((unused)) void *priv,
-    __attribute__((unused)) enum logtypes logtype,
-    int loglevel, const char *message)
+static void getstatus_log_for_client(void *priv _U_,
+                                     enum logtypes logtype _U_,
+                                     int loglevel, const char *message)
 {
     if (loglevel_to_rank(loglevel) < log_min_rank) {
         return;

--- a/daemon/daemon.c
+++ b/daemon/daemon.c
@@ -26,6 +26,7 @@
 #include "afp.h"
 #include "afp_server.h"
 #include "commands.h"
+#include "compat.h"
 #include "daemon.h"
 #include "daemon_socket.h"
 #include "dsi.h"
@@ -58,7 +59,7 @@ static void daemon_set_log_level(int loglevel)
 }
 
 static void daemon_log_for_client(void * priv,
-                                  __attribute__((unused)) enum logtypes logtype,
+                                  enum logtypes logtype _U_,
                                   int loglevel, const char *message)
 {
     struct daemon_client * c = priv;

--- a/daemon/daemon_client.c
+++ b/daemon/daemon_client.c
@@ -24,6 +24,7 @@
 #include "afp_server.h"
 #include "codepage.h"
 #include "commands.h"
+#include "compat.h"
 #include "daemon.h"
 #include "daemon_client.h"
 #include "dsi.h"
@@ -145,7 +146,7 @@ found:
  *
  */
 
-static int process_client_fds(fd_set * set, __attribute__((unused)) int max_fd,
+static int process_client_fds(fd_set * set, int max_fd _U_,
                               struct daemon_client **found)
 {
     struct daemon_client * c;

--- a/fuse/client.c
+++ b/fuse/client.c
@@ -57,8 +57,8 @@ static char *thisbin;
 static int client_log_min_rank = 2; /* Default to LOG_NOTICE */
 
 /* Log handler that filters by log level */
-static void client_log_for_client(__attribute__((unused)) void *priv,
-                                  __attribute__((unused)) enum logtypes logtype,
+static void client_log_for_client(void *priv _U_,
+                                  enum logtypes logtype _U_,
                                   int loglevel, const char *message)
 {
     int type_rank = loglevel_to_rank(loglevel);
@@ -451,8 +451,7 @@ static int send_command(int sock, char * msg, int len)
     return write(sock, msg, len);
 }
 
-static int do_exit(__attribute__((unused)) int argc,
-                   __attribute__((unused)) char **argv)
+static int do_exit(int argc _U_, char **argv _U_)
 {
     outgoing_len = 1;
     outgoing_buffer[0] = AFP_SERVER_COMMAND_EXIT;

--- a/fuse/commands.c
+++ b/fuse/commands.c
@@ -39,6 +39,7 @@
 #include "daemon.h"
 #include "uams_def.h"
 #include "codepage.h"
+#include "compat.h"
 #include "libafpclient.h"
 #include "map_def.h"
 #include "fuse_int.h"
@@ -161,8 +162,7 @@ error:
     return -1;
 }
 
-static int fuse_process_client_fds(fd_set * set,
-                                   __attribute__((unused)) int max_fd)
+static int fuse_process_client_fds(fd_set *set, int max_fd _U_)
 {
     struct fuse_client * c;
 
@@ -226,7 +226,7 @@ out:
 }
 
 static void fuse_log_for_client(void * priv,
-                                __attribute__((unused)) enum logtypes logtype,
+                                enum logtypes logtype _U_,
                                 int loglevel, const char *message)
 {
     struct fuse_client * c = priv;

--- a/fuse/fuse_int.c
+++ b/fuse/fuse_int.c
@@ -14,8 +14,6 @@
 
 #define HAVE_ARCH_STRUCT_FLOCK
 
-#include "afp.h"
-
 #include <fuse.h>
 #include <stdio.h>
 #include <string.h>
@@ -42,6 +40,9 @@
 #elif defined(HAVE_SYS_EXTATTR_H)
 #include <sys/extattr.h>
 #endif
+
+#include "afp.h"
+#include "compat.h"
 
 /* Define xattr constants if not provided by system headers */
 #ifndef XATTR_CREATE
@@ -309,20 +310,18 @@ static int fuse_removexattr(const char *path, const char *name)
 #if defined(__APPLE__) && FUSE_USE_VERSION >= 30
 static int fuse_readdir_darwin(const char *path, void *buf,
                                fuse_darwin_fill_dir_t filler,
-                               __attribute__((unused)) off_t offset,
-                               __attribute__((unused)) struct fuse_file_info *fi,
-                               __attribute__((unused)) enum fuse_readdir_flags flags)
+                               off_t offset _U_,
+                               struct fuse_file_info *fi _U_,
+                               enum fuse_readdir_flags flags _U_)
 #elif FUSE_USE_VERSION >= 30 && FUSE_NEW_API
 /* Linux FUSE 3.10+ with fuse_readdir_flags */
 static int fuse_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
-                        __attribute__((unused)) off_t offset,
-                        __attribute__((unused)) struct fuse_file_info *fi,
-                        __attribute__((unused)) enum fuse_readdir_flags flags)
+                        off_t offset _U_, struct fuse_file_info *fi _U_,
+                        enum fuse_readdir_flags flags _U_)
 #else
 /* BSD FUSE 3.x and FUSE 2.x - older API without fuse_readdir_flags */
 static int fuse_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
-                        __attribute__((unused)) off_t offset,
-                        __attribute__((unused)) struct fuse_file_info *fi)
+                        off_t offset _U_, struct fuse_file_info *fi _U_)
 #endif
 {
     struct afp_file_info * filebase = NULL, *p;
@@ -358,8 +357,7 @@ error:
     return ret;
 }
 
-static int fuse_mknod(const char *path, mode_t mode,
-                      __attribute__((unused)) dev_t dev)
+static int fuse_mknod(const char *path, mode_t mode, dev_t dev _U_)
 {
     int ret = 0;
     struct fuse_context * context = fuse_get_context();
@@ -549,15 +547,15 @@ static int fuse_opendir(const char *path, struct fuse_file_info *fi)
     return 0;
 }
 
-static int fuse_releasedir(__attribute__((unused)) const char *path,
-                           __attribute__((unused)) struct fuse_file_info *fi)
+static int fuse_releasedir(const char *path _U_,
+                           struct fuse_file_info *fi _U_)
 {
     return 0;
 }
 
-static int fuse_fsyncdir(__attribute__((unused)) const char *path,
-                         __attribute__((unused)) int datasync,
-                         __attribute__((unused)) struct fuse_file_info *fi)
+static int fuse_fsyncdir(const char *path _U_,
+                         int datasync _U_,
+                         struct fuse_file_info *fi _U_)
 {
     return 0;
 }
@@ -653,7 +651,7 @@ static int fuse_access(const char *path, int mask)
 
 #if FUSE_NEW_API
 static int fuse_chown(const char * path, uid_t uid, gid_t gid,
-                      __attribute__((unused)) struct fuse_file_info *fi)
+                      struct fuse_file_info *fi _U_)
 #else
 static int fuse_chown(const char * path, uid_t uid, gid_t gid)
 #endif
@@ -735,7 +733,7 @@ static int fuse_truncate(const char * path, off_t offset)
 
 #if FUSE_NEW_API
 static int fuse_chmod(const char * path, mode_t mode,
-                      __attribute__((unused)) struct fuse_file_info *fi)
+                      struct fuse_file_info *fi _U_)
 #else
 static int fuse_chmod(const char * path, mode_t mode)
 #endif
@@ -771,7 +769,7 @@ static int fuse_chmod(const char * path, mode_t mode)
 #if FUSE_USE_VERSION >= 30
 #if FUSE_NEW_API
 static int fuse_utimens(const char *path, const struct timespec tv[2],
-                        __attribute__((unused)) struct fuse_file_info *fi)
+                        struct fuse_file_info *fi _U_)
 #else
 static int fuse_utimens(const char *path, const struct timespec tv[2])
 #endif
@@ -842,7 +840,7 @@ static int fuse_utime(const char * path, struct utimbuf * timebuf)
 
 #endif
 
-static void afp_destroy(__attribute__((unused)) void * ignore)
+static void afp_destroy(void *ignore _U_)
 {
     struct afp_volume * volume =
         (struct afp_volume *)
@@ -1201,7 +1199,7 @@ static int fuse_setattr(const char *path, struct fuse_darwin_attr *attr,
 }
 
 static int fuse_getattr_darwin(const char *path, struct fuse_darwin_attr *attr,
-                               __attribute__((unused)) struct fuse_file_info *fi)
+                               struct fuse_file_info *fi _U_)
 {
     char *c;
     struct stat stbuf;
@@ -1251,7 +1249,7 @@ static int fuse_getattr_darwin(const char *path, struct fuse_darwin_attr *attr,
 #else
 #if FUSE_NEW_API
 static int fuse_getattr(const char *path, struct stat *stbuf,
-                        __attribute__((unused)) struct fuse_file_info *fi)
+                        struct fuse_file_info *fi _U_)
 #else
 static int fuse_getattr(const char *path, struct stat *stbuf)
 #endif
@@ -1336,7 +1334,7 @@ static void *afp_init(struct fuse_conn_info *conn, struct fuse_config *cfg)
 }
 
 #else
-static void *afp_init(__attribute__((unused)) struct fuse_conn_info * o)
+static void *afp_init(struct fuse_conn_info * o _U_)
 {
     struct afp_volume * vol = (struct afp_volume *)
                               ((struct fuse_context *)(fuse_get_context()))->private_data;
@@ -1355,7 +1353,7 @@ static void *afp_init(__attribute__((unused)) struct fuse_conn_info * o)
 
 #if defined(__APPLE__) && FUSE_USE_VERSION >= 30
 static int fuse_chflags(const char *path,
-                        __attribute__((unused)) struct fuse_file_info *fi,
+                        struct fuse_file_info *fi _U_,
                         unsigned int flags)
 {
     struct afp_volume *volume =

--- a/include/compat.h
+++ b/include/compat.h
@@ -1,6 +1,21 @@
 #ifndef _COMPAT_H_
 #define _COMPAT_H_
 
+/* Mark a declaration as intentionally unused when the compiler supports it. */
+#ifndef _U_
+#if defined(__has_attribute)
+#if __has_attribute(unused)
+#define _U_ __attribute__((unused))
+#else
+#define _U_
+#endif
+#elif defined(__GNUC__)
+#define _U_ __attribute__((unused))
+#else
+#define _U_
+#endif
+#endif
+
 /* Secure memory clearing - prefer memset_explicit (C23) over explicit_bzero */
 #if !defined(HAVE_MEMSET_EXPLICIT) && !defined(HAVE_EXPLICIT_BZERO)
 #include <stddef.h>

--- a/lib/afp.c
+++ b/lib/afp.c
@@ -33,6 +33,7 @@
 #include "did.h"
 #include "forklist.h"
 #include "codepage.h"
+#include "compat.h"
 
 struct afp_versions      afp_versions[] = {
     { "AFPVersion 1.1", 11 },
@@ -132,10 +133,10 @@ int (*afp_replies[])(struct afp_server * server, char * buf, unsigned int len,
 
 /* This is the simplest afp reply */
 static int afp_blank_reply(
-    __attribute__((unused)) struct afp_server *server,
+    struct afp_server *server _U_,
     char *buf,
-    __attribute__((unused)) unsigned int size,
-    __attribute__((unused)) void * ignored
+    unsigned int size _U_,
+    void *ignored _U_
 )
 {
     struct {

--- a/lib/log.c
+++ b/lib/log.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <stdlib.h>
 #define AFPCLIENT_NO_LOG_MACRO
+#include "compat.h"
 #include "libafpclient.h"
 #include "utils.h"
 
@@ -43,9 +44,9 @@ void log_for_client(void * priv,
 }
 
 void stdout_log_for_client(
-    __attribute__((unused)) void * priv,
-    __attribute__((unused)) enum logtypes logtype,
-    __attribute__((unused)) int loglevel,
+    void *priv _U_,
+    enum logtypes logtype _U_,
+    int loglevel _U_,
     const char *message)
 {
     if (message == NULL) {

--- a/lib/loop.c
+++ b/lib/loop.c
@@ -18,6 +18,7 @@
 #include <sys/time.h>
 
 #include "afp.h"
+#include "compat.h"
 #include "dsi.h"
 #include "utils.h"
 
@@ -132,7 +133,7 @@ void signal_main_thread(void)
 }
 
 static int ending = 0;
-void *just_end_it_now(__attribute__((unused)) void * ignore)
+void *just_end_it_now(void * ignore _U_)
 {
     if (ending) {
         return NULL;
@@ -201,8 +202,7 @@ void loop_disconnect(struct afp_server *s)
     s->need_resume = 1;
 }
 
-static int process_server_fds(fd_set * set, __attribute__((unused)) int max_fd,
-                              int **onfd)
+static int process_server_fds(fd_set *set, int max_fd _U_, int **onfd)
 {
     struct afp_server * s;
     int ret;
@@ -254,8 +254,7 @@ static int process_server_fds(fd_set * set, __attribute__((unused)) int max_fd,
     return 0;
 }
 
-static void deal_with_server_signals(__attribute__((unused)) fd_set *set,
-                                     __attribute__((unused)) int * max_fd)
+static void deal_with_server_signals(fd_set *set _U_, int *max_fd _U_)
 {
     if (exit_program == 1) {
         pthread_create(&ending_thread, NULL, just_end_it_now, NULL);
@@ -271,7 +270,7 @@ void afp_wait_for_started_loop(void)
     pthread_cond_wait(&loop_started_condition, &loop_started_mutex);
 }
 
-static void *afp_main_quick_startup_thread(__attribute__((unused)) void * other)
+static void *afp_main_quick_startup_thread(void * other _U_)
 {
     afp_main_loop(-1);
     return NULL;

--- a/lib/loop.c
+++ b/lib/loop.c
@@ -202,7 +202,7 @@ void loop_disconnect(struct afp_server *s)
     s->need_resume = 1;
 }
 
-static int process_server_fds(fd_set *set, int max_fd _U_, int **onfd)
+static int process_server_fds(fd_set *set, int **onfd)
 {
     struct afp_server * s;
     int ret;
@@ -254,7 +254,7 @@ static int process_server_fds(fd_set *set, int max_fd _U_, int **onfd)
     return 0;
 }
 
-static void deal_with_server_signals(fd_set *set _U_, int *max_fd _U_)
+static void deal_with_server_signals(void)
 {
     if (exit_program == 1) {
         pthread_create(&ending_thread, NULL, just_end_it_now, NULL);
@@ -411,7 +411,7 @@ int afp_main_loop(int command_fd)
                 log_for_client(NULL, AFPFSD, LOG_DEBUG,
                                "afp_main_loop -- pselect interrupted by signal (EINTR)");
 #endif
-                deal_with_server_signals(&rds, &max_fd);
+                deal_with_server_signals();
                 continue;
             }
 
@@ -504,7 +504,7 @@ int afp_main_loop(int command_fd)
             log_for_client(NULL, AFPFSD, LOG_DEBUG,
                            "afp_main_loop -- calling process_server_fds");
 #endif
-            int server_result = process_server_fds(&ords, max_fd, &onfd);
+            int server_result = process_server_fds(&ords, &onfd);
 #ifdef DEBUG_AFP_LOOP
             log_for_client(NULL, AFPFSD, LOG_DEBUG,
                            "afp_main_loop -- process_server_fds returned %d", server_result);

--- a/lib/lowlevel.c
+++ b/lib/lowlevel.c
@@ -18,6 +18,7 @@
 #include "afp.h"
 #include "afp_protocol.h"
 #include "codepage.h"
+#include "compat.h"
 #include "utils.h"
 #include "midlevel.h"
 #include "did.h"
@@ -234,7 +235,7 @@ int ll_get_directory_entry(struct afp_volume * volume,
 
 
 int ll_open(struct afp_volume * volume,
-            const char *path __attribute__((unused)), int flags,
+            const char *path _U_, int flags,
             struct afp_file_info *fp)
 {
     int ret;

--- a/lib/midlevel.c
+++ b/lib/midlevel.c
@@ -27,6 +27,7 @@
 #include "resource.h"
 #include "utils.h"
 #include "codepage.h"
+#include "compat.h"
 #include "midlevel.h"
 #include "afp_internal.h"
 #include "afp_xattr.h"
@@ -1670,7 +1671,7 @@ int ml_exchange(struct afp_volume * vol,
     return -ret;
 }
 
-int ml_statfs(struct afp_volume * vol, __attribute__((unused)) const char *path,
+int ml_statfs(struct afp_volume * vol, const char *path _U_,
               struct statvfs *stat)
 {
     unsigned short flags;

--- a/lib/proto_attr.c
+++ b/lib/proto_attr.c
@@ -10,6 +10,7 @@
 #include <stdlib.h>
 #include "dsi.h"
 #include "afp.h"
+#include "compat.h"
 #include "utils.h"
 #include "afp_protocol.h"
 #include "dsi_protocol.h"
@@ -72,7 +73,7 @@ int afp_listextattr(struct afp_volume * volume,
     return ret;
 }
 
-int afp_listextattrs_reply(__attribute__((unused)) struct afp_server * server,
+int afp_listextattrs_reply(struct afp_server *server _U_,
                            char *buf,
                            unsigned int size, void *x)
 {
@@ -131,7 +132,7 @@ int afp_listextattrs_reply(__attribute__((unused)) struct afp_server * server,
     return 0;
 }
 
-int afp_getextattr_reply(__attribute__((unused)) struct afp_server * server,
+int afp_getextattr_reply(struct afp_server *server _U_,
                          char *buf,
                          unsigned int size, void *x)
 {

--- a/lib/proto_desktop.c
+++ b/lib/proto_desktop.c
@@ -10,6 +10,7 @@
 
 #include "dsi.h"
 #include "afp.h"
+#include "compat.h"
 #include "utils.h"
 #include "afp_protocol.h"
 #include "dsi_protocol.h"
@@ -48,7 +49,7 @@ int afp_geticon(struct afp_volume * volume, unsigned int filecreator,
                     afpGetIcon, (void *) icon);
 }
 
-int afp_geticon_reply(__attribute__((unused)) struct afp_server *server,
+int afp_geticon_reply(struct afp_server *server _U_,
                       char *buf, unsigned int size, void *other)
 {
     struct {
@@ -146,7 +147,7 @@ int afp_getcomment(struct afp_volume *volume, unsigned int did,
     return rc;
 }
 
-int afp_getcomment_reply(__attribute__((unused)) struct afp_server *server,
+int afp_getcomment_reply(struct afp_server *server _U_,
                          char *buf, unsigned int size, void *other)
 {
     struct {
@@ -209,7 +210,7 @@ int afp_opendt(struct afp_volume *volume, unsigned short * refnum)
 }
 
 
-int afp_opendt_reply(__attribute__((unused)) struct afp_server *server,
+int afp_opendt_reply(struct afp_server *server _U_,
                      char *buf, unsigned int size, void *other)
 {
     struct {

--- a/lib/proto_directory.c
+++ b/lib/proto_directory.c
@@ -11,6 +11,7 @@
 
 #include "dsi.h"
 #include "afp.h"
+#include "compat.h"
 #include "utils.h"
 #include "afp_protocol.h"
 #include "dsi_protocol.h"
@@ -249,7 +250,7 @@ int afp_createdir(struct afp_volume * volume, unsigned int dirid,
     return ret;
 }
 
-int afp_createdir_reply(__attribute__((unused)) struct afp_server * server,
+int afp_createdir_reply(struct afp_server *server _U_,
                         char *buf, unsigned int size, void *other)
 {
     /* We're actually just going to ignore the return bitmap and forkid. */

--- a/lib/proto_files.c
+++ b/lib/proto_files.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include "dsi.h"
 #include "afp.h"
+#include "compat.h"
 #include "utils.h"
 #include "dsi_protocol.h"
 #include "afp_protocol.h"
@@ -234,7 +235,7 @@ int afp_read(struct afp_volume * volume, unsigned short forkid,
     return rc;
 }
 
-int afp_read_reply(__attribute__((unused)) struct afp_server *server,
+int afp_read_reply(struct afp_server *server _U_,
                    char *buf, unsigned int size,
                    void *other)
 {
@@ -290,7 +291,7 @@ int afp_readext(struct afp_volume * volume, unsigned short forkid,
     return rc;
 }
 
-int afp_readext_reply(__attribute__((unused)) struct afp_server *server,
+int afp_readext_reply(struct afp_server *server _U_,
                       char *buf, unsigned int size,
                       void *other)
 {
@@ -482,7 +483,7 @@ int afp_write(struct afp_volume * volume, unsigned short forkid,
 }
 
 
-int afp_write_reply(__attribute__((unused)) struct afp_server *server,
+int afp_write_reply(struct afp_server *server _U_,
                     char *buf, unsigned int size,
                     void *other)
 {
@@ -550,7 +551,7 @@ int afp_writeext(struct afp_volume * volume, unsigned short forkid,
 }
 
 
-int afp_writeext_reply(__attribute__((unused)) struct afp_server *server,
+int afp_writeext_reply(struct afp_server *server _U_,
                        char *buf, unsigned int size,
                        void *other)
 {

--- a/lib/proto_fork.c
+++ b/lib/proto_fork.c
@@ -11,6 +11,7 @@
 
 #include "dsi.h"
 #include "afp.h"
+#include "compat.h"
 #include "utils.h"
 #include "dsi_protocol.h"
 #include "afp_protocol.h"
@@ -107,7 +108,7 @@ int afp_flushfork(struct afp_volume * volume,
                     sizeof(request_packet), DSI_DEFAULT_TIMEOUT, afpFlushFork, NULL);
 }
 
-int afp_openfork_reply(__attribute__((unused)) struct afp_server *server,
+int afp_openfork_reply(struct afp_server *server _U_,
                        char *buf, unsigned int size, void *x)
 {
     struct afp_file_info *fp = (struct afp_file_info *)x;
@@ -210,7 +211,7 @@ int afp_byterangelock(struct afp_volume * volume,
     return rc;
 }
 
-int afp_byterangelock_reply(__attribute__((unused)) struct afp_server *server,
+int afp_byterangelock_reply(struct afp_server *server _U_,
                             char *buf, unsigned int size, void *x)
 {
     struct {
@@ -256,7 +257,7 @@ int afp_byterangelockext(struct afp_volume * volume,
     return rc;
 }
 
-int afp_byterangelockext_reply(__attribute__((unused)) struct afp_server
+int afp_byterangelockext_reply(struct afp_server _U_
                                *server, char *buf, unsigned int size, void *x)
 {
     struct {

--- a/lib/proto_login.c
+++ b/lib/proto_login.c
@@ -12,6 +12,7 @@
 #include "dsi.h"
 #include "dsi_protocol.h"
 #include "afp.h"
+#include "compat.h"
 #include "utils.h"
 #include "afp_internal.h"
 
@@ -32,7 +33,7 @@ int afp_logout(struct afp_server *server, unsigned char wait)
                     wait, afpLogout, NULL);
 }
 
-int afp_login_reply(__attribute__((unused)) struct afp_server *server,
+int afp_login_reply(struct afp_server *server _U_,
                     char *buf, unsigned int size,
                     void *other)
 {
@@ -103,7 +104,7 @@ int afp_changepassword(struct afp_server *server, const char * ua_name,
     return ret;
 }
 
-int afp_changepassword_reply(__attribute__((unused)) struct afp_server *server,
+int afp_changepassword_reply(struct afp_server *server _U_,
                              char *buf,
                              unsigned int size, void *other)
 {

--- a/lib/proto_map.c
+++ b/lib/proto_map.c
@@ -10,6 +10,7 @@
 
 #include "dsi.h"
 #include "afp.h"
+#include "compat.h"
 #include "utils.h"
 #include "dsi_protocol.h"
 #include "afp_protocol.h"
@@ -55,7 +56,7 @@ int afp_getuserinfo(struct afp_server * server, int thisuser,
 }
 
 
-int afp_getuserinfo_reply(__attribute__((unused)) struct afp_server *server,
+int afp_getuserinfo_reply(struct afp_server *server _U_,
                           char *buf, unsigned int size, void *other)
 {
     struct {
@@ -121,7 +122,7 @@ int afp_mapid(struct afp_server * server, unsigned char subfunction,
     return ret;
 }
 
-int afp_mapid_reply(__attribute__((unused)) struct afp_server *server,
+int afp_mapid_reply(struct afp_server *server _U_,
                     char *buf, unsigned int size, void *other)
 {
     struct {
@@ -183,7 +184,7 @@ int afp_mapname(struct afp_server * server, unsigned char subfunction,
 }
 
 
-int afp_mapname_reply(__attribute__((unused)) struct afp_server *server,
+int afp_mapname_reply(struct afp_server *server _U_,
                       char *buf, unsigned int size, void *other)
 {
     struct {

--- a/lib/proto_replyblock.c
+++ b/lib/proto_replyblock.c
@@ -9,6 +9,7 @@
 #include <string.h>
 #include "dsi.h"
 #include "afp.h"
+#include "compat.h"
 #include "utils.h"
 #include "afp_internal.h"
 #include "afp_replies.h"
@@ -95,7 +96,7 @@ static int copy_afpname_bounded(char *dest, size_t dest_len,
     return 0;
 }
 
-int parse_reply_block(__attribute__((unused)) struct afp_server *server,
+int parse_reply_block(struct afp_server *server _U_,
                       const char *buf,
                       unsigned int size, unsigned char isdir,
                       unsigned int filebitmap,

--- a/lib/proto_server.c
+++ b/lib/proto_server.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include "dsi.h"
 #include "afp.h"
+#include "compat.h"
 #include "utils.h"
 #include "dsi_protocol.h"
 #include "afp_protocol.h"
@@ -34,7 +35,7 @@ int afp_getsrvrparms(struct afp_server *server)
 
 
 int afp_getsrvrparms_reply(struct afp_server *server, char * msg,
-                           unsigned int size, __attribute__((unused)) void * ignore)
+                           unsigned int size, void *ignore _U_)
 {
     const struct {
         struct dsi_header header __attribute__((__packed__));
@@ -99,7 +100,7 @@ int afp_getsrvrparms_reply(struct afp_server *server, char * msg,
 }
 
 
-int afp_getsrvrmsg_reply(__attribute__((unused)) struct afp_server *server,
+int afp_getsrvrmsg_reply(struct afp_server *server _U_,
                          char *buf, unsigned int size, void *other)
 {
     struct afp_getsrvrmsg_reply_packet {

--- a/lib/proto_session.c
+++ b/lib/proto_session.c
@@ -10,6 +10,7 @@
 #include "dsi.h"
 #include "dsi_protocol.h"
 #include "afp.h"
+#include "compat.h"
 #include "utils.h"
 
 int afp_getsessiontoken(struct afp_server * server, int type,
@@ -79,9 +80,9 @@ error:
     return ret;
 }
 
-int afp_getsessiontoken_reply(__attribute__((unused)) struct afp_server *server,
+int afp_getsessiontoken_reply(struct afp_server *server _U_,
                               char *buf,
-                              __attribute__((unused)) unsigned int size, void * other)
+                              unsigned int size _U_, void *other)
 {
     struct afp_token * token = other;
     struct {

--- a/lib/proto_volume.c
+++ b/lib/proto_volume.c
@@ -10,16 +10,17 @@
 #include <stdlib.h>
 #include "dsi.h"
 #include "afp.h"
+#include "compat.h"
 #include "utils.h"
 #include "dsi_protocol.h"
 #include "afp_protocol.h"
 #include "afp_internal.h"
 #include "codepage.h"
 
-static int parse_volbitmap_reply(__attribute__((unused)) struct afp_server
-                                 *server,
+static int parse_volbitmap_reply(struct afp_server *server _U_,
                                  struct afp_volume *tmpvol,
-                                 unsigned short bitmap, char *msg, unsigned int size)
+                                 unsigned short bitmap, char *msg,
+                                 unsigned int size)
 {
     char *p = msg;
 

--- a/lib/resource.c
+++ b/lib/resource.c
@@ -14,6 +14,7 @@
 
 #include "afp.h"
 #include "afp_protocol.h"
+#include "compat.h"
 #include "resource.h"
 #include "lowlevel.h"
 #include "did.h"
@@ -163,7 +164,7 @@ out:
 }
 
 int appledouble_creat(struct afp_volume * volume, const char * path,
-                      __attribute__((unused)) mode_t mode)
+                      mode_t mode _U_)
 {
     int resource;
     char *newpath;
@@ -194,7 +195,7 @@ int appledouble_creat(struct afp_volume * volume, const char * path,
 }
 
 int appledouble_chmod(struct afp_volume * volume, const char * path,
-                      __attribute__((unused)) mode_t mode)
+                      mode_t mode _U_)
 {
     int resource;
     char *newpath;
@@ -487,7 +488,7 @@ int appledouble_read(struct afp_volume * volume, struct afp_file_info *fp,
 }
 
 int appledouble_truncate(struct afp_volume * volume, const char * path,
-                         __attribute__((unused)) int offset)
+                         int offset _U_)
 {
     char *newpath;
     int resource = extra_translate(volume, path, &newpath);
@@ -835,7 +836,7 @@ int appledouble_readdir(struct afp_volume * volume,
 }
 
 int appledouble_mkdir(struct afp_volume * volume, const char * path,
-                      __attribute__((unused)) mode_t mode)
+                      mode_t mode _U_)
 {
     int resource;
     char *newpath;
@@ -851,7 +852,7 @@ int appledouble_mkdir(struct afp_volume * volume, const char * path,
 }
 
 int appledouble_readlink(struct afp_volume * volume, const char * path,
-                         __attribute__((unused)) char * buf, __attribute__((unused)) size_t size)
+                         char *buf _U_, size_t size _U_)
 {
     int resource;
     char *newpath;
@@ -882,7 +883,7 @@ int appledouble_rmdir(struct afp_volume * volume, const char * path)
 }
 
 int appledouble_chown(struct afp_volume * volume, const char * path,
-                      __attribute__((unused)) uid_t uid, __attribute__((unused)) gid_t gid)
+                      uid_t uid _U_, gid_t gid _U_)
 {
     int resource;
     char *newpath;
@@ -898,7 +899,7 @@ int appledouble_chown(struct afp_volume * volume, const char * path,
 }
 
 int appledouble_utime(struct afp_volume * volume, const char * path,
-                      __attribute__((unused)) struct utimbuf * timebuf)
+                      struct utimbuf * timebuf _U_)
 {
     int resource;
     char *newpath;
@@ -914,7 +915,7 @@ int appledouble_utime(struct afp_volume * volume, const char * path,
 }
 
 int appledouble_symlink(struct afp_volume *vol, const char *path1,
-                        __attribute__((unused)) const char *path2)
+                        const char *path2 _U_)
 {
     int resource;
     char *newpath;
@@ -930,7 +931,7 @@ int appledouble_symlink(struct afp_volume *vol, const char *path1,
 }
 
 int appledouble_rename(struct afp_volume * volume,
-                       __attribute__((unused)) const char * path_from,
+                       const char *path_from _U_,
                        const char *path_to)
 {
     int resource;

--- a/lib/uams.c
+++ b/lib/uams.c
@@ -179,8 +179,8 @@ int init_uams(void)
 
 static int noauth_login(
     struct afp_server *server,
-    __attribute__((unused)) char *username,
-    __attribute__((unused)) char *passwd
+    char *username _U_,
+    char *passwd _U_
 )
 {
     return afp_login(server, "No User Authent", NULL, 0, NULL);

--- a/test/test_log.c
+++ b/test/test_log.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "compat.h"
 #include "libafpclient.h"
 #include "tap.h"
 #include "utils.h"
@@ -8,9 +9,9 @@
 static char captured_message[MAX_ERROR_LEN * 4];
 
 static void capture_log_message(
-    __attribute__((unused)) void *priv,
-    __attribute__((unused)) enum logtypes logtype,
-    __attribute__((unused)) int loglevel,
+    void *priv _U_,
+    enum logtypes logtype _U_,
+    int loglevel _U_,
     const char *message)
 {
     snprintf(captured_message, sizeof(captured_message), "%s", message);


### PR DESCRIPTION
this borrows the `_U_` compatibility macro from Netatalk instead of using the not fully portable `__attribute__((unused))` directly (we get more compact code too)

also aligns with the Netatalk convension of appending the unused attribute to the function signature declarations

remove a handful of unused parameters in static functions in the main loop module