### PR TITLE
update straggler references to the old project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Unmount the volume when you are done:
 
     % afp_client unmount /home/myuser/fusemount
 
-Shut down the afpfs-ng management daemon (*afpfsd*) when no FUSE mounts are active:
+Shut down the FUSE management daemon (*afpfsd*) when no FUSE mounts are active:
 
     % afp_client exit
 
@@ -68,7 +68,7 @@ Connect anonymously to afpserver.local, list all volumes available to guest user
     Attached to volume Dropbox
     afpcmd: ls
     -rw-r--r--   6148 2025-07-11 14:09 .DS_Store
-    -rw-r--r-- 108320 2025-10-12 13:59 afpfs-ng-0.9.0.tar.xz
+    -rw-r--r-- 108320 2025-10-12 13:59 mytarball.tar.xz
     -rw-------      0 2025-10-12 00:39 bork.txt
     -rw-r--r-- 525362 2024-10-09 13:02 group_photo.jpg
     -rw-r--r--  46954 2023-08-03 02:03 Information Sheet.xlsx
@@ -80,18 +80,18 @@ and *help* for a list of all supported commands.
 
 Use *afpcmd* in batch mode to download files from the AFP share to the local machine:
 
-    $ afpcmd "afp://myuser@afpserver.local/File Sharing/afpfs-ng-0.9.0.tar.xz" .
+    $ afpcmd "afp://myuser@afpserver.local/File Sharing/mytarball.tar.xz" .
     Password: [input hidden]
     Connected to server afpserver
-        Downloading file afpfs-ng-0.9.0.tar.xz
+        Downloading file mytarball.tar.xz
         Transferred 108320 bytes in 0.015 seconds. (7200 kB/s)
     Transfer complete. 108320 bytes received.
 
-## Differences from afpfs-ng
+## Differences with afpfs-ng
 
 Netatalk Client has the goal of maintaining continuity with afpfs-ng commands and APIs,
 so that moving from one to the other is as seamless as possible. However we do not guarantee
-libafpclient ABI compatibility with afpfs-ng, and some differences in behavior and supported features may exist.
+libafpclient ABI compatibility with afpfs-ng, and differences in behavior and supported features exist.
 
 - afpfsd.h is now a shim header which includes afp_server.h
 - afpfs-ng had to be built either with FUSE or Stateless API support, but Netatalk Client supports both simultaneously
@@ -101,9 +101,12 @@ libafpclient ABI compatibility with afpfs-ng, and some differences in behavior a
 - The *afpcmd* command line client has been rewritten to use the Stateless API instead of implementing
   libafpclient calls directly, and now relies on the *afpsld* daemon to manage AFP sessions and connections
   instead of implementing its own session management
+- The *afpfsd* FUSE controller daemon has been rewritten to have one process per FUSE mount,
+  with a manager process to handle mount requests and manage the afpfsd processes.
+  This allows for better isolation and stability of FUSE mounts compared to a single process handling all mounts.
 
-We have also introduced numerous new options and features, which will not be listed in full here
-but can be found in the documentation and command line help.
+We have also introduced numerous new options and features, which will not be listed in full here.
+Refer to the documentation and command line help text.
 
 ## How to Contribute
 

--- a/cmdline/cmdline_main.c
+++ b/cmdline/cmdline_main.c
@@ -468,7 +468,7 @@ static void usage(void)
         "Batch transfer mode:\n"
         "\tafpcmd [-r] [-V] [-M mode] <afp url> <local path>   (Download from server)\n"
         "\tafpcmd [-r] [-V] [-M mode] <local path> <afp url>   (Upload to server)\n\n"
-        "See the afpcmd(1) man page for more information.\n", AFPFS_VERSION
+        "See the afpcmd(1) man page for more information.\n", NETATALK_CLIENT_VERSION
     );
 }
 

--- a/cmdline/getstatus.c
+++ b/cmdline/getstatus.c
@@ -290,7 +290,7 @@ static void usage(void)
            "Options:\n"
            "\t-i             Show server icon\n"
            "\t-v loglevel    Set log level (debug, info, notice, warning, error)\n"
-           "\t-h             Show this help\n", AFPFS_VERSION);
+           "\t-h             Show this help\n", NETATALK_CLIENT_VERSION);
 }
 
 void afp_wait_for_started_loop(void);

--- a/daemon/daemon.c
+++ b/daemon/daemon.c
@@ -161,7 +161,7 @@ static void usage(void)
            "  -v, --loglevel     LOG_DEBUG|LOG_INFO|LOG_NOTICE|LOG_WARNING|LOG_ERR\n"
            "  -f, --foreground   Do not fork\n"
            "  -d, --debug        Do not fork, debug loglevel, logs to stdout\n"
-           "Version %s\n", AFPFS_VERSION);
+           "Version %s\n", NETATALK_CLIENT_VERSION);
 }
 
 static struct libafpclient client = {
@@ -302,8 +302,9 @@ int main(int argc, char *argv[])
             goto error;
         }
 
-        log_for_client(NULL, AFPFSD, LOG_NOTICE, "Starting up AFPFS version %s",
-                       AFPFS_VERSION);
+        log_for_client(NULL, AFPFSD, LOG_NOTICE,
+                       "Starting up AFP Stateless daemon version %s",
+                       NETATALK_CLIENT_VERSION);
         afp_main_loop(command_fd);
         close_commands(command_fd);
     }

--- a/fuse/client.c
+++ b/fuse/client.c
@@ -787,7 +787,8 @@ static void mount_afpfs_usage(void)
 {
     printf("Netatalk Client %s - mount an Apple Filing Protocol network filesystem with FUSE\n"
            "Usage:\n"
-           "\tmount_afpfs [-o volpass=password] <afp url> <mountpoint>\n", AFPFS_VERSION);
+           "\tmount_afpfs [-o volpass=password] <afp url> <mountpoint>\n",
+           NETATALK_CLIENT_VERSION);
 }
 
 static int handle_mount_afpfs(int argc, char * argv[])

--- a/fuse/daemon.c
+++ b/fuse/daemon.c
@@ -155,7 +155,7 @@ static void usage(void)
            "  -d, --debug        Do not fork, debug loglevel, log to stdout\n"
            "  -m, --manager      Run as a manager daemon\n"
            "  -s, --socket-id    Socket filename (for per-mount daemon support)\n",
-           AFPFS_VERSION);
+           NETATALK_CLIENT_VERSION);
 }
 
 
@@ -1081,7 +1081,7 @@ int main(int argc, char *argv[])
 
         command_fd_global = command_fd;
         log_for_client(NULL, AFPFSD, LOG_NOTICE,
-                       "Starting up AFPFS version %s", AFPFS_VERSION);
+                       "Starting up AFP FUSE controller daemon version %s", NETATALK_CLIENT_VERSION);
         afp_main_loop(command_fd);
         close_commands(command_fd);
     }

--- a/lib/afp.c
+++ b/lib/afp.c
@@ -639,7 +639,7 @@ int afp_server_login(struct afp_server *server,
 
     case kFPAuthContinue:
         *l += snprintf(mesg, max - *l,
-                       "Authentication method unsupported by AFPFS\n");
+                       "Unsupported authentication method\n");
         goto error;
 
     case kFPBadUAM:
@@ -671,7 +671,7 @@ int afp_server_login(struct afp_server *server,
 
     case kFPServerGoingDown:
         *l += snprintf(mesg, max - *l,
-                       "Server going down, so I can't log you in.\n");
+                       "Server going down, so I can't log you in\n");
         goto error;
 
     case kFPUserNotAuth:

--- a/lib/status.c
+++ b/lib/status.c
@@ -17,17 +17,23 @@
 int afp_status_header(char * text, int * len)
 {
     int pos;
+
+    if (*len <= 0) {
+        return -1;
+    }
+
     memset(text, 0, *len);
     pos = snprintf(text, *len, "Netatalk Client Version: %s\n"
                                "Client UAMs: %s\n",
                    NETATALK_CLIENT_VERSION,
                    get_uam_names_list());
-    *len -= pos;
 
-    if (*len == 0) {
+    if ((pos < 0) || (pos >= *len)) {
+        *len = 0;
         return -1;
     }
 
+    *len -= pos;
     return pos;
 }
 

--- a/lib/status.c
+++ b/lib/status.c
@@ -18,9 +18,9 @@ int afp_status_header(char * text, int * len)
 {
     int pos;
     memset(text, 0, *len);
-    pos = snprintf(text, *len, "AFPFS Version: %s\n"
+    pos = snprintf(text, *len, "Netatalk Client Version: %s\n"
                                "Client UAMs: %s\n",
-                   AFPFS_VERSION,
+                   NETATALK_CLIENT_VERSION,
                    get_uam_names_list());
     *len -= pos;
 

--- a/meson.build
+++ b/meson.build
@@ -9,8 +9,6 @@ project(
 
 cc = meson.get_compiler('c')
 host_os = host_machine.system()
-build_type = get_option('buildtype')
-afpfsng_version = meson.project_version()
 pkg = import('pkgconfig')
 
 install_prefix = get_option('prefix')
@@ -23,7 +21,7 @@ includedir = install_prefix / get_option('includedir')
 libsearch_dirs = []
 include_dirs = []
 cflags = [
-    '-DAFPFS_VERSION="' + afpfsng_version + '"',
+    '-DNETATALK_CLIENT_VERSION="' + meson.project_version() + '"',
     '-DBINDIR="' + bindir + '"',
     '-D_FILE_OFFSET_BITS=64',
     '-DAFPCLIENT_INTERNAL',
@@ -224,7 +222,7 @@ summary_info = {
     'Host CPU': host_machine.cpu_family(),
     'Host endianness': build_machine.endian(),
     'C compiler': cc.get_id(),
-    'Build stype': build_type,
+    'Build type': get_option('buildtype'),
     'Shared or static libraries': get_option('default_library'),
 }
 summary(summary_info, bool_yn: true, section: 'Compilation:')


### PR DESCRIPTION
this removes all internal and user facing usage of afpfs-ng or afpfs when used as a shorthand for the former

we still keep afpfs around where appropriate, such as a prefix for the two controller daemons, as well as the label for our FUSE filesystem name

check buffer length in afp_status_header in the in the status module for better resilience