### PR TITLE
recover afpcmd sessions after idle disconnects

### DIFF
--- a/cmdline/cmdline_afp.c
+++ b/cmdline/cmdline_afp.c
@@ -155,7 +155,7 @@ static int is_recoverable_session_error(int ret)
     return afp_sl_recovery_for_error(ret) != AFP_SL_RECOVERY_NONE;
 }
 
-static int reconnect_session(int restore_volume, int restore_dir)
+static int recover_session(int restore_volume, int restore_dir)
 {
     char mesg[MAX_ERROR_LEN];
     unsigned int uam_mask;
@@ -163,7 +163,9 @@ static int reconnect_session(int restore_volume, int restore_dir)
     serverid_t new_server_id = NULL;
     volumeid_t new_vol_id = NULL;
     serverid_t old_server_id;
+    volumeid_t old_vol_id;
     struct afp_url reconnect_url;
+    struct afp_url resume_url;
     char saved_volume[AFP_VOLUME_NAME_LEN];
     char saved_dir[AFP_MAX_PATH];
     int had_volume;
@@ -178,15 +180,14 @@ static int reconnect_session(int restore_volume, int restore_dir)
     strlcpy(saved_dir, curdir, sizeof(saved_dir));
     had_volume = (vol_id != NULL);
     old_server_id = server_id;
-
-    /* Drop local cached handles; stale IDs are no longer trustworthy. */
-    if (old_server_id && afp_sl_disconnect(&old_server_id) != 0) {
-        afp_sl_exit();
-    }
-
+    old_vol_id = vol_id;
+    server_id = NULL;
+    vol_id = NULL;
     uam_mask = get_uam_mask_for_url();
 
     if (uam_mask == 0) {
+        server_id = old_server_id;
+        vol_id = old_vol_id;
         return -1;
     }
 
@@ -197,9 +198,28 @@ static int reconnect_session(int restore_volume, int restore_dir)
                 sizeof(reconnect_url.servername));
     }
 
-    if (afp_sl_connect(&reconnect_url, uam_mask, &new_server_id, mesg) != 0) {
+    resume_url = reconnect_url;
+    explicit_bzero(resume_url.password, sizeof(resume_url.password));
+
+    /*
+     * Prefer resuming the daemon's existing AFP session.  This mirrors the
+     * manual recovery path of detaching to the volume list, and avoids tearing
+     * down a server connection that may still be usable after an idle timeout.
+     */
+    if (afp_sl_resume(&resume_url, uam_mask, &new_server_id, mesg) != 0
+            && afp_sl_connect(&reconnect_url, uam_mask, &new_server_id, mesg) != 0) {
+        server_id = old_server_id;
+        vol_id = old_vol_id;
         return -1;
     }
+
+    if (old_server_id && old_server_id != new_server_id
+            && afp_sl_disconnect(&old_server_id) != 0) {
+        afp_sl_exit();
+    }
+
+    server_id = new_server_id;
+    connected = 1;
 
     if ((restore_volume || had_volume) && saved_volume[0] != '\0') {
         strlcpy(url.volumename, saved_volume, sizeof(url.volumename));
@@ -207,13 +227,12 @@ static int reconnect_session(int restore_volume, int restore_dir)
               volume_options);
 
         if (ret != 0) {
+            vol_id = NULL;
             return -1;
         }
     }
 
-    server_id = new_server_id;
     vol_id = new_vol_id;
-    connected = 1;
 
     if (restore_dir && saved_dir[0] != '\0') {
         strlcpy(curdir, saved_dir, sizeof(curdir));
@@ -778,7 +797,7 @@ static void list_volumes(void)
     ret = afp_sl_getvols(server_id, &url, 0, count, &numvols, vols);
 
     if (ret != 0 && is_recoverable_session_error(ret)
-            && reconnect_session(0, 0) == 0) {
+            && recover_session(0, 0) == 0) {
         numvols = 0;
         ret = afp_sl_getvols(server_id, &url, 0, count, &numvols, vols);
     }
@@ -944,7 +963,7 @@ int com_dir(char * arg)
                          &eod);
 
     if (ret != 0 && is_recoverable_session_error(ret)
-            && reconnect_session(1, 1) == 0) {
+            && recover_session(1, 1) == 0) {
         if (filebase) {
             free(filebase);
             filebase = NULL;
@@ -3137,7 +3156,7 @@ int com_cd(char *arg)
               volume_options);
 
         if (ret != 0
-                && is_recoverable_session_error(ret) && reconnect_session(0, 0) == 0) {
+                && is_recoverable_session_error(ret) && recover_session(0, 0) == 0) {
             ret = attach_volume_with_password_prompt(server_id, &vol_id,
                   volume_options);
         }
@@ -3201,7 +3220,7 @@ int com_cd(char *arg)
     ret = afp_sl_stat(&vol_id, dir_path, NULL, &statbuf);
 
     if (ret != 0 && is_recoverable_session_error(ret)
-            && reconnect_session(1, 1) == 0) {
+            && recover_session(1, 1) == 0) {
         ret = afp_sl_stat(&vol_id, dir_path, NULL, &statbuf);
     }
 

--- a/cmdline/cmdline_afp.c
+++ b/cmdline/cmdline_afp.c
@@ -169,6 +169,7 @@ static int recover_session(int restore_volume, int restore_dir)
     char saved_volume[AFP_VOLUME_NAME_LEN];
     char saved_dir[AFP_MAX_PATH];
     int had_volume;
+    int was_connected;
     unsigned int volume_options = VOLUME_EXTRA_FLAGS_NO_LOCKING;
 
     if (!connected) {
@@ -181,13 +182,10 @@ static int recover_session(int restore_volume, int restore_dir)
     had_volume = (vol_id != NULL);
     old_server_id = server_id;
     old_vol_id = vol_id;
-    server_id = NULL;
-    vol_id = NULL;
+    was_connected = connected;
     uam_mask = get_uam_mask_for_url();
 
     if (uam_mask == 0) {
-        server_id = old_server_id;
-        vol_id = old_vol_id;
         return -1;
     }
 
@@ -208,9 +206,17 @@ static int recover_session(int restore_volume, int restore_dir)
      */
     if (afp_sl_resume(&resume_url, uam_mask, &new_server_id, mesg) != 0
             && afp_sl_connect(&reconnect_url, uam_mask, &new_server_id, mesg) != 0) {
-        server_id = old_server_id;
-        vol_id = old_vol_id;
         return -1;
+    }
+
+    if ((restore_volume || had_volume) && saved_volume[0] != '\0') {
+        strlcpy(url.volumename, saved_volume, sizeof(url.volumename));
+        ret = attach_volume_with_password_prompt(new_server_id, &new_vol_id,
+              volume_options);
+
+        if (ret != 0) {
+            goto error;
+        }
     }
 
     if (old_server_id && old_server_id != new_server_id
@@ -220,18 +226,6 @@ static int recover_session(int restore_volume, int restore_dir)
 
     server_id = new_server_id;
     connected = 1;
-
-    if ((restore_volume || had_volume) && saved_volume[0] != '\0') {
-        strlcpy(url.volumename, saved_volume, sizeof(url.volumename));
-        ret = attach_volume_with_password_prompt(new_server_id, &new_vol_id,
-              volume_options);
-
-        if (ret != 0) {
-            vol_id = NULL;
-            return -1;
-        }
-    }
-
     vol_id = new_vol_id;
 
     if (restore_dir && saved_dir[0] != '\0') {
@@ -239,6 +233,18 @@ static int recover_session(int restore_volume, int restore_dir)
     }
 
     return 0;
+error:
+
+    if (new_server_id && new_server_id != old_server_id) {
+        afp_sl_disconnect(&new_server_id);
+    }
+
+    server_id = old_server_id;
+    vol_id = old_vol_id;
+    connected = was_connected;
+    strlcpy(url.volumename, saved_volume, sizeof(url.volumename));
+    strlcpy(curdir, saved_dir, sizeof(curdir));
+    return -1;
 }
 
 static int escape_paths(char * outgoing1, char * outgoing2, char * incoming)

--- a/daemon/commands.c
+++ b/daemon/commands.c
@@ -22,12 +22,14 @@
 #include <unistd.h>
 #include <utime.h>
 
+#ifdef HAVE_LIBBSD
+#include <bsd/string.h>
+#endif
+
 #include "afp.h"
 #include "afp_server.h"
 #include "codepage.h"
-#include "commands.h"
-#include "daemon.h"
-#include "daemon_client.h"
+#include "compat.h"
 #include "dsi.h"
 #include "lib/users.h"
 #include "libafpclient.h"
@@ -35,6 +37,10 @@
 #include "midlevel.h"
 #include "uams_def.h"
 #include "utils.h"
+
+#include "commands.h"
+#include "daemon.h"
+#include "daemon_client.h"
 
 /* File handle table for mapping 32-bit IDs to 64-bit pointers */
 #define MAX_OPEN_FILES 1024
@@ -55,6 +61,17 @@ static void finish_response(struct daemon_client *c, int send_result,
     } else {
         continue_client_connection(c);
     }
+}
+
+static void *alloc_response(size_t len, size_t fixed_len)
+{
+    void *response = malloc(len);
+
+    if (response) {
+        memset(response, 0, fixed_len);
+    }
+
+    return response;
 }
 
 static int register_file_handle(struct afp_file_info *fp)
@@ -85,6 +102,13 @@ static struct afp_file_info *get_file_handle(int id)
     fp = file_handle_table[id];
     pthread_mutex_unlock(&file_handle_mutex);
     return fp;
+}
+
+static int volume_server_is_connected(const struct afp_volume *volume)
+{
+    return volume && volume->server
+           && volume->server->connect_state == SERVER_STATE_CONNECTED
+           && volume->server->fd > 0;
 }
 
 static void release_file_handle(int id)
@@ -176,7 +200,7 @@ static unsigned char process_status(struct daemon_client * c)
 
     afp_unlock_server_list();
     response_len = sizeof(struct afp_server_status_response) + output_len + 1;
-    response = malloc(response_len);
+    response = alloc_response(response_len, sizeof(*response));
 
     if (!response) {
         free(output_buffer);
@@ -551,7 +575,7 @@ static unsigned char process_getvols(struct daemon_client * c)
     }
 
     len += numvols * sizeof(struct afp_volume_summary);
-    response = malloc(len);
+    response = alloc_response(len, sizeof(*response));
 
     if (!response) {
         log_for_client((void *) c, AFPFSD, LOG_ERR,
@@ -573,7 +597,7 @@ static unsigned char process_getvols(struct daemon_client * c)
     response->num = numvols;
     goto done;
 error:
-    response = malloc(len);
+    response = alloc_response(len, sizeof(*response));
 
     if (!response) {
         log_for_client((void *) c, AFPFSD, LOG_ERR, "Out of memory in error path");
@@ -620,6 +644,11 @@ static unsigned char process_open(struct daemon_client * c)
 
     if ((v = afp_volume_find_by_pointer_hold(request->volumeid)) == NULL) {
         result = AFP_SERVER_RESULT_NOTATTACHED;
+        goto done;
+    }
+
+    if (!volume_server_is_connected(v)) {
+        result = AFP_SERVER_RESULT_NOTCONNECTED;
         goto done;
     }
 
@@ -681,7 +710,7 @@ static unsigned char process_read(struct daemon_client * c)
 
     if ((size_t)(c->completed_packet_size) < sizeof(struct
             afp_server_read_request)) {
-        response = malloc(len);
+        response = alloc_response(len, sizeof(*response));
 
         if (!response) {
             log_for_client((void *) c, AFPFSD, LOG_ERR, "Out of memory in read");
@@ -693,7 +722,7 @@ static unsigned char process_read(struct daemon_client * c)
     }
 
     if ((v = afp_volume_find_by_pointer_hold(request->volumeid)) == NULL) {
-        response = malloc(len);
+        response = alloc_response(len, sizeof(*response));
 
         if (!response) {
             log_for_client((void *) c, AFPFSD, LOG_ERR, "Out of memory in read");
@@ -704,8 +733,20 @@ static unsigned char process_read(struct daemon_client * c)
         goto done;
     }
 
+    if (!volume_server_is_connected(v)) {
+        response = alloc_response(len, sizeof(*response));
+
+        if (!response) {
+            log_for_client((void *) c, AFPFSD, LOG_ERR, "Out of memory in read");
+            return AFP_SERVER_RESULT_ERROR;
+        }
+
+        result = AFP_SERVER_RESULT_NOTCONNECTED;
+        goto done;
+    }
+
     len += request->length;
-    response = malloc(len);
+    response = alloc_response(len, sizeof(*response));
 
     if (!response) {
         log_for_client((void *) c, AFPFSD, LOG_ERR,
@@ -770,6 +811,11 @@ static unsigned char process_write(struct daemon_client * c)
 
     if ((v = afp_volume_find_by_pointer_hold(request->volumeid)) == NULL) {
         result = AFP_SERVER_RESULT_NOTATTACHED;
+        goto done;
+    }
+
+    if (!volume_server_is_connected(v)) {
+        result = AFP_SERVER_RESULT_NOTCONNECTED;
         goto done;
     }
 
@@ -880,6 +926,11 @@ static unsigned char process_creat(struct daemon_client * c)
         goto done;
     }
 
+    if (!volume_server_is_connected(v)) {
+        result = AFP_SERVER_RESULT_NOTCONNECTED;
+        goto done;
+    }
+
     log_for_client((void *) c, AFPFSD, LOG_DEBUG, "Creating file '%s' mode=%04o",
                    request->path, request->mode);
     ret = ml_creat(v, request->path, request->mode);
@@ -937,6 +988,11 @@ static unsigned char process_chmod(struct daemon_client * c)
         goto done;
     }
 
+    if (!volume_server_is_connected(v)) {
+        result = AFP_SERVER_RESULT_NOTCONNECTED;
+        goto done;
+    }
+
     ret = ml_chmod(v, request->path, request->mode);
 
     if (ret < 0) {
@@ -989,6 +1045,11 @@ static unsigned char process_rename(struct daemon_client * c)
         goto done;
     }
 
+    if (!volume_server_is_connected(v)) {
+        result = AFP_SERVER_RESULT_NOTCONNECTED;
+        goto done;
+    }
+
     ret = ml_rename(v, request->path_from, request->path_to);
 
     if (ret < 0) {
@@ -1030,6 +1091,11 @@ static unsigned char process_unlink(struct daemon_client * c)
 
     if ((v = afp_volume_find_by_pointer_hold(request->volumeid)) == NULL) {
         result = AFP_SERVER_RESULT_NOTATTACHED;
+        goto done;
+    }
+
+    if (!volume_server_is_connected(v)) {
+        result = AFP_SERVER_RESULT_NOTCONNECTED;
         goto done;
     }
 
@@ -1089,6 +1155,11 @@ static unsigned char process_truncate(struct daemon_client * c)
         goto done;
     }
 
+    if (!volume_server_is_connected(v)) {
+        result = AFP_SERVER_RESULT_NOTCONNECTED;
+        goto done;
+    }
+
     ret = ml_truncate(v, request->path, request->offset);
 
     if (ret < 0) {
@@ -1145,6 +1216,11 @@ static unsigned char process_utime(struct daemon_client * c)
         goto done;
     }
 
+    if (!volume_server_is_connected(v)) {
+        result = AFP_SERVER_RESULT_NOTCONNECTED;
+        goto done;
+    }
+
     ret = ml_utime(v, request->path, &request->times);
 
     if (ret < 0) {
@@ -1192,6 +1268,11 @@ static unsigned char process_mkdir(struct daemon_client * c)
 
     if ((v = afp_volume_find_by_pointer_hold(request->volumeid)) == NULL) {
         result = AFP_SERVER_RESULT_NOTATTACHED;
+        goto done;
+    }
+
+    if (!volume_server_is_connected(v)) {
+        result = AFP_SERVER_RESULT_NOTCONNECTED;
         goto done;
     }
 
@@ -1257,6 +1338,11 @@ static unsigned char process_rmdir(struct daemon_client * c)
         goto done;
     }
 
+    if (!volume_server_is_connected(v)) {
+        result = AFP_SERVER_RESULT_NOTCONNECTED;
+        goto done;
+    }
+
     ret = ml_rmdir(v, request->path);
 
     if (ret < 0) {
@@ -1316,6 +1402,11 @@ static unsigned char process_statfs(struct daemon_client * c)
 
     if ((v = afp_volume_find_by_pointer_hold(request->volumeid)) == NULL) {
         result = AFP_SERVER_RESULT_NOTATTACHED;
+        goto done;
+    }
+
+    if (!volume_server_is_connected(v)) {
+        result = AFP_SERVER_RESULT_NOTCONNECTED;
         goto done;
     }
 
@@ -1379,6 +1470,11 @@ static unsigned char process_close(struct daemon_client * c)
         goto done;
     }
 
+    if (!volume_server_is_connected(v)) {
+        ret = AFP_SERVER_RESULT_NOTCONNECTED;
+        goto done;
+    }
+
     struct afp_file_info *fp = get_file_handle(request->fileid);
 
     if (!fp) {
@@ -1423,6 +1519,11 @@ static unsigned char process_stat(struct daemon_client * c)
 
     if ((v = afp_volume_find_by_pointer_hold(request->volumeid)) == NULL) {
         result = AFP_SERVER_RESULT_NOTATTACHED;
+        goto done;
+    }
+
+    if (!volume_server_is_connected(v)) {
+        result = AFP_SERVER_RESULT_NOTCONNECTED;
         goto done;
     }
 
@@ -1566,6 +1667,12 @@ static unsigned char process_metadata(struct daemon_client *c)
 
     if (!volume) {
         send_metadata_response(c, -ESTALE, NULL, 0, 0);
+        return 0;
+    }
+
+    if (!volume_server_is_connected(volume)) {
+        send_metadata_response(c, -ENOTCONN, NULL, 0, 0);
+        afp_server_release(volume->server);
         return 0;
     }
 
@@ -1730,6 +1837,11 @@ static unsigned char process_readdir(struct daemon_client * c)
         goto error;
     }
 
+    if (!volume_server_is_connected(v)) {
+        result = AFP_SERVER_RESULT_NOTCONNECTED;
+        goto error;
+    }
+
     ret = ml_readdir(v, req->path, &filebase);
 
     if (ret) {
@@ -1782,7 +1894,7 @@ static unsigned char process_readdir(struct daemon_client * c)
     }
 
     /* We allocate max buffer, actual length will be determined during packing */
-    response = malloc(MAX_CLIENT_RESPONSE);
+    response = alloc_response(MAX_CLIENT_RESPONSE, sizeof(*response));
 
     if (!response) {
         log_for_client((void *) c, AFPFSD, LOG_ERR,
@@ -1866,7 +1978,7 @@ static unsigned char process_readdir(struct daemon_client * c)
 error:
     /* Reset len for error case */
     len = sizeof(struct afp_server_readdir_response);
-    response = malloc(len);
+    response = alloc_response(len, sizeof(*response));
 
     if (!response) {
         log_for_client((void *) c, AFPFSD, LOG_ERR,
@@ -1942,6 +2054,21 @@ static int server_auth_matches_resume(struct afp_server *server,
     return 1;
 }
 
+static int server_auth_matches_reconnect(struct afp_server *server,
+        const struct afp_url *url, unsigned int uam_mask)
+{
+    if (strcmp(server->username, url->username) != 0) {
+        return 0;
+    }
+
+    if (uam_mask != 0 && server->using_uam != 0
+            && (server->using_uam & uam_mask) == 0) {
+        return 0;
+    }
+
+    return 1;
+}
+
 static struct afp_server *find_resumable_server_hold(void *priv,
         const struct afp_url *url, unsigned int uam_mask, int *error)
 {
@@ -1995,6 +2122,80 @@ static struct afp_server *find_resumable_server_hold(void *priv,
     }
 
     return match;
+}
+
+static struct afp_server *find_disconnected_server_hold(void *priv,
+        const struct afp_url *url, unsigned int uam_mask, int *error)
+{
+    struct afp_server *match = NULL;
+    struct addrinfo *address = NULL;
+    int matches = 0;
+
+    if (error) {
+        *error = ENOTCONN;
+    }
+
+    address = afp_get_address(priv, url->servername, url->port);
+    afp_lock_server_list();
+
+    for (struct afp_server *s = get_server_base(); s; s = s->next) {
+        if (s->connect_state != SERVER_STATE_DISCONNECTED || s->fd > 0) {
+            continue;
+        }
+
+        if (!server_name_matches_url(s, url)
+                && !server_address_matches(s, address)) {
+            continue;
+        }
+
+        if (!server_auth_matches_reconnect(s, url, uam_mask)) {
+            continue;
+        }
+
+        match = s;
+        matches++;
+
+        if (matches > 1) {
+            break;
+        }
+    }
+
+    if (matches == 1) {
+        afp_server_hold(match);
+    } else {
+        match = NULL;
+
+        if (error && matches > 1) {
+            *error = EEXIST;
+        }
+    }
+
+    afp_unlock_server_list();
+
+    if (address) {
+        freeaddrinfo(address);
+    }
+
+    return match;
+}
+
+static int reconnect_disconnected_server(void *priv, struct afp_server *server,
+        const struct afp_url *url)
+{
+    char mesg[MAX_ERROR_LEN];
+    unsigned int len = 0;
+    int ret;
+    memset(mesg, 0, sizeof(mesg));
+    strlcpy(server->password, url->password, sizeof(server->password));
+    errno = 0;
+    ret = afp_server_reconnect(server, mesg, &len, sizeof(mesg));
+    explicit_bzero(server->password, sizeof(server->password));
+
+    if (ret != 0 && mesg[0] != '\0') {
+        log_for_client(priv, AFPFSD, LOG_WARNING, "%s", mesg);
+    }
+
+    return ret;
 }
 
 static int process_connect(struct daemon_client * c)
@@ -2051,6 +2252,28 @@ static int process_connect(struct daemon_client * c)
         memcpy(loginmesg_copy, s->loginmesg, AFP_LOGINMESG_LEN);
         afp_server_release(s);
         goto done;
+    }
+
+    s = find_disconnected_server_hold(c, &req->url, req->uam_mask, &error);
+
+    if (s) {
+        log_for_client((void *) c, AFPFSD, LOG_INFO,
+                       "Recovering disconnected session for server %s",
+                       req->url.servername);
+
+        if (reconnect_disconnected_server(c, s, &req->url) == 0) {
+            response_result = AFP_SERVER_RESULT_OKAY;
+            server_copy = s;
+            memcpy(loginmesg_copy, s->loginmesg, AFP_LOGINMESG_LEN);
+            afp_server_release(s);
+            goto done;
+        }
+
+        error = errno ? errno : ECONNRESET;
+        afp_server_release(s);
+        s = NULL;
+    } else if (error == EEXIST) {
+        goto error;
     }
 
     /* Initialize connection request */

--- a/daemon/commands.c
+++ b/daemon/commands.c
@@ -31,7 +31,6 @@
 #include "codepage.h"
 #include "compat.h"
 #include "dsi.h"
-#include "lib/users.h"
 #include "libafpclient.h"
 #include "map_def.h"
 #include "midlevel.h"
@@ -1951,15 +1950,6 @@ static unsigned char process_readdir(struct daemon_client * c)
         p += sizeof(uint32_t);
         memcpy(p, &fp->modification_date, sizeof(uint32_t));
         p += sizeof(uint32_t);
-        /* Translate UID/GID from server-side to client-side values
-         * before sending to the stateless client */
-        {
-            unsigned int tmp_uid = fp->unixprivs.uid;
-            unsigned int tmp_gid = fp->unixprivs.gid;
-            translate_uidgid_to_client(v, &tmp_uid, &tmp_gid);
-            fp->unixprivs.uid = tmp_uid;
-            fp->unixprivs.gid = tmp_gid;
-        }
         memcpy(p, &fp->unixprivs, sizeof(struct afp_unixprivs));
         p += sizeof(struct afp_unixprivs);
         memcpy(p, &fp->size, sizeof(uint64_t));

--- a/daemon/commands.c
+++ b/daemon/commands.c
@@ -107,7 +107,7 @@ static int volume_server_is_connected(const struct afp_volume *volume)
 {
     return volume && volume->server
            && volume->server->connect_state == SERVER_STATE_CONNECTED
-           && volume->server->fd > 0;
+           && volume->server->fd >= 0;
 }
 
 static void release_file_handle(int id)
@@ -417,7 +417,7 @@ static unsigned char process_getvolid(struct daemon_client * c)
     req->url.volpassword[AFP_VOLPASS_LEN] = '\0';
     s = find_server_by_pointer((struct afp_server *)req->serverid);
 
-    if (!s || s->connect_state != SERVER_STATE_CONNECTED || s->fd <= 0) {
+    if (!s || s->connect_state != SERVER_STATE_CONNECTED || s->fd < 0) {
         ret = AFP_SERVER_RESULT_NOTCONNECTED;
         goto done;
     }
@@ -556,7 +556,7 @@ static unsigned char process_getvols(struct daemon_client * c)
     server = find_server_by_pointer((struct afp_server *)request->serverid);
 
     if (!server || server->connect_state != SERVER_STATE_CONNECTED
-            || server->fd <= 0) {
+            || server->fd < 0) {
         result = AFP_SERVER_RESULT_NOTCONNECTED;
         goto error;
     }
@@ -2074,7 +2074,7 @@ static struct afp_server *find_resumable_server_hold(void *priv,
     afp_lock_server_list();
 
     for (struct afp_server *s = get_server_base(); s; s = s->next) {
-        if (s->connect_state != SERVER_STATE_CONNECTED || s->fd <= 0) {
+        if (s->connect_state != SERVER_STATE_CONNECTED || s->fd < 0) {
             continue;
         }
 
@@ -2129,7 +2129,7 @@ static struct afp_server *find_disconnected_server_hold(void *priv,
     afp_lock_server_list();
 
     for (struct afp_server *s = get_server_base(); s; s = s->next) {
-        if (s->connect_state != SERVER_STATE_DISCONNECTED || s->fd > 0) {
+        if (s->connect_state != SERVER_STATE_DISCONNECTED || s->fd >= 0) {
             continue;
         }
 
@@ -2379,7 +2379,7 @@ static int process_attach(struct daemon_client * c)
                    (char *) req->url.servername);
     s = find_server_by_pointer((struct afp_server *)req->serverid);
 
-    if (!s || s->connect_state != SERVER_STATE_CONNECTED || s->fd <= 0) {
+    if (!s || s->connect_state != SERVER_STATE_CONNECTED || s->fd < 0) {
         log_for_client((void *) c, AFPFSD, LOG_ERR,
                        "Attach request with invalid or disconnected server %p",
                        req->serverid);

--- a/daemon/meson.build
+++ b/daemon/meson.build
@@ -17,6 +17,7 @@ executable(
     'afpsld',
     sources: afpsld_sources,
     dependencies: [
+        root_dependencies,
         pthread_dep,
     ],
     link_with: [libafpclient],

--- a/include/afp.h
+++ b/include/afp.h
@@ -238,6 +238,7 @@ struct afp_server {
     /* Session */
     struct afp_token token;
     char need_resume;
+    char reconnect_in_progress;
 
     /* Versions */
     unsigned char requested_version;
@@ -291,6 +292,27 @@ struct afp_server {
     char *attention_buffer;
 
 };
+
+static inline int afp_server_reconnect_try_begin(struct afp_server *server)
+{
+    char expected = 0;
+    return __atomic_compare_exchange_n(&server->reconnect_in_progress,
+                                       &expected, 1, 0,
+                                       __ATOMIC_ACQ_REL,
+                                       __ATOMIC_ACQUIRE);
+}
+
+static inline void afp_server_reconnect_end(struct afp_server *server)
+{
+    __atomic_store_n(&server->reconnect_in_progress, 0, __ATOMIC_RELEASE);
+}
+
+static inline int afp_server_reconnect_is_in_progress(
+    const struct afp_server *server)
+{
+    return __atomic_load_n(&server->reconnect_in_progress,
+                           __ATOMIC_ACQUIRE) != 0;
+}
 
 struct afp_comment {
     unsigned int maxsize;

--- a/include/dsi.h
+++ b/include/dsi.h
@@ -10,6 +10,7 @@ struct dsi_request {
     void *other;
     int wait;
     int done_waiting;
+    int ignore_replies;
     pthread_cond_t  waiting_cond;
     pthread_mutex_t waiting_mutex;
     struct dsi_request *next;
@@ -21,6 +22,7 @@ int dsi_receive(struct afp_server * server, void * data, int size);
 int dsi_getstatus(struct afp_server * server);
 int dsi_sendtickle(struct afp_server *server);
 void dsi_flush_request_queue(struct afp_server *server);
+void dsi_fail_request_queue(struct afp_server *server, int error);
 
 int dsi_opensession(struct afp_server *server);
 

--- a/lib/afp.c
+++ b/lib/afp.c
@@ -567,6 +567,7 @@ struct afp_server *afp_server_init(struct addrinfo * address)
     s->attention_buffer = malloc(s->attention_quantum);
     s->attention_len = 0;
     s->connect_state = SERVER_STATE_DISCONNECTED;
+    afp_server_reconnect_end(s);
     s->address = address;
     /* Initialize mutexes */
     pthread_mutex_init(&s->requestid_mutex, NULL);
@@ -689,10 +690,19 @@ int afp_server_login(struct afp_server *server,
     if (server->flags & kSupportsReconnect) {
         /* Get the session */
         if (server->need_resume) {
-            resume_token(server);
+            if (resume_token(server) != 0) {
+                *l += snprintf(mesg, max - *l,
+                               "Could not resume session token\n");
+                goto error;
+            }
+
             server->need_resume = 0;
         } else {
-            setup_token(server);
+            if (setup_token(server) != 0) {
+                *l += snprintf(mesg, max - *l,
+                               "Could not set up session token\n");
+                goto error;
+            }
         }
     }
 
@@ -824,35 +834,70 @@ int afp_server_reconnect(struct afp_server * s, char * mesg,
                          unsigned int *l, unsigned int max)
 {
     int i;
+    int ret = 0;
     struct afp_volume * v;
+
+    if (!afp_server_reconnect_try_begin(s)) {
+        return 1;
+    }
+
     /* Flush pending requests before reconnecting to avoid late reply confusion */
     dsi_flush_request_queue(s);
 
     if (afp_server_connect(s, 0))  {
         *l += snprintf(mesg, max - *l, "Error resuming connection to %s\n",
                        s->server_name_printable);
-        return 1;
+
+        if (errno == 0) {
+            errno = ECONNRESET;
+        }
+
+        goto error;
     }
 
-    dsi_opensession(s);
+    if (dsi_opensession(s) != 0) {
+        *l += snprintf(mesg, max - *l, "Error opening DSI session to %s\n",
+                       s->server_name_printable);
+        errno = ECONNRESET;
+        goto error;
+    }
 
     if (afp_server_login(s, mesg, l, max)) {
-        return 1;
+        if (errno == 0) {
+            errno = EACCES;
+        }
+
+        goto error;
     }
 
     for (i = 0; i < s->num_volumes; i++) {
         v = &s->volumes[i];
 
-        if (strlen(v->mountpoint)) {
-            if (afp_connect_volume(v, v->server, mesg, l, max))
-                *l += snprintf(mesg, max - *l,
-                               "Could not mount %s\n",
-                               v->volume_name_printable);
+        if ((v->attached == AFP_VOLUME_ATTACHED || strlen(v->mountpoint))
+                && afp_connect_volume(v, v->server, mesg, l, max)) {
+            *l += snprintf(mesg, max - *l,
+                           "Could not mount %s\n",
+                           v->volume_name_printable);
+
+            if (errno == 0) {
+                errno = EIO;
+            }
+
+            ret = 1;
         }
     }
 
+    if (ret != 0) {
+        goto error;
+    }
+
     s->connect_state = SERVER_STATE_CONNECTED;
+    afp_server_reconnect_end(s);
     return 0;
+error:
+    loop_disconnect(s);
+    afp_server_reconnect_end(s);
+    return 1;
 }
 
 
@@ -865,6 +910,8 @@ int afp_server_connect(struct afp_server *server, int full)
     static char log_msg[LOG_MSG_SIZE];
     char	ip_addr[INET6_ADDRSTRLEN];
     address = server->address;
+    server->data_read = 0;
+    server->attention_len = 0;
 
     if (server->fd > 0) {
         log_for_client(NULL, AFPFSD, LOG_INFO,
@@ -943,8 +990,7 @@ int afp_server_connect(struct afp_server *server, int full)
 
     server->connect_state	= SERVER_STATE_CONNECTING;
     server->used_address	= address;
-    /* Add server to the list if it's not already there.
-     * On reconnect, the server is already in the list, so we skip this. */
+    /* Add server to the list if it's not already there. */
     int found = 0;
 
     for (struct afp_server *s = get_server_base(); s; s = s->next) {

--- a/lib/afp.c
+++ b/lib/afp.c
@@ -566,6 +566,7 @@ struct afp_server *afp_server_init(struct addrinfo * address)
     s->attention_quantum = AFP_DEFAULT_ATTENTION_QUANTUM;
     s->attention_buffer = malloc(s->attention_quantum);
     s->attention_len = 0;
+    s->fd = -1;
     s->connect_state = SERVER_STATE_DISCONNECTED;
     afp_server_reconnect_end(s);
     s->address = address;
@@ -913,7 +914,7 @@ int afp_server_connect(struct afp_server *server, int full)
     server->data_read = 0;
     server->attention_len = 0;
 
-    if (server->fd > 0) {
+    if (server->fd >= 0) {
         log_for_client(NULL, AFPFSD, LOG_INFO,
                        "Closing old socket fd=%d before reconnection", server->fd);
         close(server->fd);

--- a/lib/dsi.c
+++ b/lib/dsi.c
@@ -266,7 +266,7 @@ int dsi_send(struct afp_server *server, char * msg, int size, int wait,
         }
     }
 
-    if (server->fd <= 0) {
+    if (server->fd < 0) {
         return -EIO;
     }
 

--- a/lib/dsi.c
+++ b/lib/dsi.c
@@ -110,10 +110,9 @@ int dsi_opensession(struct afp_server *server)
     dsi_opensession_header.flags = 1;
     dsi_opensession_header.length = sizeof(unsigned int);
     dsi_opensession_header.rx_quantum = htonl(server->attention_quantum);
-    dsi_send(server, (char *) &dsi_opensession_header,
-             sizeof(dsi_opensession_header), DSI_BLOCK_TIMEOUT,
-             DSI_DSIOpenSession, NULL);
-    return 0;
+    return dsi_send(server, (char *) &dsi_opensession_header,
+                    sizeof(dsi_opensession_header), DSI_LOGIN_TIMEOUT,
+                    DSI_DSIOpenSession, NULL);
 }
 
 static int dsi_remove_from_request_queue(struct afp_server *server,
@@ -141,12 +140,11 @@ static int dsi_remove_from_request_queue(struct afp_server *server,
             }
 
             server->stats.requests_pending--;
-            /* SAFEGUARD: Wake any waiting thread before destroying */
+            /* Wake any waiter before destroying the request state. */
             pthread_mutex_lock(&p->waiting_mutex);
             p->done_waiting = 1;
             pthread_cond_signal(&p->waiting_cond);
             pthread_mutex_unlock(&p->waiting_mutex);
-            /* Now safe to destroy mutex/cond */
             pthread_cond_destroy(&p->waiting_cond);
             pthread_mutex_destroy(&p->waiting_mutex);
             free(p);
@@ -163,6 +161,14 @@ static int dsi_remove_from_request_queue(struct afp_server *server,
                    "*** Never removed anything for %d, %s", toremove->requestid,
                    afp_get_command_name(toremove->subcommand));
 #endif
+
+    if (toremove->ignore_replies) {
+        pthread_cond_destroy(&toremove->waiting_cond);
+        pthread_mutex_destroy(&toremove->waiting_mutex);
+        free(toremove);
+        return 0;
+    }
+
     log_for_client(NULL, AFPFSD, LOG_WARNING,
                    "Got an unknown reply for requestid %i",
                    ntohs(toremove->requestid));
@@ -179,36 +185,45 @@ void dsi_flush_request_queue(struct afp_server *server)
         return;
     }
 
-    log_for_client(NULL, AFPFSD, LOG_INFO,
+    log_for_client(NULL, AFPFSD, LOG_DEBUG,
                    "Flushing pending request queue before reconnection");
     pthread_mutex_lock(&server->request_queue_mutex);
     p = server->command_requests;
+    server->command_requests = NULL;
 
-    while (p != NULL) {
+    while (p) {
         next = p->next;
-#ifdef DEBUG_DSI
-        log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                       "*** Flushing request %d, %s", p->requestid,
-                       afp_get_command_name(p->subcommand));
-#endif
-        /* Wake any waiting thread with error */
+        p->next = NULL;
+        p->ignore_replies = 1;
+        server->stats.requests_pending--;
         pthread_mutex_lock(&p->waiting_mutex);
         p->return_code = -EIO;
         p->done_waiting = 1;
         pthread_cond_signal(&p->waiting_cond);
         pthread_mutex_unlock(&p->waiting_mutex);
-        /* Destroy and free */
-        pthread_cond_destroy(&p->waiting_cond);
-        pthread_mutex_destroy(&p->waiting_mutex);
-        free(p);
-        server->stats.requests_pending--;
         p = next;
     }
 
-    server->command_requests = NULL;
     pthread_mutex_unlock(&server->request_queue_mutex);
-    log_for_client(NULL, AFPFSD, LOG_INFO,
-                   "Request queue flushed");
+}
+
+void dsi_fail_request_queue(struct afp_server *server, int error)
+{
+    if (!server_still_valid(server)) {
+        return;
+    }
+
+    pthread_mutex_lock(&server->request_queue_mutex);
+
+    for (struct dsi_request *p = server->command_requests; p; p = p->next) {
+        pthread_mutex_lock(&p->waiting_mutex);
+        p->return_code = error;
+        p->done_waiting = 1;
+        pthread_cond_signal(&p->waiting_cond);
+        pthread_mutex_unlock(&p->waiting_mutex);
+    }
+
+    pthread_mutex_unlock(&server->request_queue_mutex);
 }
 
 
@@ -226,7 +241,7 @@ int dsi_send(struct afp_server *server, char * msg, int size, int wait,
     struct timeval tv;
     header->length = htonl(size - sizeof(struct dsi_header));
 
-    if (!server || !server_still_valid(server) || server->fd == 0) {
+    if (!server || !server_still_valid(server)) {
         return -1;
     }
 
@@ -235,6 +250,25 @@ int dsi_send(struct afp_server *server, char * msg, int size, int wait,
     }
 
     afp_wait_for_started_loop();
+
+    if (server->connect_state == SERVER_STATE_DISCONNECTED) {
+        char mesg[MAX_ERROR_LEN];
+        unsigned int l = 0;
+
+        if (afp_server_reconnect_is_in_progress(server)) {
+            return -EIO;
+        }
+
+        memset(mesg, 0, sizeof(mesg));
+
+        if (afp_server_reconnect(server, mesg, &l, MAX_ERROR_LEN) != 0) {
+            return -EIO;
+        }
+    }
+
+    if (server->fd <= 0) {
+        return -EIO;
+    }
 
     /* Add request to the queue */
     if ((new_request = malloc(sizeof(struct dsi_request))) == NULL) {
@@ -251,7 +285,7 @@ int dsi_send(struct afp_server *server, char * msg, int size, int wait,
     new_request->next = NULL;
     new_request->done_waiting = 0;
     new_request->connection_generation = server->connection_generation;
-    /* SAFEGUARD: Initialize mutex/cond BEFORE adding to queue to prevent race condition */
+    /* Initialize before queueing so dsi_recv can signal this request safely. */
     pthread_cond_init(&new_request->waiting_cond, NULL);
     pthread_mutex_init(&new_request->waiting_mutex, NULL);
     pthread_mutex_lock(&server->request_queue_mutex);
@@ -266,14 +300,6 @@ int dsi_send(struct afp_server *server, char * msg, int size, int wait,
 
     server->stats.requests_pending++;
     pthread_mutex_unlock(&server->request_queue_mutex);
-
-    if (server->connect_state == SERVER_STATE_DISCONNECTED) {
-        char mesg[MAX_ERROR_LEN];
-        unsigned int l = 0;
-        /* Try and reconnect */
-        afp_server_reconnect(server, mesg, &l, MAX_ERROR_LEN);
-    }
-
     pthread_mutex_lock(&server->send_mutex);
 #ifdef DEBUG_DSI
     log_for_client(NULL, AFPFSD, LOG_DEBUG, "*** Sending %d, %s",
@@ -298,15 +324,13 @@ int dsi_send(struct afp_server *server, char * msg, int size, int wait,
                 server->connect_state = SERVER_STATE_DISCONNECTED;
                 rc = -1;
                 pthread_mutex_unlock(&server->send_mutex);
-                /* SAFEGUARD: Set return_code so waiting thread gets the error */
                 new_request->return_code = -EIO;
-                goto out;  /* SAFEGUARD: Properly clean up instead of direct return */
+                goto out;
             }
 
             perror("writing to server");
             rc = -1;
             pthread_mutex_unlock(&server->send_mutex);
-            /* SAFEGUARD: Set return_code so waiting thread gets the error */
             new_request->return_code = -EIO;
             goto out;
         }
@@ -331,7 +355,6 @@ int dsi_send(struct afp_server *server, char * msg, int size, int wait,
 #endif
         pthread_mutex_lock(&new_request->waiting_mutex);
 
-        /* SAFEGUARD: Use while loop to handle spurious wakeups */
         while (new_request->done_waiting == 0) {
             rc = pthread_cond_wait(
                      &new_request->waiting_cond,
@@ -355,19 +378,8 @@ int dsi_send(struct afp_server *server, char * msg, int size, int wait,
         ts.tv_sec = tv.tv_sec;
         ts.tv_sec += new_request->wait;
         ts.tv_nsec = tv.tv_usec * 1000;
-
-        if (new_request->wait == 0) {
-#ifdef DEBUG_DSI
-            log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                           "=== Changing my mind, no longer waiting for %d",
-                           new_request->requestid);
-#endif
-            goto skip;
-        }
-
         pthread_mutex_lock(&new_request->waiting_mutex);
 
-        /* SAFEGUARD: Use while loop to handle spurious wakeups */
         while (new_request->done_waiting == 0) {
             rc = pthread_cond_timedwait(
                      &new_request->waiting_cond,
@@ -412,9 +424,7 @@ int dsi_send(struct afp_server *server, char * msg, int size, int wait,
                    new_request->wait,
                    rc, new_request->return_code);
 #endif
-skip:
 
-    /* SAFEGUARD: Only use return_code if we didn't have an error */
     if (rc == 0) {
         rc = new_request->return_code;
     }
@@ -728,7 +738,7 @@ void *dsi_incoming_attention(void * other)
         struct dsi_header header __attribute__((__packed__));
         uint16_t flags ;
     } __attribute__((__packed__)) *packet = (void *) server->attention_buffer;
-    unsigned short flags;
+    unsigned short flags = 0;
     char mesg[AFP_LOGINMESG_LEN];
     unsigned char shutdown = 0;
     unsigned char mins = 0;
@@ -792,7 +802,7 @@ struct dsi_request *dsi_find_request(struct afp_server *server,
     pthread_mutex_lock(&server->request_queue_mutex);
 
     for (p = server->command_requests; p; p = p->next) {
-        if (request_id == p->requestid) {
+        if (!p->ignore_replies && request_id == p->requestid) {
             pthread_mutex_unlock(&server->request_queue_mutex);
             return p;
         }

--- a/lib/loop.c
+++ b/lib/loop.c
@@ -481,7 +481,7 @@ int afp_main_loop(int command_fd)
                 afp_lock_server_list();
 
                 for (struct afp_server *s = get_server_base(); s; s = s->next) {
-                    if (s->connect_state == SERVER_STATE_CONNECTED && s->fd > 0) {
+                    if (s->connect_state == SERVER_STATE_CONNECTED && s->fd >= 0) {
 #ifdef DEBUG_AFP_LOOP
                         log_for_client(NULL, AFPFSD, LOG_DEBUG,
                                        "afp_main_loop -- Sending tickle to server %s (fd=%d, connected_for=%lds)",

--- a/lib/loop.c
+++ b/lib/loop.c
@@ -194,6 +194,9 @@ void loop_disconnect(struct afp_server *s)
         return;
     }
 
+    dsi_fail_request_queue(s, -EIO);
+    s->data_read = 0;
+    s->attention_len = 0;
     rm_fd_and_signal(s->fd);
     /* Handle disconnect */
     close(s->fd);

--- a/lib/midlevel.c
+++ b/lib/midlevel.c
@@ -212,6 +212,24 @@ static int set_uidgid(struct afp_volume * volume,
     return 0;
 }
 
+static int map_filebase_uidgid_to_client(struct afp_volume * volume,
+        struct afp_file_info * filebase)
+{
+    for (struct afp_file_info * fp = filebase; fp; fp = fp->next) {
+        unsigned int uid = fp->unixprivs.uid;
+        unsigned int gid = fp->unixprivs.gid;
+
+        if (translate_uidgid_to_client(volume, &uid, &gid)) {
+            return -EIO;
+        }
+
+        fp->unixprivs.uid = uid;
+        fp->unixprivs.gid = gid;
+    }
+
+    return 0;
+}
+
 static void update_time(unsigned int * newtime)
 {
     struct timeval tv;
@@ -375,9 +393,21 @@ int ml_readdir(struct afp_volume * volume,
         goto done;
     }
 
-    return ll_readdir(volume, converted_path, fb, 0);
+    ret = ll_readdir(volume, converted_path, fb, 0);
+
+    if (ret < 0) {
+        return ret;
+    }
+
 done:
-    return 0;
+    ret = map_filebase_uidgid_to_client(volume, *fb);
+
+    if (ret < 0) {
+        afp_ml_filebase_free(fb);
+        return ret;
+    }
+
+    return ret;
 }
 
 int ml_read(struct afp_volume * volume, const char *path,

--- a/lib/proto_login.c
+++ b/lib/proto_login.c
@@ -160,7 +160,7 @@ int afp_login(struct afp_server *server, const char * ua_name,
     p += copy_to_pascal(p, server->using_version->av_name) +1;
     p += copy_to_pascal(p, ua_name) +1;
     memcpy(p, userauthinfo, userauthinfo_len);
-    ret = dsi_send(server, (char *) msg, len, DSI_BLOCK_TIMEOUT,
+    ret = dsi_send(server, (char *) msg, len, DSI_LOGIN_TIMEOUT,
                    afpLogin, (void *)rx);
     free(msg);
     return ret;
@@ -239,7 +239,7 @@ int afp_loginext(struct afp_server *server, const char *ua_name,
 
     /* UserAuthInfo */
     memcpy(p, userauthinfo, userauthinfo_len);
-    ret = dsi_send(server, msg, len, DSI_BLOCK_TIMEOUT,
+    ret = dsi_send(server, msg, len, DSI_LOGIN_TIMEOUT,
                    afpLoginExt, (void *)rx);
     free(msg);
     return ret;

--- a/lib/proto_session.c
+++ b/lib/proto_session.c
@@ -75,7 +75,7 @@ int afp_getsessiontoken(struct afp_server * server, int type,
                    DSI_DEFAULT_TIMEOUT, afpGetSessionToken,
                    (void *) incoming_token);
     free(request);
-    return 0;
+    return ret;
 error:
     return ret;
 }
@@ -153,5 +153,4 @@ int afp_disconnectoldsession(struct afp_server * server, int type,
     free(request);
     return ret;
 }
-
 

--- a/lib/server.c
+++ b/lib/server.c
@@ -42,7 +42,14 @@ struct afp_server *afp_server_complete_connection(
     strlcpy(server->username, username, sizeof(server->username));
     strlcpy(server->password, password, sizeof(server->password));
     add_fd_and_signal(server->fd);
-    dsi_opensession(server);
+
+    if (dsi_opensession(server) != 0) {
+        log_for_client(priv, AFPFSD, LOG_ERR,
+                       "Could not open DSI session");
+        errno = ECONNRESET;
+        goto error;
+    }
+
     log_for_client(NULL, AFPFSD, LOG_DEBUG,
                    "afp_server_complete_connection -- DSI session: tx_quantum=%u (max write size)",
                    server->tx_quantum);


### PR DESCRIPTION
Recent code changes to harden AFP reconnection logic led to the afpcmd client being unable to resume a timed out server connection.

Preserve afpcmd's cached daemon handles while recovery decides whether the existing session can be reused. Try a passwordless daemon-session resume first, then fall back to a credentialed connect, and only disconnect the old server when recovery actually moves to a replacement session.

Teach afpsld CONNECT to recover a matching disconnected authenticated server session, including previously attached stateless volumes. Ordinary stateless volume operations now return NOTCONNECTED when their server handle is disconnected, so afpcmd receives a recoverable error instead of letting READDIR or other request handlers disappear into low-level reconnect work and time out the IPC request.

Harden the underlying DSI reconnect path by waking queued requests on disconnect, preventing recursive reconnect attempts, propagating session-token and OpenSession failures, and bounding login/session waits. This keeps KIO's explicit resume semantics intact while restoring afpcmd recovery after idle disconnects.

additional surrounding improvements:

## map readdir ownership in midlevel layer

Translate AFP file owner and group IDs for directory listings as part of
ml_readdir so every midlevel caller receives client-side values.

Remove the daemon-specific mutation while packing readdir responses,
avoiding duplicated ownership mapping logic and keeping FUSE and stateless
daemon behavior aligned.

## Treat AFP server fd 0 as valid

Initialize AFP server sockets to -1 and use that as the invalid-socket
sentinel throughout server connection checks.

This prevents daemon commands, DSI sends, reconnect cleanup, and tickle
handling from reporting valid fd 0 sockets as disconnected when standard
input has been closed.

## keep afpcmd recovery state transactional

Delay updating the global server and volume handles until session recovery
has also restored the requested volume.

If reattach fails, disconnect any replacement server session and restore
the previous CLI handles, connection flag, volume name, and working
directory before reporting recovery failure.
