### PR TITLE
bind stateless operations to authenticated sessions

### DIFF
--- a/cmdline/cmdline_afp.c
+++ b/cmdline/cmdline_afp.c
@@ -123,8 +123,8 @@ static int command_recursive_option(char **arg)
     return 1;
 }
 
-static int attach_volume_with_password_prompt(volumeid_t *vol_id_ptr,
-        unsigned int volume_options);
+static int attach_volume_with_password_prompt(serverid_t attach_server_id,
+        volumeid_t *vol_id_ptr, unsigned int volume_options);
 
 static unsigned int get_uam_mask_for_url(void)
 {
@@ -192,7 +192,8 @@ static int reconnect_session(int restore_volume, int restore_dir)
 
     if ((restore_volume || had_volume) && saved_volume[0] != '\0') {
         strlcpy(url.volumename, saved_volume, sizeof(url.volumename));
-        ret = attach_volume_with_password_prompt(&new_vol_id, volume_options);
+        ret = attach_volume_with_password_prompt(new_server_id, &new_vol_id,
+              volume_options);
 
         if (ret != 0) {
             return -1;
@@ -347,15 +348,16 @@ static int cmdline_get_volpass(void)
     return 0;
 }
 
-static int attach_volume_with_password_prompt(volumeid_t *vol_id_ptr,
-        unsigned int volume_options)
+static int attach_volume_with_password_prompt(serverid_t attach_server_id,
+        volumeid_t *vol_id_ptr, unsigned int volume_options)
 {
     enum afp_sl_attach_status status;
     int ret;
     /* Clear any previous password to force a fresh prompt if needed */
     explicit_bzero(url.volpassword, sizeof(url.volpassword));
     /* First attempt */
-    ret = afp_sl_attach(&url, volume_options, vol_id_ptr, &status);
+    ret = afp_sl_attach(attach_server_id, &url, volume_options, vol_id_ptr,
+                        &status);
 
     if (ret == 0) {
         return 0;
@@ -368,7 +370,8 @@ static int attach_volume_with_password_prompt(volumeid_t *vol_id_ptr,
         }
 
         /* Second attempt with password */
-        ret = afp_sl_attach(&url, volume_options, vol_id_ptr, &status);
+        ret = afp_sl_attach(attach_server_id, &url, volume_options, vol_id_ptr,
+                            &status);
     }
 
     return ret;
@@ -761,12 +764,12 @@ static void list_volumes(void)
         return;
     }
 
-    ret = afp_sl_getvols(&url, 0, count, &numvols, vols);
+    ret = afp_sl_getvols(server_id, &url, 0, count, &numvols, vols);
 
     if (ret != 0 && is_recoverable_session_error(ret)
             && reconnect_session(0, 0) == 0) {
         numvols = 0;
-        ret = afp_sl_getvols(&url, 0, count, &numvols, vols);
+        ret = afp_sl_getvols(server_id, &url, 0, count, &numvols, vols);
     }
 
     if (ret == 0) {
@@ -3018,11 +3021,13 @@ int com_cd(char *arg)
         /* Not attached to a volume, treat arg as volume name */
         strlcpy(url.volumename, path, AFP_VOLUME_NAME_LEN);
         unsigned int volume_options = VOLUME_EXTRA_FLAGS_NO_LOCKING;
-        ret = attach_volume_with_password_prompt(&vol_id, volume_options);
+        ret = attach_volume_with_password_prompt(server_id, &vol_id,
+              volume_options);
 
         if (ret != 0
                 && is_recoverable_session_error(ret) && reconnect_session(0, 0) == 0) {
-            ret = attach_volume_with_password_prompt(&vol_id, volume_options);
+            ret = attach_volume_with_password_prompt(server_id, &vol_id,
+                  volume_options);
         }
 
         if (ret != 0) {
@@ -3259,7 +3264,8 @@ static int cmdline_server_startup(int batch_mode)
     if (url.volumename[0] != '\0') {
         unsigned int volume_options = VOLUME_EXTRA_FLAGS_NO_LOCKING;
         int ret;
-        ret = attach_volume_with_password_prompt(&vol_id, volume_options);
+        ret = attach_volume_with_password_prompt(server_id, &vol_id,
+              volume_options);
 
         if (ret != 0) {
             if (ret == -EACCES) {
@@ -3757,7 +3763,8 @@ char *afp_remote_file_generator(const char *text, int state)
                 return NULL;
             }
 
-            if (afp_sl_getvols(&url, 0, 100, &numvols, volbase) == 0) {
+            if (afp_sl_getvols(server_id, &url, 0, 100, &numvols,
+                               volbase) == 0) {
                 count = numvols;
                 is_volume_list = 1;
             } else {

--- a/daemon/commands.c
+++ b/daemon/commands.c
@@ -392,8 +392,9 @@ static unsigned char process_getvolid(struct daemon_client * c)
     req->url.path[AFP_MAX_PATH - 1] = '\0';
     req->url.zone[AFP_ZONE_LEN - 1] = '\0';
     req->url.volpassword[AFP_VOLPASS_LEN] = '\0';
+    s = find_server_by_pointer((struct afp_server *)req->serverid);
 
-    if ((s = afp_server_find_by_name_hold(req->url.servername)) == NULL) {
+    if (!s || s->connect_state != SERVER_STATE_CONNECTED || s->fd <= 0) {
         ret = AFP_SERVER_RESULT_NOTCONNECTED;
         goto done;
     }
@@ -529,25 +530,10 @@ static unsigned char process_getvols(struct daemon_client * c)
     request->url.path[AFP_MAX_PATH - 1] = '\0';
     request->url.zone[AFP_ZONE_LEN - 1] = '\0';
     request->url.volpassword[AFP_VOLPASS_LEN] = '\0';
+    server = find_server_by_pointer((struct afp_server *)request->serverid);
 
-    if ((server = afp_server_find_by_name_hold(request->url.servername)) == NULL) {
-        struct addrinfo *address;
-
-        if ((address = afp_get_address((void *)c, request->url.servername,
-                                       request->url.port)) != NULL) {
-            server = afp_server_find_by_address_hold(address);
-            freeaddrinfo(address);
-        }
-
-        if (server == NULL) {
-            result = AFP_SERVER_RESULT_NOTCONNECTED;
-            goto error;
-        }
-    }
-
-    if (server->connect_state != SERVER_STATE_CONNECTED) {
-        afp_server_release(server);
-        server = NULL;
+    if (!server || server->connect_state != SERVER_STATE_CONNECTED
+            || server->fd <= 0) {
         result = AFP_SERVER_RESULT_NOTCONNECTED;
         goto error;
     }
@@ -1908,6 +1894,109 @@ done:
     return 0;
 }
 
+static int server_name_matches_url(struct afp_server *server,
+                                   const struct afp_url *url)
+{
+    return strcmp(server->server_name_utf8, url->servername) == 0
+           || strcmp(server->server_name, url->servername) == 0
+           || strcmp(server->server_name_printable, url->servername) == 0;
+}
+
+static int server_address_matches(struct afp_server *server,
+                                  struct addrinfo *address)
+{
+    if (!address || !server->used_address || !server->used_address->ai_addr) {
+        return 0;
+    }
+
+    for (struct addrinfo *p = address; p; p = p->ai_next) {
+        if (p->ai_addr && server->used_address->ai_addrlen == p->ai_addrlen
+                && memcmp(server->used_address->ai_addr, p->ai_addr,
+                          p->ai_addrlen) == 0) {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+static int server_auth_matches_resume(struct afp_server *server,
+                                      const struct afp_url *url,
+                                      unsigned int uam_mask)
+{
+    /*
+     * Resume is not AFP reauthentication. A password-less resume proves only
+     * that the caller can access this daemon's existing session state; it may
+     * omit username/UAM and match by host when exactly one live session exists.
+     */
+    if (url->username[0] != '\0'
+            && strcmp(server->username, url->username) != 0) {
+        return 0;
+    }
+
+    if (uam_mask != 0 && server->using_uam != 0
+            && (server->using_uam & uam_mask) == 0) {
+        return 0;
+    }
+
+    return 1;
+}
+
+static struct afp_server *find_resumable_server_hold(void *priv,
+        const struct afp_url *url, unsigned int uam_mask, int *error)
+{
+    struct afp_server *match = NULL;
+    struct addrinfo *address = NULL;
+    int matches = 0;
+
+    if (error) {
+        *error = ENOTCONN;
+    }
+
+    address = afp_get_address(priv, url->servername, url->port);
+    afp_lock_server_list();
+
+    for (struct afp_server *s = get_server_base(); s; s = s->next) {
+        if (s->connect_state != SERVER_STATE_CONNECTED || s->fd <= 0) {
+            continue;
+        }
+
+        if (!server_name_matches_url(s, url)
+                && !server_address_matches(s, address)) {
+            continue;
+        }
+
+        if (!server_auth_matches_resume(s, url, uam_mask)) {
+            continue;
+        }
+
+        match = s;
+        matches++;
+
+        if (matches > 1) {
+            break;
+        }
+    }
+
+    if (matches == 1) {
+        afp_server_hold(match);
+    } else {
+        match = NULL;
+
+        if (error && matches > 1) {
+            *error = EEXIST;
+        }
+    }
+
+    afp_unlock_server_list();
+
+    if (address) {
+        freeaddrinfo(address);
+    }
+
+    return match;
+}
+
 static int process_connect(struct daemon_client * c)
 {
     struct afp_server_connect_request * req;
@@ -1939,54 +2028,29 @@ static int process_connect(struct daemon_client * c)
     log_for_client((void *) c, AFPFSD, LOG_INFO, "Connecting to server %s",
                    (char *) req->url.servername);
 
-    if ((s = afp_server_find_by_name_hold(req->url.servername))) {
-        /* Check if the server is actually connected, not a stale object */
-        if (s->connect_state == SERVER_STATE_CONNECTED && s->fd > 0) {
-            response_result = AFP_SERVER_RESULT_ALREADY_CONNECTED;
-            server_copy = s;
-            memcpy(loginmesg_copy, s->loginmesg, AFP_LOGINMESG_LEN);
-            afp_server_release(s);  /* Release hold; server stays alive via list ref */
-            goto done;
-        } else if (s->connect_state == SERVER_STATE_CONNECTING) {
-            /* Connection in progress by another thread — wait for it */
-            int wait_ms = 0;
-
-            while (s->connect_state == SERVER_STATE_CONNECTING && wait_ms < 10000) {
-                afp_server_release(s);
-                struct timespec ts = {0, 100000000}; /* 100ms */
-                nanosleep(&ts, NULL);
-                wait_ms += 100;
-                s = afp_server_find_by_name_hold(req->url.servername);
-
-                if (!s) {
-                    break;
-                }
-            }
-
-            if (s && s->connect_state == SERVER_STATE_CONNECTED) {
-                response_result = AFP_SERVER_RESULT_ALREADY_CONNECTED;
-                server_copy = s;
-                memcpy(loginmesg_copy, s->loginmesg, AFP_LOGINMESG_LEN);
-                afp_server_release(s);
-                goto done;
-            }
-
-            if (s) {
-                afp_server_release(s);
-            }
-
-            s = NULL;
-            /* Fall through to create new connection */
-        } else {
-            /* Stale server from previous failed connection, remove it */
-            log_for_client((void *) c, AFPFSD, LOG_INFO,
-                           "Removing stale server %s (state=%d, fd=%d)",
-                           req->url.servername, s->connect_state, s->fd);
-            afp_server_remove(s);
-            afp_server_release(s);  /* Release our hold */
-            s = NULL;
-            /* Continue to create a new connection */
+    if (req->flags & AFP_SERVER_CONNECT_RESUME_EXISTING) {
+        if (req->url.password[0] != '\0') {
+            log_for_client((void *) c, AFPFSD, LOG_WARNING,
+                           "Refusing to resume server %s with supplied password",
+                           req->url.servername);
+            error = EACCES;
+            goto error;
         }
+
+        s = find_resumable_server_hold(c, &req->url, req->uam_mask, &error);
+
+        if (!s) {
+            log_for_client((void *) c, AFPFSD, LOG_INFO,
+                           "No resumable session for server %s",
+                           req->url.servername);
+            goto error;
+        }
+
+        response_result = AFP_SERVER_RESULT_ALREADY_CONNECTED;
+        server_copy = s;
+        memcpy(loginmesg_copy, s->loginmesg, AFP_LOGINMESG_LEN);
+        afp_server_release(s);
+        goto done;
     }
 
     /* Initialize connection request */
@@ -2081,7 +2145,6 @@ static int process_attach(struct daemon_client * c)
     struct afp_volume * volume = NULL;
     int response_result = AFP_SERVER_RESULT_ERROR;
     struct afp_server_attach_response response;
-    struct addrinfo * address = NULL;
 
     if ((size_t)(c->completed_packet_size) < sizeof(struct
             afp_server_attach_request)) {
@@ -2101,28 +2164,14 @@ static int process_attach(struct daemon_client * c)
                    "Attaching volume %s on server %s",
                    (char *) req->url.volumename,
                    (char *) req->url.servername);
+    s = find_server_by_pointer((struct afp_server *)req->serverid);
 
-    /* Try to find existing connected server by name first */
-    if ((s = afp_server_find_by_name_hold(req->url.servername)) != NULL) {
-        /* Found by name */
-    } else {
-        /* Resolve the server name to an address and find by address
-         * This allows matching by IP address even if server reports a different hostname */
-        if ((address = afp_get_address((void *)c, req->url.servername,
-                                       req->url.port)) == NULL) {
-            log_for_client((void *) c, AFPFSD, LOG_ERR,
-                           "Could not resolve address for server %s", req->url.servername);
-            goto error;
-        }
-
-        if ((s = afp_server_find_by_address_hold(address)) == NULL) {
-            log_for_client((void *) c, AFPFSD, LOG_ERR,
-                           "Not yet connected to server %s", req->url.servername);
-            freeaddrinfo(address);
-            goto error;
-        }
-
-        freeaddrinfo(address);
+    if (!s || s->connect_state != SERVER_STATE_CONNECTED || s->fd <= 0) {
+        log_for_client((void *) c, AFPFSD, LOG_ERR,
+                       "Attach request with invalid or disconnected server %p",
+                       req->serverid);
+        response_result = AFP_SERVER_RESULT_NOTCONNECTED;
+        goto error;
     }
 
     /* Always call command_sub_attach_volume, which handles:

--- a/daemon/stateless.c
+++ b/daemon/stateless.c
@@ -659,16 +659,35 @@ int afp_sl_status(const char *volumename, const char *servername, char *text,
  *
  */
 
-int afp_sl_getvolid(struct afp_url * url, volumeid_t *volid)
+int afp_sl_getvolid(serverid_t serverid, struct afp_url * url,
+                    volumeid_t *volid)
 {
     struct afp_server_getvolid_request req;
     struct afp_server_getvolid_response response;
     int ret;
     int retries = 10;
+
+    if (!serverid) {
+        if (!url || url->password[0] != '\0') {
+            return -EACCES;
+        }
+
+        ret = afp_sl_resume(url, default_uams_mask(), &serverid, NULL);
+
+        if (ret != 0) {
+            return ret;
+        }
+
+        if (!serverid) {
+            return -EIO;
+        }
+    }
+
     memset(&req, 0, sizeof(req));
     req.header.close = 0;
     req.header.len = sizeof(struct afp_server_getvolid_request);
     req.header.command = AFP_SERVER_COMMAND_GETVOLID;
+    req.serverid = serverid;
     memcpy(&req.url, url, sizeof(*url));
 
     while (1) {
@@ -713,7 +732,7 @@ int afp_sl_stat(volumeid_t *volid, const char *path, struct afp_url *url,
     request.header.command = AFP_SERVER_COMMAND_STAT;
 
     if (volid == NULL) {
-        ret = afp_sl_getvolid(url, &tmpvolid);
+        ret = afp_sl_getvolid(NULL, url, &tmpvolid);
 
         if (ret) {
             return ret;
@@ -756,7 +775,7 @@ int afp_sl_open(volumeid_t *volid, const char *path, struct afp_url *url,
     request.header.command = AFP_SERVER_COMMAND_OPEN;
 
     if (volid == NULL) {
-        ret = afp_sl_getvolid(url, &tmpvolid);
+        ret = afp_sl_getvolid(NULL, url, &tmpvolid);
 
         if (ret) {
             return ret;
@@ -1222,7 +1241,7 @@ int afp_sl_creat(volumeid_t *volid, const char *path, struct afp_url *url,
     request.header.command = AFP_SERVER_COMMAND_CREAT;
 
     if (volid == NULL) {
-        ret = afp_sl_getvolid(url, &tmpvolid);
+        ret = afp_sl_getvolid(NULL, url, &tmpvolid);
 
         if (ret) {
             return ret;
@@ -1260,7 +1279,7 @@ int afp_sl_chmod(volumeid_t *volid, const char *path, struct afp_url *url,
     request.header.command = AFP_SERVER_COMMAND_CHMOD;
 
     if (volid == NULL) {
-        ret = afp_sl_getvolid(url, &tmpvolid);
+        ret = afp_sl_getvolid(NULL, url, &tmpvolid);
 
         if (ret) {
             return ret;
@@ -1297,7 +1316,7 @@ int afp_sl_rename(volumeid_t *volid, const char *path_from, const char *path_to,
     request.header.command = AFP_SERVER_COMMAND_RENAME;
 
     if (volid == NULL) {
-        ret = afp_sl_getvolid(url, &tmpvolid);
+        ret = afp_sl_getvolid(NULL, url, &tmpvolid);
 
         if (ret) {
             return ret;
@@ -1333,7 +1352,7 @@ int afp_sl_unlink(volumeid_t *volid, const char *path, struct afp_url *url)
     request.header.command = AFP_SERVER_COMMAND_UNLINK;
 
     if (volid == NULL) {
-        ret = afp_sl_getvolid(url, &tmpvolid);
+        ret = afp_sl_getvolid(NULL, url, &tmpvolid);
 
         if (ret) {
             return ret;
@@ -1370,7 +1389,7 @@ int afp_sl_truncate(volumeid_t *volid, const char *path, struct afp_url *url,
     request.header.command = AFP_SERVER_COMMAND_TRUNCATE;
 
     if (volid == NULL) {
-        ret = afp_sl_getvolid(url, &tmpvolid);
+        ret = afp_sl_getvolid(NULL, url, &tmpvolid);
 
         if (ret) {
             return ret;
@@ -1408,7 +1427,7 @@ int afp_sl_utime(volumeid_t *volid, const char *path, struct afp_url *url,
     request.header.command = AFP_SERVER_COMMAND_UTIME;
 
     if (volid == NULL) {
-        ret = afp_sl_getvolid(url, &tmpvolid);
+        ret = afp_sl_getvolid(NULL, url, &tmpvolid);
 
         if (ret) {
             return ret;
@@ -1446,7 +1465,7 @@ int afp_sl_mkdir(volumeid_t *volid, const char *path, struct afp_url *url,
     request.header.command = AFP_SERVER_COMMAND_MKDIR;
 
     if (volid == NULL) {
-        ret = afp_sl_getvolid(url, &tmpvolid);
+        ret = afp_sl_getvolid(NULL, url, &tmpvolid);
 
         if (ret) {
             return ret;
@@ -1483,7 +1502,7 @@ int afp_sl_rmdir(volumeid_t *volid, const char *path, struct afp_url *url)
     request.header.command = AFP_SERVER_COMMAND_RMDIR;
 
     if (volid == NULL) {
-        ret = afp_sl_getvolid(url, &tmpvolid);
+        ret = afp_sl_getvolid(NULL, url, &tmpvolid);
 
         if (ret) {
             return ret;
@@ -1520,7 +1539,7 @@ int afp_sl_statfs(volumeid_t *volid, const char *path, struct afp_url *url,
     request.header.command = AFP_SERVER_COMMAND_STATFS;
 
     if (volid == NULL) {
-        ret = afp_sl_getvolid(url, &tmpvolid);
+        ret = afp_sl_getvolid(NULL, url, &tmpvolid);
 
         if (ret) {
             return ret;
@@ -1593,7 +1612,7 @@ int afp_sl_readdir(volumeid_t * volid, const char * path, struct afp_url * url,
     }
 
     if (volid == NULL) {
-        ret = afp_sl_getvolid(url, &tmpvolid);
+        ret = afp_sl_getvolid(NULL, url, &tmpvolid);
 
         if (ret) {
             return ret;
@@ -1719,12 +1738,17 @@ int afp_sl_readdir(volumeid_t * volid, const char * path, struct afp_url * url,
     return 0;
 }
 
-int afp_sl_getvols(struct afp_url *url, unsigned int start, unsigned int count,
-                   unsigned int *numvols, struct afp_volume_summary *vols)
+int afp_sl_getvols(serverid_t serverid, struct afp_url *url,
+                   unsigned int start, unsigned int count, unsigned int *numvols,
+                   struct afp_volume_summary *vols)
 {
     struct afp_server_getvols_request req;
     int ret;
     struct afp_server_getvols_response * response;
+
+    if (!serverid) {
+        return -EINVAL;
+    }
 
     if (ensure_daemon_connection()) {
         return -ECONNREFUSED;
@@ -1733,6 +1757,7 @@ int afp_sl_getvols(struct afp_url *url, unsigned int start, unsigned int count,
     req.header.close = 0;
     req.header.len = sizeof(struct afp_server_getvols_request);
     req.header.command = AFP_SERVER_COMMAND_GETVOLS;
+    req.serverid = serverid;
     req.start = start;
     req.count = count;
     memcpy(&req.url, url, sizeof(*url));
@@ -1759,8 +1784,9 @@ int afp_sl_getvols(struct afp_url *url, unsigned int start, unsigned int count,
     return ret;
 }
 
-int afp_sl_connect(struct afp_url *url, unsigned int uam_mask, serverid_t *id,
-                   char *loginmesg)
+static int afp_sl_connect_with_flags(struct afp_url *url, unsigned int uam_mask,
+                                     unsigned int flags, serverid_t *id,
+                                     char *loginmesg)
 {
     struct afp_server_connect_request req;
     const struct afp_server_connect_response *resp;
@@ -1775,6 +1801,7 @@ int afp_sl_connect(struct afp_url *url, unsigned int uam_mask, serverid_t *id,
     req.header.command = AFP_SERVER_COMMAND_CONNECT;
     memcpy(&req.url, url, sizeof(struct afp_url));
     req.uam_mask = uam_mask;
+    req.flags = flags;
 
     if (send_command(sizeof(req), (char *)&req, AFP_SERVER_COMMAND_CONNECT) < 0) {
         return -ECONNRESET;
@@ -1810,8 +1837,23 @@ int afp_sl_connect(struct afp_url *url, unsigned int uam_mask, serverid_t *id,
     return server_result_to_errno(resp->header.result);
 }
 
-int afp_sl_attach(struct afp_url * url, unsigned int volume_options,
-                  volumeid_t *volumeid, enum afp_sl_attach_status *status)
+int afp_sl_connect(struct afp_url *url, unsigned int uam_mask, serverid_t *id,
+                   char *loginmesg)
+{
+    return afp_sl_connect_with_flags(url, uam_mask, 0, id, loginmesg);
+}
+
+int afp_sl_resume(struct afp_url *url, unsigned int uam_mask, serverid_t *id,
+                  char *loginmesg)
+{
+    return afp_sl_connect_with_flags(url, uam_mask,
+                                     AFP_SERVER_CONNECT_RESUME_EXISTING, id,
+                                     loginmesg);
+}
+
+int afp_sl_attach(serverid_t serverid, struct afp_url * url,
+                  unsigned int volume_options, volumeid_t *volumeid,
+                  enum afp_sl_attach_status *status)
 {
     struct afp_server_attach_request req;
     struct afp_server_attach_response * response;
@@ -1819,6 +1861,10 @@ int afp_sl_attach(struct afp_url * url, unsigned int volume_options,
 
     if (status) {
         *status = AFP_SL_ATTACH_STATUS_NONE;
+    }
+
+    if (!serverid) {
+        return -EINVAL;
     }
 
     if (ensure_daemon_connection()) {
@@ -1829,6 +1875,7 @@ int afp_sl_attach(struct afp_url * url, unsigned int volume_options,
     req.header.close = 0;
     req.header.len = sizeof(struct afp_server_attach_request);
     req.header.command = AFP_SERVER_COMMAND_ATTACH;
+    req.serverid = serverid;
     memcpy(&req.url, url, sizeof(struct afp_url));
     req.volume_options = volume_options;
 
@@ -1875,7 +1922,7 @@ int afp_sl_detach(volumeid_t *volumeid, struct afp_url * url)
     }
 
     if (volumeid == NULL) {
-        ret = afp_sl_getvolid(url, &tmpvolid);
+        ret = afp_sl_getvolid(NULL, url, &tmpvolid);
 
         if (ret) {
             return ret;

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -382,9 +382,16 @@ streaming operations, including reads, writes, metadata calls, and directory lis
    send one request, receive one response, and close
 2. **Persistent server/volume state**: Even though socket connections are ephemeral,
    the server and volume state persists in afpsld's memory
-3. **Volume ID handles**: When a volume is attached, afpsld returns a `volumeid_t` (opaque pointer)
+3. **Server ID handles**: When a server is connected, afpsld returns a `serverid_t` (opaque pointer)
+   that identifies the authenticated AFP session. Follow-up attach requests must present this handle;
+   afpsld does not implicitly rediscover authenticated sessions by server name.
+4. **Volume ID handles**: When a volume is attached, afpsld returns a `volumeid_t` (opaque pointer)
    that remains valid across separate socket connections as long as the daemon runs
-4. **Connection reuse for CONNECT/ATTACH**: The CONNECT operation keeps the socket open (`close=0` flag)
+5. **Explicit session resume**: `afp_sl_resume()` can return an existing connected `serverid_t` without
+   reauthentication, but only when the caller supplies no password and the daemon can identify one matching session.
+   Resume authenticates the caller's access to the per-user daemon's existing session state, not the AFP user identity.
+   Normal `afp_sl_connect()` always performs AFP authentication.
+6. **Connection reuse for CONNECT/ATTACH**: The CONNECT operation keeps the socket open (`close=0` flag)
    to allow the subsequent ATTACH to use the same connection
 
 **Request flow:**
@@ -395,15 +402,15 @@ streaming operations, including reads, writes, metadata calls, and directory lis
         |                        |----TCP connect---------->|
         |<---server_id-----------|                          |
         |                        |                          |
-        |--ATTACH (close=1)----->|                          |
+        |--ATTACH server_id----->|                          |
         |                        |----FPOpenVol------------>|
         |<---volumeid------------|                          |
-        [connection closes]      |                          |
+        |  [connection closes]   |                          |
         |                        |                          |
         |--READDIR (close=1)---->|                          |
         |  (new socket)          |----FPEnumerate---------->|
         |<---file list-----------|                          |
-        [connection closes]      |                          |
+        |  [connection closes]   |                          |
 
 **Threading model:**
 
@@ -478,6 +485,7 @@ instead of directly calling the midlevel API. This change provides several benef
 
 afpcmd maintains minimal connection state:
 
+- `serverid_t server_id` - Opaque handle returned by afpsld after CONNECT
 - `volumeid_t vol_id` - Opaque handle returned by afpsld after ATTACH
 - `int connected` - Boolean flag indicating whether a volume is attached
 - `char curdir[]` - Current working directory path (client-side tracking)
@@ -486,10 +494,18 @@ afpcmd maintains minimal connection state:
 
 1. User runs: `afpcmd afp://user:pass@server/volume`
 2. afpcmd calls `afp_sl_connect()` → afpsld connects to AFP server
-3. afpcmd calls `afp_sl_attach()` → afpsld opens volume
+3. afpcmd calls `afp_sl_attach(server_id, ...)` → afpsld opens volume on that authenticated session
 4. afpcmd receives `volumeid_t` handle and sets `connected = 1`
 5. All subsequent commands pass this volumeid to afp_sl_* functions
 6. afpsld uses volumeid to look up the volume in its global state
+
+Volume listing and volume attachment are bound to `server_id`; callers should not rely on URL-only lookup to rediscover
+an authenticated session.
+
+Long-lived clients that need cross-process reuse, such as KIO workers, should first call `afp_sl_resume()` with no
+password. This resumes the per-user daemon's existing host session rather than reauthenticating AFP user identity. If no
+matching daemon session exists, they should retrieve credentials from their own credential cache or prompt the user, then
+call `afp_sl_connect()` to authenticate.
 
 **Disconnect flow:**
 

--- a/include/afp_server.h
+++ b/include/afp_server.h
@@ -16,8 +16,11 @@ struct afp_server_request_header {
     unsigned int close;
 };
 
+#define AFP_SERVER_CONNECT_RESUME_EXISTING 0x1U
+
 struct afp_server_attach_request {
     struct afp_server_request_header header;
+    serverid_t serverid;
     struct afp_url url;
     unsigned int volume_options;
 };
@@ -41,6 +44,7 @@ struct afp_server_connect_request {
     struct afp_server_request_header header;
     struct afp_url url;
     unsigned int uam_mask;
+    unsigned int flags;
 };
 
 struct afp_server_connect_response {
@@ -61,6 +65,7 @@ struct afp_server_disconnect_response {
 
 struct afp_server_getvolid_request {
     struct afp_server_request_header header;
+    serverid_t serverid;
     struct afp_url url;
 };
 
@@ -85,6 +90,7 @@ struct afp_server_readdir_response {
 
 struct afp_server_getvols_request {
     struct afp_server_request_header header;
+    serverid_t serverid;
     struct afp_url url;
     int start;
     int count;

--- a/include/afpsl.h
+++ b/include/afpsl.h
@@ -95,12 +95,15 @@ int afp_sl_status(const char * volumename, const char * servername,
                   char *text, unsigned int *remaining);
 int afp_sl_connect(struct afp_url * url, unsigned int uam_mask,
                    serverid_t *id, char *loginmesg);
+int afp_sl_resume(struct afp_url * url, unsigned int uam_mask,
+                  serverid_t *id, char *loginmesg);
 int afp_sl_disconnect(serverid_t *id);
-int afp_sl_getvolid(struct afp_url * url, volumeid_t *volid);
+int afp_sl_getvolid(serverid_t serverid, struct afp_url * url,
+                    volumeid_t *volid);
 /* status is optional. On return it distinguishes a volume-password challenge
  * from other -EACCES failures. */
-int afp_sl_attach(struct afp_url * url, unsigned int volume_options,
-                  volumeid_t *volumeid,
+int afp_sl_attach(serverid_t serverid, struct afp_url * url,
+                  unsigned int volume_options, volumeid_t *volumeid,
                   enum afp_sl_attach_status *status);
 int afp_sl_detach(volumeid_t * volumeid,
                   struct afp_url * url);
@@ -108,7 +111,8 @@ int afp_sl_readdir(volumeid_t * volid, const char * path, struct afp_url * url,
                    int start, int count, unsigned int *numfiles,
                    struct afp_file_info_basic **fpb,
                    int *eod);
-int afp_sl_getvols(struct afp_url * url, unsigned int start,
+int afp_sl_getvols(serverid_t serverid, struct afp_url * url,
+                   unsigned int start,
                    unsigned int count, unsigned int *numvols,
                    struct afp_volume_summary * vols);
 int afp_sl_stat(volumeid_t * volid, const char * path,

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -11,7 +11,6 @@
 #include <netdb.h>
 #include <signal.h>
 #include <string.h>
-#include <time.h>
 
 #include "afp.h"
 #include "dsi.h"
@@ -67,26 +66,6 @@ struct afp_server *afp_server_full_connect(void * priv,
         goto error;
     }
 
-    if ((s = find_server_by_address(address))) {
-        if (s->connect_state == SERVER_STATE_CONNECTING) {
-            /* Connection in progress by another thread — wait for it */
-            int wait_ms = 0;
-
-            while (s->connect_state == SERVER_STATE_CONNECTING && wait_ms < 10000) {
-                struct timespec ts = {0, 100000000}; /* 100ms */
-                nanosleep(&ts, NULL);
-                wait_ms += 100;
-            }
-
-            if (s->connect_state != SERVER_STATE_CONNECTED) {
-                s = NULL;  /* Not ours to remove */
-                goto error;
-            }
-        }
-
-        goto have_server;
-    }
-
     if ((tmpserver = afp_server_init(address)) == NULL) {
         goto error;
     }
@@ -120,54 +99,57 @@ struct afp_server *afp_server_full_connect(void * priv,
            AFP_SERVER_NAME_UTF8_LEN);
     rx_quantum = tmpserver->rx_quantum;
     afp_server_remove(tmpserver);
-    s = find_server_by_signature(signature);
+    s = afp_server_init(address);
 
     if (!s) {
-        s = afp_server_init(address);
-
-        if ((ret = afp_server_connect(s, 0)) != 0) {
-            int connect_error = -ret;
-            log_for_client(priv, AFPFSD, LOG_ERR,
-                           "Connection to server failed with error: %s",
-                           strerror(connect_error));
-            afp_server_remove(s);
-            errno = connect_error;
-            s = NULL;
-            goto error;
+        if (errno == 0) {
+            errno = ENOMEM;
         }
 
-        s->supported_uams = uams;
-        memcpy(s->signature, signature, AFP_SIGNATURE_LEN);
-        memcpy(s->server_name, server_name, AFP_SERVER_NAME_LEN);
-        memcpy(s->server_name_utf8, server_name_utf8,
-               AFP_SERVER_NAME_UTF8_LEN);
-        memcpy(s->server_name_printable, server_name_printable,
-               AFP_SERVER_NAME_UTF8_LEN);
-        memcpy(s->machine_type, machine_type, AFP_MACHINETYPE_LEN);
-        memcpy(s->icon, icon, AFP_SERVER_ICON_LEN);
-        s->rx_quantum = rx_quantum;
-        afp_server_identify(s);
-
-        /* if our user and password strings are both empty, or if the username
-         * is "nobody" (AFP guest user), and the server supports guest logins,
-         * fall back to "No User Authent" (guest) UAM */
-        if (((*req->url.username == '\0' && *req->url.password == '\0') ||
-                strcmp(req->url.username, "nobody") == 0)
-                && (uams & UAM_NOUSERAUTHENT)) {
-            req->uam_mask = UAM_NOUSERAUTHENT;
-        }
-
-        if ((afp_server_complete_connection(priv,
-                                            s, (unsigned char *) &versions, uams,
-                                            req->url.username, req->url.password,
-                                            req->url.requested_version, req->uam_mask)) == NULL) {
-            /* complete_connection already called afp_server_remove() on failure */
-            s = NULL;
-            goto error;
-        }
+        goto error;
     }
 
-have_server:
+    if ((ret = afp_server_connect(s, 0)) != 0) {
+        int connect_error = -ret;
+        log_for_client(priv, AFPFSD, LOG_ERR,
+                       "Connection to server failed with error: %s",
+                       strerror(connect_error));
+        afp_server_remove(s);
+        errno = connect_error;
+        s = NULL;
+        goto error;
+    }
+
+    s->supported_uams = uams;
+    memcpy(s->signature, signature, AFP_SIGNATURE_LEN);
+    memcpy(s->server_name, server_name, AFP_SERVER_NAME_LEN);
+    memcpy(s->server_name_utf8, server_name_utf8,
+           AFP_SERVER_NAME_UTF8_LEN);
+    memcpy(s->server_name_printable, server_name_printable,
+           AFP_SERVER_NAME_UTF8_LEN);
+    memcpy(s->machine_type, machine_type, AFP_MACHINETYPE_LEN);
+    memcpy(s->icon, icon, AFP_SERVER_ICON_LEN);
+    s->rx_quantum = rx_quantum;
+    afp_server_identify(s);
+
+    /* if our user and password strings are both empty, or if the username
+     * is "nobody" (AFP guest user), and the server supports guest logins,
+     * fall back to "No User Authent" (guest) UAM */
+    if (((*req->url.username == '\0' && *req->url.password == '\0') ||
+            strcmp(req->url.username, "nobody") == 0)
+            && (uams & UAM_NOUSERAUTHENT)) {
+        req->uam_mask = UAM_NOUSERAUTHENT;
+    }
+
+    if ((afp_server_complete_connection(priv,
+                                        s, (unsigned char *) &versions, uams,
+                                        req->url.username, req->url.password,
+                                        req->url.requested_version, req->uam_mask)) == NULL) {
+        /* complete_connection already called afp_server_remove() on failure */
+        s = NULL;
+        goto error;
+    }
+
     afp_server_identify(s);
     return s;
 error:

--- a/lib/loop.c
+++ b/lib/loop.c
@@ -45,7 +45,7 @@ void termination_handler(int signum)
     switch (signum) {
     case SIGINT:
     case SIGTERM:
-        trigger_exit();
+        exit_program = 2;
         break;
 
     default:

--- a/lib/server.c
+++ b/lib/server.c
@@ -11,6 +11,7 @@
 #include <time.h>
 
 #include "afp.h"
+#include "compat.h"
 #include "dsi.h"
 #include "utils.h"
 #include "uams_def.h"
@@ -68,11 +69,14 @@ struct afp_server *afp_server_complete_connection(
     server->using_uam = using_uam;
 
     if (afp_server_login(server, mesg, &len, MAX_ERROR_LEN)) {
+        explicit_bzero(server->password, sizeof(server->password));
         log_for_client(priv, AFPFSD, LOG_ERR,
                        "Login error: %s", mesg);
         errno = EACCES;
         goto error;
     }
+
+    explicit_bzero(server->password, sizeof(server->password));
 
     if (afp_getsrvrparms(server)) {
         log_for_client(priv, AFPFSD, LOG_ERR,


### PR DESCRIPTION
Require callers to pass the serverid returned by CONNECT when attaching volumes, listing volumes, or resolving volume ids. afpsld now validates those handles directly instead of implicitly rediscovering authenticated sessions by server name or address.

Keep afp_sl_connect() strict: every CONNECT performs AFP authentication, so a wrong password can no longer reuse an existing daemon session. Scrub cached server passwords immediately after login.

Add afp_sl_resume() for clients such as KIO that need cross-worker session reuse without prompting. Resume only succeeds when the caller supplies no password and afpsld can identify one matching connected session; ambiguous or password-bearing resume attempts fail closed.

Update afpcmd and developer docs for the handle-bound connect/resume/attach flow.