### PR TITLE
lib/afp.c: Disable TCP Nagle

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,15 +36,15 @@ jobs:
             shfmt \
             yamlfmt
       - name: Check C formatting
-        run: ./codefmt.sh -v -s c
+        run: ./contrib/scripts/codefmt.sh -v -s c
       - name: Check markdown formatting
-        run: ./codefmt.sh -v -s markdown
+        run: ./contrib/scripts/codefmt.sh -v -s markdown
       - name: Check meson formatting
-        run: ./codefmt.sh -v -s meson
+        run: ./contrib/scripts/codefmt.sh -v -s meson
       - name: Check shell script formatting
-        run: ./codefmt.sh -v -s shell
+        run: ./contrib/scripts/codefmt.sh -v -s shell
       - name: Check yaml formatting
-        run: ./codefmt.sh -v -s yaml
+        run: ./contrib/scripts/codefmt.sh -v -s yaml
 
   markdown-linting:
     name: Markdown Linting

--- a/contrib/scripts/codefmt.sh
+++ b/contrib/scripts/codefmt.sh
@@ -2,7 +2,7 @@
 
 # Recursively format source files in the current repo directory
 #
-# (c) 2025 Daniel Markstedt <daniel@mindani.net>
+# (c) 2025-2026 Daniel Markstedt <daniel@mindani.net>
 #
 #  This program is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -47,9 +47,9 @@ while getopts "vs:" opt; do
     esac
 done
 
-if ! git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
-    echo "Warning: Not inside a git repository; will not be able to determine if any changes were made by this script" >&2
-else
+git config --global --add safe.directory "$PWD" > /dev/null 2>&1
+
+if git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
     IS_GIT=1
     INITIAL_DIFF_HASH=$(git diff HEAD | git hash-object --stdin)
 fi
@@ -58,11 +58,11 @@ if [ "$SOURCE_TYPE" = "c" ] || [ "$SOURCE_TYPE" = "" ]; then
     if command -v astyle > /dev/null 2>&1; then
         FORMATTER_CMD="astyle --options=.astylerc --recursive --suffix=none"
         if [ $VERBOSE -eq 1 ]; then
-            echo "Formatting C sources..."
+            echo "Formatting C / C++ sources..."
         else
             FORMATTER_CMD="$FORMATTER_CMD --quiet"
         fi
-        eval "$FORMATTER_CMD '*.h' '*.c'"
+        eval "$FORMATTER_CMD '*.h' '*.c' '*.cc'"
     else
         echo "Error: astyle not found in PATH" >&2
         exit 2
@@ -166,4 +166,7 @@ if [ $IS_GIT -eq 1 ]; then
         fi
         exit 0
     fi
+else
+    echo "Error: Not inside a git repository; cannot verify formatting changes" >&2
+    exit 2
 fi

--- a/lib/afp.c
+++ b/lib/afp.c
@@ -14,6 +14,8 @@
 #include <sys/socket.h>
 #include <sys/time.h>
 #include <sys/types.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
 
 #include <errno.h>
 #include <stdio.h>
@@ -906,6 +908,16 @@ int afp_server_connect(struct afp_server *server, int full)
 
         if (server->fd >= 0) {
             if (connect(server->fd, address->ai_addr, address->ai_addrlen) == 0) {
+                /* Disable Nagle */
+                int nodelay = 1;
+
+                if (setsockopt(server->fd, IPPROTO_TCP, TCP_NODELAY,
+                               &nodelay, sizeof(nodelay)) < 0) {
+                    log_for_client(NULL, AFPFSD, LOG_WARNING,
+                                   "Could not set TCP_NODELAY on fd=%d: %s",
+                                   server->fd, strerror(errno));
+                }
+
                 break;
             }
 


### PR DESCRIPTION
AFP is a round-trip-bound request/reply protocol, so coalescing small client sends under Nagle stalls on the peer's delayed-ACK timer (up to ~40ms per round-trip). The Netatalk server already disables Nagle on its session socket (libatalk/dsi/dsi_tcp.c); set it on the client side too.

Set TCP_NODELAY in afp_server_connect() immediately after connect() succeeds, so it applies to every connection and reconnection (all route through this function). A failed setsockopt warns but does not abort.

---

Imported latest version of codefmt.sh and normalised location