### PR TITLE
refactor AFP server type snapshots

### DIFF
--- a/daemon/commands.c
+++ b/daemon/commands.c
@@ -483,10 +483,7 @@ static unsigned char process_serverinfo(struct daemon_client * c)
 
     if (tmpserver) {
         /* We're already connected */
-        memcpy(tmpserver->basic.server_name_printable,
-               tmpserver->server_name_printable, AFP_SERVER_NAME_UTF8_LEN);
-        memcpy(&response.server_basic, &tmpserver->basic,
-               sizeof(struct afp_server_basic));
+        afp_server_fill_basic(tmpserver, &response.server_basic);
     } else {
         struct addrinfo *address;
 
@@ -503,8 +500,7 @@ static unsigned char process_serverinfo(struct daemon_client * c)
             goto error;
         }
 
-        memcpy(&response.server_basic, &tmpserver->basic,
-               sizeof(struct afp_server_basic));
+        afp_server_fill_basic(tmpserver, &response.server_basic);
         afp_server_remove(tmpserver);
         tmpserver = NULL;  /* Already freed by remove, don't release again */
     }
@@ -2740,7 +2736,7 @@ struct afp_volume *command_sub_attach_volume(struct daemon_client *c,
         if (volname && volname[0]) {
             log_for_client((void *) c, AFPFSD, LOG_ERR,
                            "Volume %s does not exist on server %s.", volname,
-                           server->basic.server_name_printable);
+                           server->server_name_printable);
         }
 
         if (response_result) {
@@ -2755,7 +2751,7 @@ struct afp_volume *command_sub_attach_volume(struct daemon_client *c,
         } else {
             log_for_client((void *)c, AFPFSD, LOG_ERR,
                            "No volumes available on server %s.",
-                           server->basic.server_name_printable);
+                           server->server_name_printable);
         }
 
         goto error;

--- a/include/afp.h
+++ b/include/afp.h
@@ -149,20 +149,14 @@ struct afp_volume {
 #define SERVER_STATE_DISCONNECTED 2
 #define SERVER_STATE_CONNECTING 3
 
-enum server_type {
-    AFPFS_SERVER_TYPE_UNKNOWN,
-    AFPFS_SERVER_TYPE_NETATALK,
-    AFPFS_SERVER_TYPE_AIRPORT,
-    AFPFS_SERVER_TYPE_MACINTOSH,
-    AFPFS_SERVER_TYPE_TIMECAPSULE,
-    AFPFS_SERVER_TYPE_WINDOWS,
+enum afp_server_type {
+    AFP_SERVER_TYPE_UNKNOWN,
+    AFP_SERVER_TYPE_NETATALK,
+    AFP_SERVER_TYPE_AIRPORT,
+    AFP_SERVER_TYPE_MACINTOSH,
+    AFP_SERVER_TYPE_TIMECAPSULE,
+    AFP_SERVER_TYPE_WINDOWS,
 };
-
-#define is_netatalk(x) ( (x)->machine_type == AFPFS_SERVER_TYPE_NETATALK )
-#define is_airport(x) ( (x)->machine_type == AFPFS_SERVER_TYPE_AIRPORT )
-#define is_macintosh(x) ( (x)->machine_type == AFPFS_SERVER_TYPE_MACINTOSH )
-#define is_timecapsule(x) ( (x)->machine_type == AFPFS_SERVER_TYPE_TIMECAPSULE )
-#define is_windows(x) ( (x)->machine_type == AFPFS_SERVER_TYPE_WINDOWS )
 
 struct afp_versions {
     char        *av_name;
@@ -181,13 +175,11 @@ struct afp_server_basic {
     unsigned short flags;
     /* Skipping addresses */
     /* Skipping directories */
-    enum server_type server_type;
+    enum afp_server_type server_type;
 };
 
 
 struct afp_server {
-
-    struct afp_server_basic basic;
 
     /* Our buffer sizes */
     unsigned int tx_quantum;
@@ -222,7 +214,7 @@ struct afp_server {
     char signature[16];
     unsigned short flags;
     int connect_state;
-    enum server_type server_type;
+    enum afp_server_type server_type;
 
     /* This is the time we connected */
     time_t connect_time;
@@ -341,7 +333,10 @@ char *get_uam_names_list(void);
 
 unsigned int default_uams_mask(void);
 
+enum afp_server_type afp_identify_machine_type(const char *machine_type);
 void afp_server_identify(struct afp_server * s);
+void afp_server_fill_basic(const struct afp_server *server,
+                           struct afp_server_basic *basic);
 
 struct afp_volume *find_volume_by_name(struct afp_server * server,
                                        char *volname);

--- a/lib/afp.c
+++ b/lib/afp.c
@@ -585,6 +585,30 @@ struct afp_server *afp_server_init(struct addrinfo * address)
     return s;
 }
 
+void afp_server_fill_basic(const struct afp_server *server,
+                           struct afp_server_basic *basic)
+{
+    memset(basic, 0, sizeof(*basic));
+    memcpy(basic->server_name_printable,
+           server->server_name_printable,
+           sizeof(basic->server_name_printable));
+    memcpy(basic->machine_type,
+           server->machine_type,
+           sizeof(basic->machine_type));
+    memcpy(basic->icon,
+           server->icon,
+           sizeof(basic->icon));
+    memcpy(basic->signature,
+           server->signature,
+           sizeof(basic->signature));
+    memcpy(basic->versions,
+           server->versions,
+           sizeof(basic->versions));
+    basic->supported_uams = server->supported_uams;
+    basic->flags = server->flags;
+    basic->server_type = server->server_type;
+}
+
 static void setup_default_outgoing_token(struct afp_token * token)
 {
     char foo[] = {(char)0x54, (char)0xc0, (char)0x75, (char)0xb0, (char)0x15, (char)0xe6, (char)0x1c, (char)0x13,

--- a/lib/identify.c
+++ b/lib/identify.c
@@ -10,6 +10,29 @@
 #include "afp.h"
 #include "dsi.h"
 
+enum afp_server_type afp_identify_machine_type(const char *machine_type)
+{
+    if (machine_type == NULL) {
+        return AFP_SERVER_TYPE_UNKNOWN;
+    }
+
+    if (strncmp(machine_type, "Netatalk", 8) == 0) {
+        return AFP_SERVER_TYPE_NETATALK;
+    } else if (strncmp(machine_type, "AirPort", 7) == 0) {
+        return AFP_SERVER_TYPE_AIRPORT;
+    } else if (strncmp(machine_type, "Mac", 3) == 0
+               || strncmp(machine_type, "iMac", 4) == 0
+               || strncmp(machine_type, "Xserve", 6) == 0) {
+        return AFP_SERVER_TYPE_MACINTOSH;
+    } else if (strncmp(machine_type, "TimeCapsule", 11) == 0) {
+        return AFP_SERVER_TYPE_TIMECAPSULE;
+    } else if (strncmp(machine_type, "Windows", 7) == 0) {
+        return AFP_SERVER_TYPE_WINDOWS;
+    }
+
+    return AFP_SERVER_TYPE_UNKNOWN;
+}
+
 /*
  * afp_server_identify()
  *
@@ -23,41 +46,47 @@
 void afp_server_identify(struct afp_server * s)
 {
     s->dsi_default_timeout = DSI_DEFAULT_TIMEOUT;
+    s->server_type = afp_identify_machine_type(s->machine_type);
 
-    if (strncmp(s->machine_type, "Netatalk", 8) == 0) {
+    switch (s->server_type) {
+    case AFP_SERVER_TYPE_NETATALK:
         log_for_client(NULL, AFPFSD, LOG_DEBUG,
                        "Identified server %s as Netatalk",
                        s->server_name_printable);
-        s->server_type = AFPFS_SERVER_TYPE_NETATALK;
-    } else if (strncmp(s->machine_type, "AirPort", 7) == 0) {
+        break;
+
+    case AFP_SERVER_TYPE_AIRPORT:
         log_for_client(NULL, AFPFSD, LOG_DEBUG,
                        "Identified server %s as AirPort",
                        s->server_name_printable);
-        s->server_type = AFPFS_SERVER_TYPE_AIRPORT;
-    } else if (strncmp(s->machine_type, "Mac", 3) == 0
-               || strncmp(s->machine_type, "iMac", 4) == 0
-               || strncmp(s->machine_type, "Xserve", 6) == 0) {
+        break;
+
+    case AFP_SERVER_TYPE_MACINTOSH:
         log_for_client(NULL, AFPFSD, LOG_DEBUG,
                        "Identified server %s as Macintosh",
                        s->server_name_printable);
-        s->server_type = AFPFS_SERVER_TYPE_MACINTOSH;
-    } else if (strncmp(s->machine_type, "TimeCapsule", 11) == 0) {
+        break;
+
+    case AFP_SERVER_TYPE_TIMECAPSULE:
         log_for_client(NULL, AFPFSD, LOG_DEBUG,
                        "Identified server %s as Time Capsule",
                        s->server_name_printable);
-        s->server_type = AFPFS_SERVER_TYPE_TIMECAPSULE;
         s->dsi_default_timeout = DSI_TIMECAPSULE_DEFAULT_TIMEOUT;
-    } else if (strncmp(s->machine_type, "Windows", 7) == 0) {
+        break;
+
+    case AFP_SERVER_TYPE_WINDOWS:
         /* PCMacLan returns "Windows based PC"; Windows SFM returns "Windows NT"*/
         log_for_client(NULL, AFPFSD, LOG_DEBUG,
                        "Identified server %s as Windows",
                        s->server_name_printable);
-        s->server_type = AFPFS_SERVER_TYPE_WINDOWS;
-    } else {
+        break;
+
+    case AFP_SERVER_TYPE_UNKNOWN:
+    default:
         log_for_client(NULL, AFPFSD, LOG_DEBUG,
                        "Could not identify server %s (machine type %s)",
                        s->server_name_printable,
                        s->machine_type);
-        s->server_type = AFPFS_SERVER_TYPE_UNKNOWN;
+        break;
     }
 }

--- a/test/meson.build
+++ b/test/meson.build
@@ -49,6 +49,23 @@ test(
     verbose: true,
 )
 
+identify_test = executable(
+    'test_identify',
+    sources: ['test_identify.c'],
+    include_directories: incdir,
+    link_with: libafpclient,
+    dependencies: root_dependencies,
+    c_args: cflags,
+)
+
+test(
+    'AFP server machine type identification',
+    identify_test,
+    args: ['--tap'],
+    protocol: 'tap',
+    verbose: true,
+)
+
 stateless_log_test = executable(
     'test_stateless_log',
     sources: ['test_stateless_log.c'],

--- a/test/test_identify.c
+++ b/test/test_identify.c
@@ -1,0 +1,17 @@
+#include "afp.h"
+#include "tap.h"
+
+int main(int argc, char **argv)
+{
+    test_tap_init(argc, argv);
+    CHECK(afp_identify_machine_type(NULL) == AFP_SERVER_TYPE_UNKNOWN);
+    CHECK(afp_identify_machine_type("") == AFP_SERVER_TYPE_UNKNOWN);
+    CHECK(afp_identify_machine_type("Netatalk") == AFP_SERVER_TYPE_NETATALK);
+    CHECK(afp_identify_machine_type("AirPort") == AFP_SERVER_TYPE_AIRPORT);
+    CHECK(afp_identify_machine_type("Mac mini") == AFP_SERVER_TYPE_MACINTOSH);
+    CHECK(afp_identify_machine_type("iMac") == AFP_SERVER_TYPE_MACINTOSH);
+    CHECK(afp_identify_machine_type("Xserve") == AFP_SERVER_TYPE_MACINTOSH);
+    CHECK(afp_identify_machine_type("TimeCapsule") == AFP_SERVER_TYPE_TIMECAPSULE);
+    CHECK(afp_identify_machine_type("Windows NT") == AFP_SERVER_TYPE_WINDOWS);
+    return test_tap_finish();
+}


### PR DESCRIPTION
Remove the broken server-type predicate macros and rename the enum tag to make the typed classification field explicit.

Stop embedding afp_server_basic inside afp_server. Build basic server snapshots from the live server fields instead, so daemon serverinfo responses cannot copy stale cached state.