### PR TITLE
introduce auto metadata mode that aligns with Netatalk

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,12 +16,12 @@ The names of tools and libraries will not be changed to signal continuity and co
 
 - Allow library consumers to register a persistent logging callback with context and syslog severity. Local libafpsl
   diagnostics and structured logs returned by every afpsld command use the same callback.
-- Add reusable metadata replacement and transfer helpers to `libafpsl`, with explicit filesystem-xattr, macOS AppleDouble,
-  and Netatalk AppleDouble storage modes and non-fatal warning flags for non-interactive consumers.
+- Add reusable metadata replacement and transfer helpers to `libafpsl`, with auto, filesystem-xattr,
+  macOS AppleDouble, and Netatalk AppleDouble storage modes and non-fatal warning flags for non-interactive consumers.
 
 ### afpcmd Client Improvements
 
-- Preserve Finder Info, resource forks, and generic extended attributes when transferring files, with selectable local
+- Preserve FinderInfo, ResourceFork, and generic extended attributes when transferring files, with selectable local
   metadata storage modes.
 
 ## afpfs-ng 0.9.4 (February 28, 2026)

--- a/cmdline/cmdline_afp.c
+++ b/cmdline/cmdline_afp.c
@@ -76,7 +76,7 @@ int full_url = 0;
 static volumeid_t vol_id = NULL;
 static serverid_t server_id = NULL;
 static int connected = 0;
-static enum afp_metadata_mode transfer_metadata_mode = AFP_METADATA_NETATALK;
+static enum afp_metadata_mode transfer_metadata_mode = AFP_METADATA_AUTO;
 static int metadata_warning_emitted = 0;
 
 static int write_all_fd(int fd, const void *data, size_t size);
@@ -86,6 +86,11 @@ static int write_all_fd(int fd, const void *data, size_t size);
  * their contents are transferred while processing the corresponding file. */
 static int metadata_sidecar_entry(const char *name)
 {
+    if (transfer_metadata_mode == AFP_METADATA_AUTO) {
+        return strncmp(name, "._", 2) == 0
+               || strcmp(name, ".AppleDouble") == 0;
+    }
+
     if (transfer_metadata_mode == AFP_METADATA_MACOS) {
         return strncmp(name, "._", 2) == 0;
     }

--- a/cmdline/cmdline_main.c
+++ b/cmdline/cmdline_main.c
@@ -245,7 +245,7 @@ COMMAND commands[] = {
     { "quit", com_quit, "Shut down afpcmd (leaves server connections intact)", 0 },
     { "rm", com_delete, "Delete FILE (-r for directories)", 1 },
     { "rmdir", com_rmdir, "Remove directory DIRECTORY", 1 },
-    { "resourcefork", com_resourcefork, "Get, set, or remove a resource fork", 1 },
+    { "resourcefork", com_resourcefork, "Get, set, or remove a ResourceFork", 1 },
     { "status", com_status, "Get some server status", 1 },
     { "touch", com_touch, "Touch FILE", 1 },
     { "xattr", com_xattr, "List, get, set, or remove extended attributes", 1 },
@@ -457,7 +457,7 @@ static void usage(void)
         "afpcmd [-h] [-V] [-v loglevel] [-M mode] <afp url>\n"
         "Options:\n"
         "\t-h:          show this help message and exit\n"
-        "\t-M mode:     preserve metadata using netatalk, xattr, macos, or none\n"
+        "\t-M mode:     preserve metadata using auto, netatalk, xattr, macos, or none\n"
         "\t-r:          recursively transfer directories in batch mode\n"
         "\t-V:          verbose mode (show detailed transfer messages)\n"
         "\t-v loglevel: set log verbosity (debug, info, notice, warning, error)\n"
@@ -481,7 +481,7 @@ int main(int argc, char *argv[])
     int verbose = 0;
     int show_usage = 0;
     int log_level = LOG_NOTICE;
-    const char *metadata_mode = "netatalk";
+    const char *metadata_mode = "auto";
     struct option long_options[] = {
         {"help", 0, 0, 'h'},
         {"metadata", 1, 0, 'M'},

--- a/daemon/metadata.c
+++ b/daemon/metadata.c
@@ -86,6 +86,11 @@ static int metadata_absent(int error)
     return error == ENOATTR || error == ENODATA;
 }
 
+static int metadata_unsupported(int error)
+{
+    return error == ENOTSUP || error == EOPNOTSUPP || error == ENOSYS;
+}
+
 static int local_path_check(const char *path)
 {
     struct stat st;
@@ -103,7 +108,9 @@ int afp_metadata_mode_parse(const char *name, enum afp_metadata_mode *mode)
         return -EINVAL;
     }
 
-    if (strcmp(name, "netatalk") == 0) {
+    if (strcmp(name, "auto") == 0) {
+        *mode = AFP_METADATA_AUTO;
+    } else if (strcmp(name, "netatalk") == 0) {
         *mode = AFP_METADATA_NETATALK;
     } else if (strcmp(name, "xattr") == 0) {
         *mode = AFP_METADATA_XATTR;
@@ -120,12 +127,15 @@ int afp_metadata_mode_parse(const char *name, enum afp_metadata_mode *mode)
 
 static int metadata_mode_valid(enum afp_metadata_mode mode)
 {
-    return mode >= AFP_METADATA_NETATALK && mode <= AFP_METADATA_NONE;
+    return mode >= AFP_METADATA_AUTO && mode <= AFP_METADATA_NONE;
 }
 
 const char *afp_metadata_mode_name(enum afp_metadata_mode mode)
 {
     switch (mode) {
+    case AFP_METADATA_AUTO:
+        return "auto";
+
     case AFP_METADATA_NETATALK:
         return "netatalk";
 
@@ -248,6 +258,57 @@ static int sys_remove(const char *path, const char *name)
     (void)actual;
     errno = ENOTSUP;
     return -1;
+#endif
+}
+
+static int sys_xattrs_supported(const char *path)
+{
+    ssize_t ret;
+#if defined(__APPLE__) && (defined(HAVE_SYS_XATTR_H) || defined(HAVE_ATTR_XATTR_H))
+    ret = listxattr(path, NULL, 0, 0);
+#elif defined(HAVE_SYS_XATTR_H) || defined(HAVE_ATTR_XATTR_H)
+    ret = listxattr(path, NULL, 0);
+#elif defined(HAVE_SYS_EXTATTR_H)
+    ret = extattr_list_file(path, EXTATTR_NAMESPACE_USER, NULL, 0);
+#else
+    (void)path;
+    return 0;
+#endif
+
+    if (ret >= 0) {
+        return 1;
+    }
+
+    return metadata_unsupported(errno) ? 0 : -errno;
+}
+
+static int resolve_generic_mode(const char *path, enum afp_metadata_mode mode,
+                                enum afp_metadata_mode *resolved)
+{
+    int supported;
+
+    if (mode != AFP_METADATA_AUTO) {
+        *resolved = mode;
+        return 0;
+    }
+
+    supported = sys_xattrs_supported(path);
+
+    if (supported < 0) {
+        return supported;
+    }
+
+    *resolved = supported ? AFP_METADATA_XATTR : AFP_METADATA_NETATALK;
+    return 0;
+}
+
+static int apple_metadata_uses_sys(enum afp_metadata_mode mode)
+{
+#if defined(__APPLE__)
+    return mode == AFP_METADATA_AUTO || mode == AFP_METADATA_XATTR;
+#else
+    (void)mode;
+    return 0;
 #endif
 }
 
@@ -1233,6 +1294,7 @@ int local_metadata_list(const char *path, enum afp_metadata_mode mode,
                         size_t *size)
 {
     int ret;
+    enum afp_metadata_mode resolved;
     *list = NULL;
     *size = 0;
     ret = local_path_check(path);
@@ -1241,15 +1303,21 @@ int local_metadata_list(const char *path, enum afp_metadata_mode mode,
         return ret;
     }
 
-    if (mode == AFP_METADATA_NETATALK) {
-        return netatalk_list(path, list, size);
+    ret = resolve_generic_mode(path, mode, &resolved);
+
+    if (ret < 0) {
+        return ret;
     }
 
-    if (mode == AFP_METADATA_XATTR) {
+    if (resolved == AFP_METADATA_XATTR) {
         return sys_list(path, list, size);
     }
 
-    if (mode == AFP_METADATA_MACOS || mode == AFP_METADATA_NONE) {
+    if (resolved == AFP_METADATA_NETATALK) {
+        return netatalk_list(path, list, size);
+    }
+
+    if (resolved == AFP_METADATA_MACOS || resolved == AFP_METADATA_NONE) {
         return 0;
     }
 
@@ -1260,6 +1328,7 @@ int local_metadata_get(const char *path, enum afp_metadata_mode mode,
                        const char *name, void **value, size_t *size)
 {
     ssize_t needed;
+    enum afp_metadata_mode resolved;
     int ret = local_path_check(path);
 
     if (ret < 0) {
@@ -1274,11 +1343,13 @@ int local_metadata_get(const char *path, enum afp_metadata_mode mode,
         return -ENOTSUP;
     }
 
-    if (mode == AFP_METADATA_NETATALK) {
-        return netatalk_get(path, name, value, size);
+    ret = resolve_generic_mode(path, mode, &resolved);
+
+    if (ret < 0) {
+        return ret;
     }
 
-    if (mode == AFP_METADATA_XATTR) {
+    if (resolved == AFP_METADATA_XATTR) {
         needed = sys_get(path, name, NULL, 0);
 
         if (needed >= 0) {
@@ -1306,13 +1377,18 @@ int local_metadata_get(const char *path, enum afp_metadata_mode mode,
         return -errno;
     }
 
-    return mode == AFP_METADATA_MACOS || mode == AFP_METADATA_NONE
+    if (resolved == AFP_METADATA_NETATALK) {
+        return netatalk_get(path, name, value, size);
+    }
+
+    return resolved == AFP_METADATA_MACOS || resolved == AFP_METADATA_NONE
            ? -ENOTSUP : -EINVAL;
 }
 
 int local_metadata_set(const char *path, enum afp_metadata_mode mode,
                        const char *name, const void *value, size_t size)
 {
+    enum afp_metadata_mode resolved;
     int ret = local_path_check(path);
 
     if (ret < 0) {
@@ -1327,25 +1403,28 @@ int local_metadata_set(const char *path, enum afp_metadata_mode mode,
         return -ENOTSUP;
     }
 
-    if (mode == AFP_METADATA_NETATALK) {
+    ret = resolve_generic_mode(path, mode, &resolved);
+
+    if (ret < 0) {
+        return ret;
+    }
+
+    if (resolved == AFP_METADATA_XATTR) {
+        return sys_set(path, name, value, size) == 0 ? 0 : -errno;
+    }
+
+    if (resolved == AFP_METADATA_NETATALK) {
         return netatalk_set(path, name, value, size);
     }
 
-    if (mode == AFP_METADATA_XATTR) {
-        if (sys_set(path, name, value, size) == 0) {
-            return 0;
-        }
-
-        return -errno;
-    }
-
-    return mode == AFP_METADATA_MACOS || mode == AFP_METADATA_NONE
+    return resolved == AFP_METADATA_MACOS || resolved == AFP_METADATA_NONE
            ? -ENOTSUP : -EINVAL;
 }
 
 int local_metadata_remove(const char *path, enum afp_metadata_mode mode,
                           const char *name)
 {
+    enum afp_metadata_mode resolved;
     int ret = local_path_check(path);
 
     if (ret < 0) {
@@ -1356,19 +1435,29 @@ int local_metadata_remove(const char *path, enum afp_metadata_mode mode,
         return -EINVAL;
     }
 
-    if (mode == AFP_METADATA_NETATALK) {
-        return netatalk_remove(path, name);
+    ret = resolve_generic_mode(path, mode, &resolved);
+
+    if (ret < 0) {
+        return ret;
     }
 
-    if (mode == AFP_METADATA_XATTR) {
+    if (resolved == AFP_METADATA_XATTR) {
         if (sys_remove(path, name) == 0) {
             return 0;
         }
 
-        return -errno;
+        if (!metadata_absent(errno)) {
+            return -errno;
+        }
+
+        return 0;
     }
 
-    return mode == AFP_METADATA_MACOS || mode == AFP_METADATA_NONE
+    if (resolved == AFP_METADATA_NETATALK) {
+        return netatalk_remove(path, name);
+    }
+
+    return resolved == AFP_METADATA_MACOS || resolved == AFP_METADATA_NONE
            ? -ENOTSUP : -EINVAL;
 }
 
@@ -1382,11 +1471,7 @@ int local_finderinfo_get(const char *path, enum afp_metadata_mode mode,
         return path_ret;
     }
 
-    if (mode == AFP_METADATA_NETATALK) {
-        return ad_finder_get(path, 1, value);
-    }
-
-    if (mode == AFP_METADATA_XATTR) {
+    if (apple_metadata_uses_sys(mode)) {
         ret = sys_get(path, AFP_XATTR_FINDERINFO, value, 32);
 
         if (ret == 32) {
@@ -1396,7 +1481,12 @@ int local_finderinfo_get(const char *path, enum afp_metadata_mode mode,
         return ret < 0 ? -errno : -EIO;
     }
 
-    if (mode == AFP_METADATA_MACOS) {
+    if (mode == AFP_METADATA_NETATALK) {
+        return ad_finder_get(path, 1, value);
+    }
+
+    if (mode == AFP_METADATA_AUTO || mode == AFP_METADATA_XATTR
+            || mode == AFP_METADATA_MACOS) {
         return ad_finder_get(path, 0, value);
     }
 
@@ -1412,19 +1502,17 @@ int local_finderinfo_set(const char *path, enum afp_metadata_mode mode,
         return ret;
     }
 
+    if (apple_metadata_uses_sys(mode)) {
+        return sys_set(path, AFP_XATTR_FINDERINFO, value, 32) == 0
+               ? 0 : -errno;
+    }
+
     if (mode == AFP_METADATA_NETATALK) {
         return ad_finder_set(path, 1, value);
     }
 
-    if (mode == AFP_METADATA_XATTR) {
-        if (sys_set(path, AFP_XATTR_FINDERINFO, value, 32) == 0) {
-            return 0;
-        }
-
-        return -errno;
-    }
-
-    if (mode == AFP_METADATA_MACOS) {
+    if (mode == AFP_METADATA_AUTO || mode == AFP_METADATA_XATTR
+            || mode == AFP_METADATA_MACOS) {
         return ad_finder_set(path, 0, value);
     }
 
@@ -1444,15 +1532,20 @@ int local_finderinfo_remove(const char *path, enum afp_metadata_mode mode)
         return ad_finder_set(path, 1, empty);
     }
 
-    if (mode == AFP_METADATA_XATTR) {
+    if (apple_metadata_uses_sys(mode)) {
         if (sys_remove(path, AFP_XATTR_FINDERINFO) == 0) {
             return 0;
         }
 
-        return -errno;
+        if (!metadata_absent(errno)) {
+            return -errno;
+        }
+
+        return 0;
     }
 
-    if (mode == AFP_METADATA_MACOS) {
+    if (mode == AFP_METADATA_AUTO || mode == AFP_METADATA_XATTR
+            || mode == AFP_METADATA_MACOS) {
         return ad_finder_set(path, 0, empty);
     }
 
@@ -1468,11 +1561,7 @@ off_t local_resourcefork_size(const char *path, enum afp_metadata_mode mode)
         return path_ret;
     }
 
-    if (mode == AFP_METADATA_NETATALK) {
-        return ad_resource_size(path, 1);
-    }
-
-    if (mode == AFP_METADATA_XATTR) {
+    if (apple_metadata_uses_sys(mode)) {
         ret = sys_get(path, AFP_XATTR_RESOURCEFORK, NULL, 0);
 
         if (ret >= 0) {
@@ -1482,7 +1571,12 @@ off_t local_resourcefork_size(const char *path, enum afp_metadata_mode mode)
         return -errno;
     }
 
-    if (mode == AFP_METADATA_MACOS) {
+    if (mode == AFP_METADATA_NETATALK) {
+        return ad_resource_size(path, 1);
+    }
+
+    if (mode == AFP_METADATA_AUTO || mode == AFP_METADATA_XATTR
+            || mode == AFP_METADATA_MACOS) {
         return ad_resource_size(path, 0);
     }
 
@@ -1506,11 +1600,7 @@ ssize_t local_resourcefork_read(const char *path, enum afp_metadata_mode mode,
         return path_ret;
     }
 
-    if (mode == AFP_METADATA_NETATALK) {
-        return ad_resource_read(path, 1, buf, size, offset);
-    }
-
-    if (mode == AFP_METADATA_XATTR) {
+    if (apple_metadata_uses_sys(mode)) {
         off_t total = local_resourcefork_size(path, AFP_METADATA_XATTR);
 
         if (total >= 0) {
@@ -1561,7 +1651,12 @@ ssize_t local_resourcefork_read(const char *path, enum afp_metadata_mode mode,
         return total;
     }
 
-    if (mode == AFP_METADATA_MACOS) {
+    if (mode == AFP_METADATA_NETATALK) {
+        return ad_resource_read(path, 1, buf, size, offset);
+    }
+
+    if (mode == AFP_METADATA_AUTO || mode == AFP_METADATA_XATTR
+            || mode == AFP_METADATA_MACOS) {
         return ad_resource_read(path, 0, buf, size, offset);
     }
 
@@ -1586,11 +1681,7 @@ int local_resourcefork_write(const char *path, enum afp_metadata_mode mode,
         return path_ret;
     }
 
-    if (mode == AFP_METADATA_NETATALK) {
-        return ad_resource_write(path, 1, buf, size, offset);
-    }
-
-    if (mode == AFP_METADATA_XATTR) {
+    if (apple_metadata_uses_sys(mode)) {
         off_t old_size = offset == 0 ? 0 : local_resourcefork_size(path,
                          AFP_METADATA_XATTR);
         size_t position = (size_t)offset;
@@ -1643,7 +1734,12 @@ int local_resourcefork_write(const char *path, enum afp_metadata_mode mode,
         return -error;
     }
 
-    if (mode == AFP_METADATA_MACOS) {
+    if (mode == AFP_METADATA_NETATALK) {
+        return ad_resource_write(path, 1, buf, size, offset);
+    }
+
+    if (mode == AFP_METADATA_AUTO || mode == AFP_METADATA_XATTR
+            || mode == AFP_METADATA_MACOS) {
         return ad_resource_write(path, 0, buf, size, offset);
     }
 
@@ -1662,15 +1758,20 @@ int local_resourcefork_remove(const char *path, enum afp_metadata_mode mode)
         return ad_resource_write(path, 1, NULL, 0, 0);
     }
 
-    if (mode == AFP_METADATA_XATTR) {
+    if (apple_metadata_uses_sys(mode)) {
         if (sys_remove(path, AFP_XATTR_RESOURCEFORK) == 0) {
             return 0;
         }
 
-        return -errno;
+        if (!metadata_absent(errno)) {
+            return -errno;
+        }
+
+        return 0;
     }
 
-    if (mode == AFP_METADATA_MACOS) {
+    if (mode == AFP_METADATA_AUTO || mode == AFP_METADATA_XATTR
+            || mode == AFP_METADATA_MACOS) {
         return ad_resource_write(path, 0, NULL, 0, 0);
     }
 

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -1,12 +1,42 @@
 # Developer Documentation for Netatalk Client
 
-The Apple Filing Protocol is a network filesystem that is commonly used
-to share files between Apple Macintosh computers.
+AFP (Apple Filing Protocol) originated on the Mac as Apple's network
+filesystem protocol. Today it is a cross-platform protocol with multiple
+independent client and server implementations, including Netatalk on the
+server side and this Netatalk Client project on the client side. A client
+has to establish a network connection to an AFP server, attach to a volume,
+and keep that session state alive while file operations are in progress.
 
-A network connection must be established to a server and maintained.  
-Netatalk Client provides a basic library on which to build full clients
-(called libafpclient), and a sample of clients (FUSE and a simple
-command line).
+Netatalk Client is split into a stateful protocol library, a stateless
+adapter layer, and two different front-ends. `libafpclient` is the core
+library that knows how to speak DSI and AFP, but it expects a long-lived
+process that can live with its event loop, threads, signals, and connection
+state.
+
+`libafpsl` is the stateless API in `afpsl.h`. It lets short-lived tools and
+other applications issue one operation at a time without embedding
+`libafpclient`'s event loop. Under the hood, `libafpsl` talks over a Unix
+socket to `afpsld`, the stateless daemon implemented in `daemon/`. `afpsld`
+owns the persistent AFP server and volume state, calls the `libafpclient`
+midlevel API, and returns one response to each stateless request. This is
+the layer used by `afpcmd`, and it can be built without FUSE.
+
+The user-facing clients then choose how to present AFP files to callers:
+
+- The FUSE client in `fuse/` mounts an AFP volume as a local filesystem.
+  Applications operate on files under the mountpoint, and filesystem calls
+  are translated into AFP operations. The AFP server decides how to store
+  file metadata for this path; `afpcmd` metadata mode is not involved.
+- `afpcmd` is an ftp-style file-transfer client built from `cmdline/` on top
+  of `libafpsl` and `afpsld`. It copies data between the AFP server and a
+  path on the ordinary local filesystem, not a FUSE mount. Its `-M` /
+  `--metadata` option only selects the local on-disk representation for
+  metadata preserved during these transfers.
+
+Both front-ends ultimately use the same AFP protocol machinery, but they
+answer different questions. FUSE asks "how do I make this remote volume look
+like a local filesystem?" `afpcmd` asks "how do I copy this remote object to
+or from a regular local path?"
 
 ## Architectural Diagram
 
@@ -25,9 +55,11 @@ command line).
         ├──────────────────┤          ├─────────────────────┤
         │ • CONNECT        │          │ • MOUNT/UNMOUNT     │
         │ • File I/O       │          │ • FUSE operations   │
-        │ • Dir ops        │          │ • Multi-mount mgmt  │
-        │                  │          │                     │
-        │ NO dependencies  │          │ Requires libfuse    │
+        │ • Dir ops        │          │ • xattr callbacks   │
+        │ • Metadata copy  │          │ • Multi-mount mgmt  │
+        │   modes: FI, RF, │          │                     │
+        │   xattrs         │          │                     │
+        │                  │          │ Requires libfuse    │
         └───────┬──────────┘          └───────┬─────────────┘
                 │                             │
                 │  Calls midlevel API         │  Calls midlevel API
@@ -37,6 +69,7 @@ command line).
                 │      libafpclient.so             │
                 ├──────────────────────────────────┤
                 │  • midlevel (afp.h, midlevel.h)  │
+                │  • metadata ops                  │
                 │  • lowlevel                      │
                 │  • proto_* (AFP protocol)        │
                 │  • Engine (DSI, event loop)      │
@@ -340,15 +373,20 @@ The callback runs synchronously on the calling thread. Passing a null callback d
 process-global, matching the stateless library's process-global connection state.
 
 The library also provides metadata-only replacement helpers for local-to-AFP, AFP-to-local, and AFP-to-AFP copies.
-Callers select the local representation on each operation with `enum afp_metadata_mode`;
-supported modes are Netatalk AppleDouble, filesystem xattrs, macOS AppleDouble, and none.
+Callers select the local on-disk representation on each operation with `enum afp_metadata_mode`;
+this is the implementation behind `afpcmd -M` / `--metadata` for file transfers involving an ordinary local path.
+It does not control FUSE mounts or the AFP server's own metadata storage.
+Supported modes are auto, Netatalk AppleDouble, filesystem xattrs, macOS AppleDouble, and none.
 The destination must already exist.
-These helpers clear represented destination metadata before copying Finder Info, the resource fork, and eligible generic
+These helpers clear represented destination metadata before copying FinderInfo, ResourceFork, and eligible generic
 xattrs. They deliberately do not copy the data fork, POSIX mode, or timestamps.
+In auto mode, generic xattrs use filesystem xattrs when available and Netatalk AppleDouble EA sidecars otherwise.
+FinderInfo and ResourceFork use native filesystem xattrs on macOS, and macOS AppleDouble sidecars on other systems
+unless Netatalk mode is selected explicitly.
 
 The stateless API returns zero on success and negative errno values on failure. Metadata read and list calls instead
 return a nonnegative byte count on success. Generic xattr values are limited to 4096 bytes,
-xattr name lists to `AFP_SL_XATTR_LIST_MAX`, and resource forks to `INT_MAX`. Resource-fork data is read and written in
+xattr name lists to `AFP_SL_XATTR_LIST_MAX`, and resource forks to `INT_MAX`. Resource fork data is read and written in
 4096-byte chunks. Positioned writes do not shorten an existing fork, except that a zero-length write at offset
 zero clears it; call `afp_sl_truncateresourcefork()` to set its final length explicitly. `afp_sl_setxattr()` accepts
 `AFP_SL_XATTR_CREATE` or `AFP_SL_XATTR_REPLACE` (the portable equivalents of

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -98,9 +98,13 @@ E.g.
         Getting file /linux-2.6.14.tar.bz2
     Transferred 39172170 bytes in 2.862 seconds. (13687 kB/s)
 
-Transfers preserve FinderInfo, resource forks, generic extended attributes,
+Transfers preserve FinderInfo, ResourceForks, generic extended attributes,
 file modes, and modification times by default.
-Use '-M netatalk', '-M xattr', or '-M macos' to select local metadata storage,
+The default '-M auto' mode uses filesystem extended attributes for generic
+xattrs when available, and falls back to Netatalk AppleDouble EA sidecars
+otherwise. FinderInfo and ResourceForks use native filesystem xattrs on macOS,
+and macOS AppleDouble sidecars on other systems.
+Use '-M netatalk', '-M xattr', or '-M macos' to force local metadata storage,
 and '-M none' to transfer only the data fork.
 
 See afpcmd(1) for more information.

--- a/docs/manpages/afpcmd.1
+++ b/docs/manpages/afpcmd.1
@@ -69,26 +69,43 @@ Default is
 .Cm notice .
 Logs are written to standard error and syslog.
 .It Fl M , Fl -metadata Ar mode
-Preserves FinderInfo, resource forks, generic extended attributes, modes,
+Preserves FinderInfo, ResourceFork, generic extended attributes, modes,
 and modification times during transfers.
+This option selects the local on-disk representation used by
+.Nm
+when metadata is copied between the AFP server and an ordinary local path;
+it does not configure how the AFP server stores metadata.
 The storage mode may be
+.Cm auto ,
 .Cm netatalk ,
 .Cm xattr ,
 .Cm macos ,
 or
 .Cm none .
+.Cm auto
+is the default; it uses local filesystem extended attributes for generic
+xattrs when available, and falls back to Netatalk AppleDouble EA sidecars
+otherwise.
+FinderInfo and ResourceFork use native filesystem xattrs on macOS, and
+macOS-compatible
+.Pa ._name
+AppleDouble files on other systems.
 .Cm netatalk
 uses
 .Pa .AppleDouble/name
 and
 .Pa name::EA
-files and is the default.
+files.
 .Cm xattr
-uses only local filesystem extended attributes.
+uses local filesystem extended attributes for generic xattrs.
+FinderInfo and ResourceFork use native filesystem xattrs on macOS, and
+macOS-compatible
+.Pa ._name
+AppleDouble files on other systems.
 .Cm macos
 uses macOS-compatible
 .Pa ._name
-AppleDouble files for FinderInfo and resource forks.
+AppleDouble files for FinderInfo and ResourceFork.
 .Cm none
 transfers only the data fork.
 .It Ar afp_url
@@ -205,11 +222,11 @@ Set FinderInfo from an exactly 32-byte local file.
 .It Cm finderinfo remove Ar path
 Clear FinderInfo.
 .It Cm resourcefork get Ar path Op Ar output
-Read a resource fork.
+Read a ResourceFork.
 .It Cm resourcefork set Ar path Ar input
-Set a resource fork from a local binary file.
+Set a ResourceFork from a local binary file.
 .It Cm resourcefork remove Ar path
-Remove a resource fork.
+Remove a ResourceFork.
 .El
 .Ss Status commands
 .Bl -tag -width Ds

--- a/fuse/fuse_int.c
+++ b/fuse/fuse_int.c
@@ -178,7 +178,7 @@ static int fuse_getxattr(const char *path, const char *name, char *value,
 
     if (strcmp(name, AFP_XATTR_RESOURCEFORK) == 0) {
         log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                       "*** getxattr resource fork %s (size=%zu position=%u)",
+                       "*** getxattr ResourceFork %s (size=%zu position=%u)",
                        path, size, position);
         ret = ml_getresourcefork(volume, path, value, size, position);
         return ret;
@@ -239,7 +239,7 @@ static int fuse_setxattr(const char *path, const char *name,
 
     if (strcmp(name, AFP_XATTR_RESOURCEFORK) == 0) {
         log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                       "*** setxattr resource fork %s (size=%zu position=%u)",
+                       "*** setxattr ResourceFork %s (size=%zu position=%u)",
                        path, size, position);
         ret = ml_setresourcefork_flags(volume, path, value, size, position,
                                        ml_flags);
@@ -1420,7 +1420,7 @@ int afp_register_fuse(int fuseargc, char *fuseargv[], struct afp_volume * vol)
 {
     int ret;
     struct fuse_operations oper = afp_oper;
-    /* FinderInfo and resource forks use the xattr callbacks on macOS even
+    /* FinderInfo and ResourceFork use the xattr callbacks on macOS even
      * when the AFP volume does not support generic extended attributes. */
 #ifndef __APPLE__
 

--- a/include/afpsl.h
+++ b/include/afpsl.h
@@ -45,8 +45,12 @@ enum afp_sl_password_change_status {
     AFP_SL_PASSWORD_CHANGE_STATUS_INVALID_PARAMETER,
 };
 
-/* Local filesystem representation used by metadata transfer helpers. */
+/* Local filesystem representation used by metadata transfer helpers.  AUTO
+ * probes generic filesystem xattrs, then falls back to Netatalk AppleDouble
+ * EA sidecars.  FinderInfo and ResourceFork use native xattrs on macOS and
+ * macOS AppleDouble sidecars elsewhere unless Netatalk mode is selected. */
 enum afp_metadata_mode {
+    AFP_METADATA_AUTO,
     AFP_METADATA_NETATALK,
     AFP_METADATA_XATTR,
     AFP_METADATA_MACOS,
@@ -159,7 +163,7 @@ int afp_sl_changepw(struct afp_url * url,
  *
  * afp_sl_setxattr accepts zero or one of AFP_SL_XATTR_CREATE and
  * AFP_SL_XATTR_REPLACE; other flag combinations return -EINVAL.
- * Resource-fork writes overwrite or extend the specified range but do not
+ * Resource fork writes overwrite or extend the specified range but do not
  * shorten an existing fork. A zero-length write at offset zero clears
  * the fork. Use afp_sl_truncateresourcefork to set any final length explicitly. */
 int afp_sl_getxattr(volumeid_t *volid, const char *path, const char *name,

--- a/test/test_afpcmd_batch.t
+++ b/test/test_afpcmd_batch.t
@@ -78,7 +78,7 @@ if (-e $sidecar_path) {
     my $downloaded_ad = do { local $/; <$read_ad> };
     close $read_ad;
     is($downloaded_ad, $appledouble,
-        'batch_download: FinderInfo and resource fork match');
+        'batch_download: FinderInfo and ResourceFork match');
 }
 if (-e $test_path) {
     is((stat($test_path))[2] & 07777, 0640,

--- a/test/test_afpcmd_interactive.t
+++ b/test/test_afpcmd_interactive.t
@@ -246,7 +246,7 @@ sub afpcmd_pipe {
 }
 
 # -----------------------------------------------------------------------
-# test_metadata_commands: round-trip FinderInfo, resource fork, and xattr
+# test_metadata_commands: round-trip FinderInfo, ResourceFork, and xattr
 # -----------------------------------------------------------------------
 {
     my $base = "/tmp/afpcmd_metadata_$$";
@@ -289,7 +289,7 @@ sub afpcmd_pipe {
         'test_metadata_commands: xattr appears in list');
 
     for my $pair ([$finder_in, $finder_out, 'FinderInfo'],
-                  [$resource_in, $resource_out, 'resource fork'],
+                  [$resource_in, $resource_out, 'ResourceFork'],
                   [$xattr_in, $xattr_out, 'xattr']) {
         if (!-e $pair->[1]) {
             fail('test_metadata_commands: ' . $pair->[2] . ' output exists');

--- a/test/test_metadata.c
+++ b/test/test_metadata.c
@@ -89,7 +89,7 @@ int main(int argc, char **argv)
     char temporary[] = "afpcmd-metadata-XXXXXX";
     char file[1024], missing[1024], macos_sidecar[1024], netatalk_dir[1024];
     char netatalk_sidecar[1024], ea_header[1024], ea_value[1024];
-    unsigned char finder[32], actual_finder[32];
+    unsigned char finder[32], macos_finder[32], actual_finder[32];
     unsigned char resource[7000], actual_resource[7000];
     char *list = NULL;
     size_t list_size = 0;
@@ -146,8 +146,11 @@ int main(int argc, char **argv)
     CHECK(local_resourcefork_size(missing, AFP_METADATA_MACOS) == -ENOENT);
     CHECK(local_metadata_list(missing, AFP_METADATA_NETATALK,
                               &list, &list_size) == -ENOENT);
-    CHECK(afp_metadata_clear_local(missing, AFP_METADATA_NETATALK,
+    CHECK(afp_metadata_clear_local(missing, AFP_METADATA_AUTO,
                                    &warnings) == -ENOENT);
+    CHECK(afp_metadata_mode_parse("auto", &parsed_mode) == 0
+          && parsed_mode == AFP_METADATA_AUTO);
+    CHECK(strcmp(afp_metadata_mode_name(AFP_METADATA_AUTO), "auto") == 0);
     CHECK(afp_metadata_mode_parse("netatalk", &parsed_mode) == 0
           && parsed_mode == AFP_METADATA_NETATALK);
     CHECK(strcmp(afp_metadata_mode_name(AFP_METADATA_NETATALK),
@@ -223,6 +226,8 @@ int main(int argc, char **argv)
     CHECK(local_finderinfo_get(file, AFP_METADATA_MACOS,
                                actual_finder) == -ENOATTR);
     CHECK(local_resourcefork_size(file, AFP_METADATA_MACOS) <= 0);
+    CHECK(local_finderinfo_remove(file, AFP_METADATA_MACOS) == 0);
+    CHECK(local_resourcefork_remove(file, AFP_METADATA_MACOS) == 0);
     CHECK(chmod(temporary, 0750) == 0);
     old_umask = umask(0000);
     CHECK(local_finderinfo_set(file, AFP_METADATA_NETATALK, finder) == 0);
@@ -254,6 +259,23 @@ int main(int argc, char **argv)
                              &value, &value_size) < 0);
     CHECK(local_metadata_set(file, AFP_METADATA_NETATALK, "bad/name",
                              resource, 1) == -EINVAL);
+#ifndef __APPLE__
+    memset(macos_finder, 0xa5, sizeof(macos_finder));
+    CHECK(local_finderinfo_set(file, AFP_METADATA_MACOS, macos_finder) == 0);
+    CHECK(local_resourcefork_write(file, AFP_METADATA_MACOS,
+                                   "macos", 5, 0) == 0);
+    CHECK(local_finderinfo_get(file, AFP_METADATA_AUTO, actual_finder) == 0);
+    CHECK(memcmp(actual_finder, macos_finder, sizeof(actual_finder)) == 0);
+    CHECK(local_resourcefork_size(file, AFP_METADATA_AUTO) == 5);
+    CHECK(local_resourcefork_read(file, AFP_METADATA_AUTO, actual_resource,
+                                  sizeof(actual_resource), 0) == 5);
+    CHECK(memcmp(actual_resource, "macos", 5) == 0);
+    CHECK(local_finderinfo_remove(file, AFP_METADATA_AUTO) == 0);
+    CHECK(local_resourcefork_remove(file, AFP_METADATA_AUTO) == 0);
+    CHECK(local_finderinfo_get(file, AFP_METADATA_MACOS,
+                               actual_finder) == -ENOATTR);
+    CHECK(local_resourcefork_size(file, AFP_METADATA_MACOS) <= 0);
+#endif
     CHECK(local_finderinfo_remove(file, AFP_METADATA_NONE) == -ENOTSUP);
     CHECK(local_resourcefork_remove(file, AFP_METADATA_NONE) == -ENOTSUP);
     {
@@ -300,6 +322,17 @@ int main(int argc, char **argv)
             value = NULL;
             CHECK(local_metadata_remove(file, AFP_METADATA_XATTR,
                                         "user.afpcmd-system") == 0);
+            CHECK(local_metadata_set(file, AFP_METADATA_XATTR,
+                                     "user.afpcmd-merge", "system", 6) == 0);
+            CHECK(local_metadata_get(file, AFP_METADATA_AUTO,
+                                     "user.afpcmd-merge", &value, &value_size) == 0);
+            CHECK(value_size == 6 && memcmp(value, "system", 6) == 0);
+            free(value);
+            value = NULL;
+            CHECK(local_metadata_remove(file, AFP_METADATA_AUTO,
+                                        "user.afpcmd-merge") == 0);
+            CHECK(local_metadata_get(file, AFP_METADATA_AUTO,
+                                     "user.afpcmd-merge", &value, &value_size) < 0);
         } else {
             CHECK(sys_ret == -ENOTSUP || sys_ret == -EOPNOTSUPP);
         }


### PR DESCRIPTION
Resolve auto generic xattr storage from local xattr capability, falling back to Netatalk AppleDouble EA sidecars when unsupported.

Route FinderInfo and ResourceFork through native xattrs only on macOS, using macOS AppleDouble sidecars elsewhere for auto and xattr modes.

Both of these are now aligned with Netatalk's metadata storage semantics.

Update afpcmd defaults, docs, and metadata tests.