### PR TITLE
bound xattr user prefix stripping

### DIFF
--- a/include/afp_xattr.h
+++ b/include/afp_xattr.h
@@ -34,12 +34,23 @@
 /* Utility for stripping the "user." prefix from xattr names. */
 static inline const char *afp_xattr_strip_user_prefix(const char *name)
 {
-    if (name && strncmp(name, AFP_XATTR_USER_PREFIX,
-                        AFP_XATTR_USER_PREFIX_LEN) == 0) {
-        return name + AFP_XATTR_USER_PREFIX_LEN;
+    const char *prefix = AFP_XATTR_USER_PREFIX;
+    const char *stripped = name;
+
+    if (!name) {
+        return NULL;
     }
 
-    return name;
+    while (*prefix) {
+        if (*stripped != *prefix) {
+            return name;
+        }
+
+        stripped++;
+        prefix++;
+    }
+
+    return stripped;
 }
 
 struct afp_extattr_info {


### PR DESCRIPTION
Make afp_xattr_strip_user_prefix() return early for NULL names and walk the user. prefix one byte at a time before returning the stripped pointer.

This preserves the existing normalization behavior while avoiding fixed-width memory comparisons and explicit offset arithmetic in the transfer_name_special() path flagged by static analysis.