### PR TITLE
better client handling of server connection timeouts

### DIFF
--- a/cmdline/cmdline_afp.c
+++ b/cmdline/cmdline_afp.c
@@ -67,6 +67,7 @@ static struct afp_url url;
 static int cmdline_log_min_rank = 2; /* Default rank: notice */
 static int verbose_mode = 0;
 static char connect_servername[AFP_SERVER_NAME_UTF8_LEN];
+static char last_log_message[MAX_ERROR_LEN];
 
 int full_url = 0;
 
@@ -3348,6 +3349,11 @@ static void cmdline_log_for_client(void *priv _U_, enum logtypes logtype _U_,
         return; /* Filter out less-verbose messages */
     }
 
+    if (!verbose_mode && strcmp(last_log_message, message) == 0) {
+        return;
+    }
+
+    strlcpy(last_log_message, message, sizeof(last_log_message));
     fprintf(stderr, "%s\n", message);
     syslog(loglevel, "%s", message);
 }
@@ -3369,6 +3375,7 @@ static struct libafpclient afpclient = {
 static int cmdline_server_startup(int batch_mode)
 {
     char mesg[MAX_ERROR_LEN];
+    int ret;
     memset(mesg, 0, sizeof(mesg));
     unsigned int uam_mask;
     struct afp_server_basic basic;
@@ -3383,8 +3390,11 @@ static int cmdline_server_startup(int batch_mode)
         strlcpy(connect_servername, url.servername, sizeof(connect_servername));
     }
 
-    if (afp_sl_connect(&url, uam_mask, &server_id, mesg)) {
-        printf("Could not connect to server\n");
+    ret = afp_sl_connect(&url, uam_mask, &server_id, mesg);
+
+    if (ret != 0) {
+        int error = ret < 0 ? -ret : ret;
+        printf("Could not connect to server: %s\n", strerror(error));
         return -1;
     }
 
@@ -3400,7 +3410,6 @@ static int cmdline_server_startup(int batch_mode)
 
     if (url.volumename[0] != '\0') {
         unsigned int volume_options = VOLUME_EXTRA_FLAGS_NO_LOCKING;
-        int ret;
         ret = attach_volume_with_password_prompt(server_id, &vol_id,
               volume_options);
 
@@ -3665,6 +3674,7 @@ void cmdline_afp_exit(void)
 void cmdline_afp_setup_client(void)
 {
     openlog("afpcmd", LOG_PID | LOG_CONS, LOG_USER);
+    last_log_message[0] = '\0';
     libafpclient_register(&afpclient);
     afp_sl_set_log_callback(cmdline_stateless_log, NULL);
 }

--- a/lib/afp.c
+++ b/lib/afp.c
@@ -18,6 +18,7 @@
 #include <netinet/tcp.h>
 
 #include <errno.h>
+#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -52,6 +53,8 @@ struct afp_versions      afp_versions[] = {
 
 static int afp_blank_reply(struct afp_server *server, char * buf,
                            unsigned int size, void *ignored);
+static int connect_with_timeout(int fd, const struct sockaddr *addr,
+                                socklen_t addrlen, int timeout);
 
 int (*afp_replies[])(struct afp_server * server, char * buf, unsigned int len,
                      void *other) = {
@@ -145,6 +148,76 @@ static int afp_blank_reply(
         struct dsi_header header __attribute__((__packed__));
     } * reply = (void *) buf;
     return reply->header.return_code.error_code;
+}
+
+static int connect_with_timeout(int fd, const struct sockaddr *addr,
+                                socklen_t addrlen, int timeout)
+{
+    int flags;
+    int ret;
+    int error = 0;
+    socklen_t error_len = sizeof(error);
+    fd_set writefds;
+    struct timeval tv;
+    flags = fcntl(fd, F_GETFL, 0);
+
+    if (flags < 0) {
+        return connect(fd, addr, addrlen);
+    }
+
+    if (fcntl(fd, F_SETFL, flags | O_NONBLOCK) < 0) {
+        return connect(fd, addr, addrlen);
+    }
+
+    ret = connect(fd, addr, addrlen);
+
+    if (ret == 0) {
+        if (fcntl(fd, F_SETFL, flags) < 0) {
+            return -1;
+        }
+
+        return 0;
+    }
+
+    if (errno != EINPROGRESS) {
+        int saved_errno = errno;
+        fcntl(fd, F_SETFL, flags);
+        errno = saved_errno;
+        return -1;
+    }
+
+    do {
+        FD_ZERO(&writefds);
+        FD_SET(fd, &writefds);
+        tv.tv_sec = timeout;
+        tv.tv_usec = 0;
+        ret = select(fd + 1, NULL, &writefds, NULL, &tv);
+    } while (ret < 0 && errno == EINTR);
+
+    if (ret <= 0) {
+        int saved_errno = (ret == 0) ? ETIMEDOUT : errno;
+        fcntl(fd, F_SETFL, flags);
+        errno = saved_errno;
+        return -1;
+    }
+
+    if (getsockopt(fd, SOL_SOCKET, SO_ERROR, &error, &error_len) < 0) {
+        int saved_errno = errno;
+        fcntl(fd, F_SETFL, flags);
+        errno = saved_errno;
+        return -1;
+    }
+
+    if (fcntl(fd, F_SETFL, flags) < 0) {
+        return -1;
+    }
+
+    if (error != 0) {
+        errno = error;
+        return -1;
+    }
+
+    return 0;
 }
 
 /* Handle a reply packet */
@@ -979,7 +1052,8 @@ int afp_server_connect(struct afp_server *server, int full)
                             address->ai_socktype, address->ai_protocol);
 
         if (server->fd >= 0) {
-            if (connect(server->fd, address->ai_addr, address->ai_addrlen) == 0) {
+            if (connect_with_timeout(server->fd, address->ai_addr,
+                                     address->ai_addrlen, DSI_DEFAULT_TIMEOUT) == 0) {
                 /* Disable Nagle */
                 int nodelay = 1;
 

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -74,10 +74,10 @@ struct afp_server *afp_server_full_connect(void * priv,
         int connect_error = -ret;
 
         if (ret == -ETIMEDOUT) {
-            log_for_client(priv, AFPFSD, LOG_ERR,
+            log_for_client(priv, AFPFSD, LOG_INFO,
                            "Could not connect, never got a response to getstatus, %s", strerror(-ret));
         } else {
-            log_for_client(priv, AFPFSD, LOG_ERR,
+            log_for_client(priv, AFPFSD, LOG_INFO,
                            "Could not connect, %s", strerror(-ret));
         }
 
@@ -111,7 +111,7 @@ struct afp_server *afp_server_full_connect(void * priv,
 
     if ((ret = afp_server_connect(s, 0)) != 0) {
         int connect_error = -ret;
-        log_for_client(priv, AFPFSD, LOG_ERR,
+        log_for_client(priv, AFPFSD, LOG_INFO,
                        "Connection to server failed with error: %s",
                        strerror(connect_error));
         afp_server_remove(s);


### PR DESCRIPTION
this is made up of two distinct changes: introduce an explicit timeout for server connection and enables both afpcmd and kio-afp to report timeout errors accurately, and an overhaul to afpcmd connection attempt verbosity

Use a temporary nonblocking socket and select to limit server connection attempts to DSI_DEFAULT_TIMEOUT instead of allowing connect to block indefinitely.

Restore the original socket flags on every handled path, rebuild select state on EINTR retries, and preserve errno from failed connect, select, or getsockopt calls so callers retain the expected failure reason.

Report afp_sl_connect failures from the afpcmd startup path with the returned errno text while suppressing duplicate non-verbose log messages.

before, the kio-afp client would throw unknown errors, and the afpcmd client would throw nonsense like this for an unreachable server

```
dmark@daniel-macbookpro:~/dev/netatalk-client$ afpcmd afp://airport-time-capsule.local:548
airport-time-capsule.local resolved only to link-local addresses; trying airport-time-capsule
Login error: Authentication failed
Could not connect to server: Permission denied
dmark@daniel-macbookpro:~/dev/netatalk-client$ afpcmd afp://dmark@airport-time-capsule.local:548
Password:
airport-time-capsule.local resolved only to link-local addresses; trying airport-time-capsule
Could not connect, never got a response to getstatus, Connection timed out
Could not connect to server: Connection timed out
```

after the fix we get

```
dmark@daniel-macbookpro:~/dev/netatalk-client$ afpcmd afp://airport-time-capsule.local:548
Could not connect to server: Connection timed out
dmark@daniel-macbookpro:~/dev/netatalk-client$ afpcmd afp://dmark@airport-time-capsule.local:548
Password:
Could not connect to server: Connection timed out
```