### PR TITLE
normalize copyright headers across codebase

### DIFF
--- a/daemon/commands.c
+++ b/daemon/commands.c
@@ -1,10 +1,10 @@
 /*
  *  commands.c - Stateless daemon command handlers
  *
+ *  This file contains command handlers for the afpsld stateless daemon.
+ *
  *  Copyright (C) 2006 Alex deVries <alexthepuffin@gmail.com>
  *  Copyright (C) 2026 Daniel Markstedt <daniel@mindani.net>
- *
- *  This file contains command handlers for the afpsld stateless daemon.
  */
 
 #include <errno.h>

--- a/daemon/daemon.c
+++ b/daemon/daemon.c
@@ -1,10 +1,10 @@
 /*
  *  daemon.c - Stateless daemon main loop
  *
+ *  This is the main loop for afpsld (stateless daemon).
+ *
  *  Copyright (C) 2006 Alex deVries <alexthepuffin@gmail.com>
  *  Copyright (C) 2026 Daniel Markstedt <daniel@mindani.net>
- *
- *  This is the main loop for afpsld (stateless daemon).
  */
 
 #include <errno.h>

--- a/lib/client.c
+++ b/lib/client.c
@@ -1,3 +1,11 @@
+/*
+ *  client.c
+ *
+ *  Copyright (C) 2007 Alex deVries <alexthepuffin@gmail.com>
+ *  Copyright (C) 2026 Daniel Markstedt <daniel@mindani.net>
+ *
+ */
+
 #include "afp.h"
 #include "libafpclient.h"
 

--- a/lib/debug.c
+++ b/lib/debug.c
@@ -1,3 +1,11 @@
+/*
+ *  debug.c
+ *
+ *  Copyright (C) 2008 Alex deVries <alexthepuffin@gmail.com>
+ *  Copyright (C) 2025-2026 Daniel Markstedt <daniel@mindani.net>
+ *
+ */
+
 #include <stdio.h>
 
 /* AFP function names */

--- a/lib/explicit_bzero.c
+++ b/lib/explicit_bzero.c
@@ -1,5 +1,6 @@
 /*
  * Secure memory clearing implementation for systems without explicit_bzero
+ *
  * Copyright (C) 2025-2026 Daniel Markstedt <daniel@mindani.net>
  *
  * This program is free software; you can redistribute it and/or modify

--- a/lib/map_def.c
+++ b/lib/map_def.c
@@ -1,3 +1,11 @@
+/*
+ *  map_def.c
+ *
+ *  Copyright (C) 2007 Alex deVries <alexthepuffin@gmail.com>
+ *  Copyright (C) 2026 Daniel Markstedt <daniel@mindani.net>
+ *
+ */
+
 #include <string.h>
 #include "afp.h"
 #include "map_def.h"

--- a/lib/proto_fork.c
+++ b/lib/proto_fork.c
@@ -4,7 +4,7 @@
  *  Copyright (C) 2006 Alex deVries <alexthepuffin@gmail.com>
  *  Copyright (C) 2025-2026 Daniel Markstedt <daniel@mindani.net>
  *
-*/
+ */
 
 #include <stdlib.h>
 #include <string.h>

--- a/lib/uams_def.c
+++ b/lib/uams_def.c
@@ -1,3 +1,12 @@
+/*
+ *  uams_def.c
+ *
+ *  Copyright (C) 2007 Alex deVries <alexthepuffin@gmail.com>
+ *  Copyright (C) 2007 Derrik Pates <dpates@dsdk12.net>
+ *  Copyright (C) 2025-2026 Daniel Markstedt <daniel@mindani.net>
+ *
+ */
+
 #include <string.h>
 #include <stdlib.h>
 

--- a/lib/uams_dhx2.c
+++ b/lib/uams_dhx2.c
@@ -1,5 +1,5 @@
 /*
- *  uams.c
+ *  uams_dhx2.c
  *
  *  Copyright (C) 2006 Alex deVries <alexthepuffin@gmail.com>
  *  Copyright (C) 2007 Derrik Pates <dpates@dsdk12.net>

--- a/lib/uams_srp.c
+++ b/lib/uams_srp.c
@@ -1,10 +1,15 @@
 /*
  *  uams_srp.c
  *
- *  Copyright (C) 2026 Daniel Markstedt <daniel@mindani.net>
- *
  *  SRP (Secure Remote Password) User Authentication Method for AFP.
  *  Protocol: SRP-6a with SHA-1, MGF1 KDF, RFC 5054 group #2 (1536-bit).
+ *
+ *  Copyright (C) 2026 Daniel Markstedt <daniel@mindani.net>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
  */
 
 #ifdef HAVE_CONFIG_H

--- a/lib/users.c
+++ b/lib/users.c
@@ -1,3 +1,11 @@
+/*
+ *  users.c
+ *
+ *  Copyright (C) 2007 Alex deVries <alexthepuffin@gmail.com>
+ *  Copyright (C) 2026 Daniel Markstedt <daniel@mindani.net>
+ *
+ */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <pwd.h>


### PR DESCRIPTION
this is a final push to normalize the structure of copyright headers across all implementation code files in this project

add a handful of missing copyright headers, based on the revision history of the files