### PR TITLE
restore FUSE reconnection after suspend and resume

### DIFF
--- a/fuse/commands.c
+++ b/fuse/commands.c
@@ -458,6 +458,7 @@ found:
         return AFP_SERVER_RESULT_ERROR;
     }
 
+    afp_server_set_suspended(s, 1);
     loop_disconnect(s);
     s->connect_state = SERVER_STATE_DISCONNECTED;
     log_for_client((void *) c, AFPFSD, LOG_NOTICE,
@@ -506,8 +507,10 @@ static unsigned char process_resume(struct fuse_client * c)
     return AFP_SERVER_RESULT_ERROR;
 found:
     s = v->server;
+    afp_server_set_suspended(s, 0);
 
     if (afp_server_reconnect_loud(c, s)) {
+        afp_server_set_suspended(s, 1);
         log_for_client((void *) c, AFPFSD, LOG_ERR,
                        "Unable to reconnect for %s", req.mountpoint);
         return AFP_SERVER_RESULT_ERROR;

--- a/fuse/commands.c
+++ b/fuse/commands.c
@@ -470,9 +470,10 @@ static int afp_server_reconnect_loud(struct fuse_client * c,
                                      struct afp_server * s)
 {
     char mesg[MAX_ERROR_LEN];
-    unsigned int l = 2040;
+    unsigned int l = 0;
     int rc;
-    rc = afp_server_reconnect(s, mesg, &l, l);
+    memset(mesg, 0, sizeof(mesg));
+    rc = afp_server_reconnect(s, mesg, &l, sizeof(mesg));
 
     if (rc)
         log_for_client((void *) c, AFPFSD, LOG_ERR,
@@ -677,6 +678,13 @@ static int process_mount(struct fuse_client * c)
     if ((s = afp_server_full_connect(c, &conn_req)) == NULL) {
         signal_main_thread();
         goto error;
+    }
+
+    /* FUSE suspend/resume runs without a fresh client password prompt. The
+     * core connect path scrubs this field after initial login, so the
+     * per-mount daemon deliberately restashes it for later reconnects. */
+    if (req.url.password[0] != '\0') {
+        strlcpy(s->password, req.url.password, sizeof(s->password));
     }
 
     if ((volume = mount_volume(c, s, req.url.volumename,

--- a/fuse/daemon.c
+++ b/fuse/daemon.c
@@ -550,15 +550,21 @@ static int start_mount_daemon(char *socket_id, const char *mountpoint,
                                ? "stdout" : "syslog";
         /* Type cast away const for execvp() */
         char *log_level_str = (char *) log_level_to_string(current_log_level);
-        char *argv[8];
-        argv[0] = "afpfsd";
-        argv[1] = "--socket-id";
-        argv[2] = socket_id;
-        argv[3] = "--logmethod";
-        argv[4] = log_method_str;
-        argv[5] = "--loglevel";
-        argv[6] = log_level_str;
-        argv[7] = NULL;
+        char *argv[9];
+        int argc = 0;
+        argv[argc++] = "afpfsd";
+        argv[argc++] = "--socket-id";
+        argv[argc++] = socket_id;
+        argv[argc++] = "--logmethod";
+        argv[argc++] = log_method_str;
+        argv[argc++] = "--loglevel";
+        argv[argc++] = log_level_str;
+
+        if (current_log_method & LOG_METHOD_STDOUT) {
+            argv[argc++] = "--foreground";
+        }
+
+        argv[argc] = NULL;
         execvp("afpfsd", argv);
         /* If exec fails */
         _exit(1);

--- a/fuse/daemon.c
+++ b/fuse/daemon.c
@@ -50,6 +50,20 @@ static int command_fd_global = -1;
 /* Forward declaration */
 void close_commands(int command_fd);
 
+static void wake_signal_handler(int signum)
+{
+    (void)signum;
+}
+
+static int install_fuse_wake_signal_handler(void)
+{
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = wake_signal_handler;
+    sigemptyset(&sa.sa_mask);
+    return sigaction(SIGPIPE, &sa, NULL);
+}
+
 int get_debug_mode(void)
 {
     return debug_mode;
@@ -110,18 +124,31 @@ int fuse_unmount_volume(struct afp_volume * volume)
     pthread_t self = pthread_self();
     pthread_t vol_thread = volume->thread;
     int is_same_thread = pthread_equal(self, vol_thread);
+    struct fuse *fuse = (struct fuse *)volume->priv;
     char safe_mountpoint[PATH_MAX * 4];
     sanitize_text(volume->mountpoint, safe_mountpoint,
                   sizeof(safe_mountpoint));
     log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                   "Unmounting FUSE filesystem at %s", safe_mountpoint);
-    fuse_unmount((struct fuse *)volume->priv);
+                   "Stopping FUSE filesystem at %s", safe_mountpoint);
+    fuse_exit(fuse);
 
-    /* Wait for FUSE thread to complete (if called from external thread) */
+    /* fuse_exit() only marks the session as exiting.  Wake the FUSE thread
+     * with SIGPIPE, matching libfuse's documented wake path, while main()
+     * ensures SIGPIPE cannot terminate the daemon if libfuse has not installed
+     * its handler yet.  The FUSE thread owns fuse_main() cleanup. */
     if (!is_same_thread && volume->thread) {
+        int wake_rc = pthread_kill(vol_thread, SIGPIPE);
+
+        if (wake_rc != 0) {
+            log_for_client(NULL, AFPFSD, LOG_WARNING,
+                           "Could not wake FUSE thread for %s: %s",
+                           safe_mountpoint, strerror(wake_rc));
+        }
+
         log_for_client(NULL, AFPFSD, LOG_DEBUG,
                        "Waiting for FUSE thread to complete");
         pthread_join(volume->thread, NULL);
+        volume->priv = NULL;
         log_for_client(NULL, AFPFSD, LOG_DEBUG,
                        "FUSE thread completed for %s", safe_mountpoint);
     }
@@ -1044,6 +1071,12 @@ int main(int argc, char *argv[])
     /* If logging to stdout, enable line buffering for timely output */
     if (new_log_method & LOG_METHOD_STDOUT) {
         setvbuf(stdout, NULL, _IOLBF, 0);
+    }
+
+    if (install_fuse_wake_signal_handler() != 0) {
+        log_for_client(NULL, AFPFSD, LOG_WARNING,
+                       "Could not install FUSE wake signal handler: %s",
+                       strerror(errno));
     }
 
     /* Now register the client callback and initialize UAMs with logging ready */

--- a/fuse/fuse_int.c
+++ b/fuse/fuse_int.c
@@ -19,6 +19,7 @@
 #include <string.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <inttypes.h>
 #include <syslog.h>
 #include <stdint.h>
 #include <stdarg.h>
@@ -401,7 +402,7 @@ static int fuse_create(const char *path, mode_t mode, struct fuse_file_info *fi)
     if (ret == 0) {
         fi->fh = (unsigned long) fp;
         log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                       "*** cache create \"%s\" flags=0x%x fh=%lu forkid=%d",
+                       "*** cache create \"%s\" flags=0x%x fh=%" PRIu64 " forkid=%d",
                        path, fi->flags, fi->fh, fp->forkid);
     } else {
         log_for_client(NULL, AFPFSD, LOG_DEBUG,
@@ -486,7 +487,8 @@ static int fuse_open(const char *path, struct fuse_file_info *fi)
     if (ret == 0) {
         fi->fh = (unsigned long) fp;
         log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                       "*** cache open \"%s\" flags=0x%x fh=%lu forkid=%d writable=%u resource=%u",
+                       "*** cache open \"%s\" flags=0x%x fh=%" PRIu64
+                       " forkid=%d writable=%u resource=%u",
                        path, flags, fi->fh, fp->forkid, fp->writable,
                        fp->resource);
     }

--- a/include/afp.h
+++ b/include/afp.h
@@ -231,6 +231,7 @@ struct afp_server {
     struct afp_token token;
     char need_resume;
     char reconnect_in_progress;
+    char suspended;
 
     /* Versions */
     unsigned char requested_version;
@@ -304,6 +305,18 @@ static inline int afp_server_reconnect_is_in_progress(
 {
     return __atomic_load_n(&server->reconnect_in_progress,
                            __ATOMIC_ACQUIRE) != 0;
+}
+
+static inline void afp_server_set_suspended(struct afp_server *server,
+        int suspended)
+{
+    __atomic_store_n(&server->suspended, suspended ? 1 : 0,
+                     __ATOMIC_RELEASE);
+}
+
+static inline int afp_server_is_suspended(const struct afp_server *server)
+{
+    return __atomic_load_n(&server->suspended, __ATOMIC_ACQUIRE) != 0;
 }
 
 static inline unsigned int afp_server_connection_generation(

--- a/include/afp.h
+++ b/include/afp.h
@@ -306,6 +306,27 @@ static inline int afp_server_reconnect_is_in_progress(
                            __ATOMIC_ACQUIRE) != 0;
 }
 
+static inline unsigned int afp_server_connection_generation(
+    const struct afp_server *server)
+{
+    return __atomic_load_n(&server->connection_generation,
+                           __ATOMIC_ACQUIRE);
+}
+
+static inline unsigned int afp_server_next_connection_generation(
+    struct afp_server *server)
+{
+    return __atomic_add_fetch(&server->connection_generation, 1,
+                              __ATOMIC_ACQ_REL);
+}
+
+static inline void afp_server_connection_generation_init(
+    struct afp_server *server)
+{
+    __atomic_store_n(&server->connection_generation, 0,
+                     __ATOMIC_RELEASE);
+}
+
 struct afp_comment {
     unsigned int maxsize;
     unsigned int size;

--- a/lib/afp.c
+++ b/lib/afp.c
@@ -82,19 +82,19 @@ int (*afp_replies[])(struct afp_server * server, char * buf, unsigned int len,
     NULL, NULL, NULL, NULL,
     NULL, NULL, NULL, NULL,
     NULL, NULL, NULL, NULL,
-    NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL,                       /* 80 - 99 */
 
     NULL, NULL, NULL, NULL,
     NULL, NULL, NULL, NULL,
     NULL, NULL, NULL, NULL,
     NULL, NULL, NULL, NULL,
-    NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL,                       /* 100 - 119 */
 
+    NULL, NULL, afp_blank_reply, NULL,
     NULL, NULL, NULL, NULL,
     NULL, NULL, NULL, NULL,
     NULL, NULL, NULL, NULL,
-    NULL, NULL, NULL, NULL,
-    NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL,                       /* 120 - 139 */
 
     NULL, NULL, NULL, NULL,
     NULL, NULL, NULL, NULL,
@@ -491,6 +491,7 @@ void afp_free_server(struct afp_server ** sp)
         free(volumes);
     }
 
+    explicit_bzero(server->password, sizeof(server->password));
     free(server);
     *sp = NULL;
 }

--- a/lib/afp.c
+++ b/lib/afp.c
@@ -575,7 +575,7 @@ struct afp_server *afp_server_init(struct addrinfo * address)
     pthread_mutex_init(&s->requestid_mutex, NULL);
     pthread_mutex_init(&s->request_queue_mutex, NULL);
     pthread_mutex_init(&s->send_mutex, NULL);
-    s->connection_generation = 0;
+    afp_server_connection_generation_init(s);
     s->refcount = 1;
     /* AFP 3.3+ replay cache - initialized to disabled */
     s->replay_cache_size = 0;
@@ -947,9 +947,10 @@ int afp_server_connect(struct afp_server *server, int full)
     }
 
     /* Increment connection generation to detect stale replies */
-    server->connection_generation++;
+    unsigned int connection_generation =
+        afp_server_next_connection_generation(server);
     log_for_client(NULL, AFPFSD, LOG_INFO,
-                   "Connection generation now %u", server->connection_generation);
+                   "Connection generation now %u", connection_generation);
 
     while (address) {
         switch (address->ai_family) {

--- a/lib/afp.c
+++ b/lib/afp.c
@@ -570,6 +570,7 @@ struct afp_server *afp_server_init(struct addrinfo * address)
     s->fd = -1;
     s->connect_state = SERVER_STATE_DISCONNECTED;
     afp_server_reconnect_end(s);
+    afp_server_set_suspended(s, 0);
     s->address = address;
     /* Initialize mutexes */
     pthread_mutex_init(&s->requestid_mutex, NULL);

--- a/lib/dsi.c
+++ b/lib/dsi.c
@@ -261,6 +261,10 @@ int dsi_send(struct afp_server *server, char * msg, int size, int wait,
         char mesg[MAX_ERROR_LEN];
         unsigned int l = 0;
 
+        if (afp_server_is_suspended(server)) {
+            return -EIO;
+        }
+
         if (afp_server_reconnect_is_in_progress(server)) {
             return -EIO;
         }

--- a/lib/dsi.c
+++ b/lib/dsi.c
@@ -290,7 +290,7 @@ int dsi_send(struct afp_server *server, char * msg, int size, int wait,
     new_request->wait = wait;
     new_request->next = NULL;
     new_request->done_waiting = 0;
-    new_request->connection_generation = server->connection_generation;
+    new_request->connection_generation = afp_server_connection_generation(server);
     /* Initialize before queueing so dsi_recv can signal this request safely. */
     pthread_cond_init(&new_request->waiting_cond, NULL);
     pthread_mutex_init(&new_request->waiting_mutex, NULL);
@@ -779,11 +779,13 @@ void *dsi_incoming_attention(void * other)
         checkmessage = 1;
     }
 
-    if (context->connection_generation != server->connection_generation) {
+    unsigned int current_generation = afp_server_connection_generation(server);
+
+    if (context->connection_generation != current_generation) {
         log_for_client(NULL, AFPFSD, LOG_DEBUG,
                        "Ignoring stale attention packet from connection generation %u (current: %u)",
                        context->connection_generation,
-                       server->connection_generation);
+                       current_generation);
         afp_server_release(server);
         free(context);
         return NULL;
@@ -803,15 +805,16 @@ void *dsi_incoming_attention(void * other)
         log_for_client(NULL, AFPFSD, LOG_ERR,
                        "Got a shutdown notice in packet %d, going down in %d mins",
                        ntohs(packet->header.requestid), mins);
+        current_generation = afp_server_connection_generation(server);
 
-        if (context->connection_generation == server->connection_generation) {
+        if (context->connection_generation == current_generation) {
             loop_disconnect(server);
             server->connect_state = SERVER_STATE_DISCONNECTED;
         } else {
             log_for_client(NULL, AFPFSD, LOG_DEBUG,
                            "Ignoring stale shutdown notice from connection generation %u (current: %u)",
                            context->connection_generation,
-                           server->connection_generation);
+                           current_generation);
         }
     }
 
@@ -905,12 +908,14 @@ gotenough:
     }
 
     /* Check if this is a stale reply from an old connection */
+    unsigned int current_generation = afp_server_connection_generation(server);
+
     if (request
-            && request->connection_generation != server->connection_generation) {
+            && request->connection_generation != current_generation) {
         log_for_client(NULL, AFPFSD, LOG_WARNING,
                        "Discarding stale reply id %d from connection generation %u (current: %u)",
                        ntohs(header->requestid), request->connection_generation,
-                       server->connection_generation);
+                       current_generation);
         runt_packet = 1;
         server->stats.runt_packets++;
         request = NULL;
@@ -1116,7 +1121,7 @@ process_packet:
         }
 
         context->server = server;
-        context->connection_generation = server->connection_generation;
+        context->connection_generation = afp_server_connection_generation(server);
         memcpy(context->packet, server->incoming_buffer, packet_len);
         afp_server_hold(server);
 

--- a/lib/dsi.c
+++ b/lib/dsi.c
@@ -40,6 +40,12 @@ int convert_utf8dec_to_utf8pre(char *src, int src_len,
 int convert_utf8pre_to_utf8dec(char * src, int src_len,
                                char *dest, int dest_len);
 
+struct dsi_attention_context {
+    struct afp_server *server;
+    unsigned int connection_generation;
+    char packet[];
+};
+
 /* This sets up a DSI header. */
 void dsi_setup_header(struct afp_server * server, struct dsi_header * header,
                       char command)
@@ -733,11 +739,12 @@ void dsi_incoming_tickle(struct afp_server * server)
 
 void *dsi_incoming_attention(void * other)
 {
-    struct afp_server * server = other;
+    struct dsi_attention_context *context = other;
+    struct afp_server * server = context->server;
     struct {
         struct dsi_header header __attribute__((__packed__));
         uint16_t flags ;
-    } __attribute__((__packed__)) *packet = (void *) server->attention_buffer;
+    } __attribute__((__packed__)) *packet = (void *) context->packet;
     unsigned short flags = 0;
     char mesg[AFP_LOGINMESG_LEN];
     unsigned char shutdown = 0;
@@ -772,6 +779,16 @@ void *dsi_incoming_attention(void * other)
         checkmessage = 1;
     }
 
+    if (context->connection_generation != server->connection_generation) {
+        log_for_client(NULL, AFPFSD, LOG_DEBUG,
+                       "Ignoring stale attention packet from connection generation %u (current: %u)",
+                       context->connection_generation,
+                       server->connection_generation);
+        afp_server_release(server);
+        free(context);
+        return NULL;
+    }
+
     if (checkmessage) {
         afp_getsrvrmsg(server, AFPMESG_SERVER,
                        ((server->using_version && server->using_version->av_number >= 30) ? 1 : 0),
@@ -786,11 +803,20 @@ void *dsi_incoming_attention(void * other)
         log_for_client(NULL, AFPFSD, LOG_ERR,
                        "Got a shutdown notice in packet %d, going down in %d mins",
                        ntohs(packet->header.requestid), mins);
-        loop_disconnect(server);
-        server->connect_state = SERVER_STATE_DISCONNECTED;
+
+        if (context->connection_generation == server->connection_generation) {
+            loop_disconnect(server);
+            server->connect_state = SERVER_STATE_DISCONNECTED;
+        } else {
+            log_for_client(NULL, AFPFSD, LOG_DEBUG,
+                           "Ignoring stale shutdown notice from connection generation %u (current: %u)",
+                           context->connection_generation,
+                           server->connection_generation);
+        }
     }
 
     afp_server_release(server);
+    free(context);
     return NULL;
 }
 
@@ -1081,16 +1107,24 @@ process_packet:
 
     case DSI_DSIAttention: {
         pthread_t thread;
-        memcpy(server->attention_buffer,
-               server->incoming_buffer,
-               server->data_read);
-        server->attention_len = server->data_read;
+        struct dsi_attention_context *context;
+        size_t packet_len = server->data_read;
+        context = malloc(sizeof(*context) + packet_len);
+
+        if (!context) {
+            goto error;
+        }
+
+        context->server = server;
+        context->connection_generation = server->connection_generation;
+        memcpy(context->packet, server->incoming_buffer, packet_len);
         afp_server_hold(server);
 
-        if (pthread_create(&thread, NULL, dsi_incoming_attention, server) == 0) {
+        if (pthread_create(&thread, NULL, dsi_incoming_attention, context) == 0) {
             pthread_detach(thread);
         } else {
             afp_server_release(server);
+            free(context);
         }
     }
     break;

--- a/test/TESTS.md
+++ b/test/TESTS.md
@@ -7,7 +7,7 @@
 | `test_afpcmd_batch.t` | Uploads a file to an AFP share via `afpcmd` batch mode, downloads it back, and verifies the checksum matches. |
 | `test_afpcmd_interactive.t` | Exercises `afpcmd` interactive mode by piping command sequences through stdin and asserting expected output patterns. |
 | `test_afpgetstatus.t` | Verifies `afpgetstatus` can retrieve and parse AFP server status information. |
-| `test_fuse.t` | Mounts an AFP share via `mount_afpfs` (FUSE), writes and reads a file with an authenticated mount, verifies the file is visible on a guest mount, then cleans up with a second authenticated mount. |
+| `test_fuse.t` | Mounts an AFP share via `mount_afpfs` (FUSE), writes and reads a file with an authenticated mount, verifies authenticated suspend/resume keeps the mount usable, verifies the file is visible on a guest mount, then cleans up with a second authenticated mount. |
 
 `test_fuse.t` must be run stand-alone on a real host — FUSE kernel support is not reliable inside containers. See below.
 

--- a/test/TESTS.md
+++ b/test/TESTS.md
@@ -7,15 +7,15 @@
 | `test_afpcmd_batch.t` | Uploads a file to an AFP share via `afpcmd` batch mode, downloads it back, and verifies the checksum matches. |
 | `test_afpcmd_interactive.t` | Exercises `afpcmd` interactive mode by piping command sequences through stdin and asserting expected output patterns. |
 | `test_afpgetstatus.t` | Verifies `afpgetstatus` can retrieve and parse AFP server status information. |
-| `test_fuse.t` | Mounts an AFP share via `mount_afpfs` (FUSE), writes and reads a file with an authenticated mount, verifies authenticated suspend/resume keeps the mount usable, verifies the file is visible on a guest mount, then cleans up with a second authenticated mount. |
+| `test_fuse.t` | Mounts an AFP share via `mount_afpfs` (FUSE) and performs various operations to test its functionality. |
 
 `test_fuse.t` must be run stand-alone on a real host — FUSE kernel support is not reliable inside containers. See below.
 
-All tests use `Test::More` (Perl core) and are run with `prove`.
+All tests use the `Test::More` library (part of Perl core) and are executed with the `prove` test runner.
 
 The tests assume a netatalk AFP server is running locally with a share at `afp://localhost/afpfs_test`
 that allows both guest and authenticated access.
-The authenticated user is `test_usr` with password `test_pwd`.
+The default authenticated user is `test_usr` with password `test_pwd`.
 See Manual environment prep below for setup instructions.
 
 ---
@@ -49,7 +49,35 @@ podman run --rm netatalk-client-test
 - netatalk installed and configured (see Manual environment prep below)
 - Perl (any recent version; all modules used are in core)
 
-Follow the steps in entrypoint.sh script to configure users and a shared volume for a netatalk AFP server used by the tests.
+### Manual environment prep
+
+The stand-alone tests expect a local Netatalk server named `afpfs_testsrv`
+with a volume named `afpfs_test`. The batch and interactive tests use the
+default credentials `test_usr` / `test_pwd`.
+
+Create the test user and shared directory:
+
+```sh
+sudo useradd --no-create-home test_usr || true
+echo 'test_usr:test_pwd' | sudo chpasswd
+sudo mkdir -p /mnt/afpfs
+sudo chmod 2755 /mnt/afpfs
+sudo chown test_usr:test_usr /mnt/afpfs
+```
+
+Configure Netatalk's *afp.conf* with guest and DHX2 authentication enabled:
+
+```ini
+[Global]
+log file = /var/log/afpd.log
+log level = default:debug
+server name = afpfs_testsrv
+uam list = uams_guest.so uams_dhx2.so
+
+[afpfs_test]
+path = /mnt/afpfs
+volume name = afpfs_test
+```
 
 ### Running batch and interactive tests
 
@@ -70,6 +98,19 @@ The `afpsld` session daemon is killed between the two test runs to ensure a clea
 ```sh
 cd test
 prove test_fuse.t
+```
+
+By default, `test_fuse.t` authenticates as `test_usr` with password `test_pwd`.
+Override these credentials with environment variables:
+
+```sh
+AFP_TEST_USER=my_user AFP_TEST_PASSWORD=my_password prove test_fuse.t
+```
+
+or pass them as test arguments:
+
+```sh
+prove test_fuse.t :: --user my_user --password my_password
 ```
 
 The test creates an `afpfs_mnt/` directory in the current working directory and removes it implicitly when unmounted.

--- a/test/TESTS.md
+++ b/test/TESTS.md
@@ -113,6 +113,15 @@ or pass them as test arguments:
 prove test_fuse.t :: --user my_user --password my_password
 ```
 
+To capture detailed `afpfsd` debug logs for a failing FUSE run, set
+`AFP_FUSE_DEBUG_LOG`. In this mode, `test_fuse.t` starts the manager in
+foreground debug mode and redirects manager and per-mount daemon logs to the
+given file:
+
+```sh
+AFP_FUSE_DEBUG_LOG=/tmp/test_fuse-afpfsd.log prove test_fuse.t
+```
+
 The test creates an `afpfs_mnt/` directory in the current working directory and removes it implicitly when unmounted.
 If a run is interrupted mid-test, unmount manually before re-running:
 

--- a/test/TESTS.md
+++ b/test/TESTS.md
@@ -128,3 +128,9 @@ If a run is interrupted mid-test, unmount manually before re-running:
 ```sh
 afp_client unmount ./afpfs_mnt
 ```
+
+On macOS with macFUSE, use:
+
+```sh
+/sbin/umount ./afpfs_mnt
+```

--- a/test/test_fuse.t
+++ b/test/test_fuse.t
@@ -17,6 +17,15 @@ use Cwd qw(getcwd);
 
 my $mnt_dir = getcwd() . '/afpfs_mnt';
 
+sub mount_or_bail {
+    my ($description, @cmd) = @_;
+    my $rc = system(@cmd);
+
+    is($rc, 0, $description);
+    BAIL_OUT("$description failed: @cmd exited with " . ($rc >> 8))
+        if $rc != 0;
+}
+
 # -----------------------------------------------------------------------
 # prepare test environment: ensure mount directory exists, start afpfsd
 # -----------------------------------------------------------------------
@@ -29,8 +38,8 @@ is(system('afpfsd', '--manager'), 0, 'prepare: afpfsd daemon started');
 # fuse_auth: authenticated mount
 # -----------------------------------------------------------------------
 sleep 1;
-is(system('mount_afpfs', 'afp://test_usr:test_pwd@localhost/afpfs_test', $mnt_dir), 0,
-    'fuse_auth: authenticated mount succeeds');
+mount_or_bail('fuse_auth: authenticated mount succeeds',
+    'mount_afpfs', 'afp://test_usr:test_pwd@localhost/afpfs_test', $mnt_dir);
 
 open(my $wfh, '>', "$mnt_dir/sample.txt")
     or BAIL_OUT("Cannot write to mounted share: $!");
@@ -44,6 +53,48 @@ close $rfh;
 like($content, qr/^You should read this back$/m,
     'fuse_auth: file content readable after write');
 
+# -----------------------------------------------------------------------
+# fuse_resume: authenticated suspend/resume keeps mounted volume usable
+# -----------------------------------------------------------------------
+is(system('afp_client', 'suspend', $mnt_dir), 0,
+    'fuse_resume: authenticated suspend succeeds');
+
+open(my $status_fh, '-|', 'afp_client', 'status', $mnt_dir)
+    or BAIL_OUT("Cannot run afp_client status: $!");
+my $status = do { local $/; <$status_fh> };
+my $status_close_ok = close $status_fh;
+my $status_rc = $?;
+ok($status_close_ok, 'fuse_resume: status command exits successfully')
+    or diag('afp_client status exited with '
+        . ($status_rc == -1 ? "close error: $!" : 'status ' . ($status_rc >> 8)));
+like($status, qr/connection: .*disconnected/,
+    'fuse_resume: status reports disconnected server after suspend');
+
+is(system('afp_client', 'resume', $mnt_dir), 0,
+    'fuse_resume: authenticated resume succeeds without new password');
+
+open(my $resume_rfh, '<', "$mnt_dir/sample.txt")
+    or BAIL_OUT("Cannot read file after resume: $!");
+my $resume_content = do { local $/; <$resume_rfh> };
+close $resume_rfh;
+like($resume_content, qr/^You should read this back$/m,
+    'fuse_resume: existing file readable after resume');
+
+open(my $resume_wfh, '>', "$mnt_dir/resume.txt")
+    or BAIL_OUT("Cannot write file after resume: $!");
+print $resume_wfh "Resume write survived reconnect\n";
+close $resume_wfh;
+
+open(my $resume_check_fh, '<', "$mnt_dir/resume.txt")
+    or BAIL_OUT("Cannot read resume check file: $!");
+my $resume_check = do { local $/; <$resume_check_fh> };
+close $resume_check_fh;
+like($resume_check, qr/^Resume write survived reconnect$/m,
+    'fuse_resume: new file writable after resume');
+
+unlink "$mnt_dir/resume.txt";
+ok(!-e "$mnt_dir/resume.txt", 'fuse_resume: resume check file removed');
+
 is(system('afp_client', 'unmount', $mnt_dir), 0,
     'fuse_auth: authenticated unmount succeeds');
 
@@ -51,8 +102,8 @@ is(system('afp_client', 'unmount', $mnt_dir), 0,
 # fuse_auth: guest mount
 # -----------------------------------------------------------------------
 sleep 1;
-is(system('mount_afpfs', 'afp://localhost/afpfs_test', $mnt_dir), 0,
-    'fuse_auth: guest mount succeeds');
+mount_or_bail('fuse_auth: guest mount succeeds',
+    'mount_afpfs', 'afp://localhost/afpfs_test', $mnt_dir);
 
 ok(-f "$mnt_dir/sample.txt",
     'fuse_auth: guest mount shows previously written file');
@@ -71,8 +122,8 @@ is(system('afp_client', 'unmount', $mnt_dir), 0,
 # fuse_auth: authenticated mount cleanup
 # -----------------------------------------------------------------------
 sleep 1;
-is(system('mount_afpfs', 'afp://test_usr:test_pwd@localhost/afpfs_test', $mnt_dir), 0,
-    'fuse_auth: cleanup mount succeeds');
+mount_or_bail('fuse_auth: cleanup mount succeeds',
+    'mount_afpfs', 'afp://test_usr:test_pwd@localhost/afpfs_test', $mnt_dir);
 
 open(my $cfh, '<', "$mnt_dir/sample.txt")
     or BAIL_OUT("Cannot read file on cleanup mount: $!");

--- a/test/test_fuse.t
+++ b/test/test_fuse.t
@@ -15,12 +15,16 @@ use warnings;
 use Test::More;
 use Cwd qw(getcwd);
 use Getopt::Long qw(GetOptions);
+use IO::Handle;
+use POSIX qw(WNOHANG setsid);
 
 my $AFP_USER = $ENV{AFP_TEST_USER} // 'test_usr';
 my $AFP_PASS = $ENV{AFP_TEST_PASSWORD} // 'test_pwd';
 my $AFP_HOST = 'localhost';
 my $AFP_VOL  = 'afpfs_test';
+my $AFP_FUSE_DEBUG_LOG = $ENV{AFP_FUSE_DEBUG_LOG};
 my $mnt_dir = getcwd() . '/afpfs_mnt';
+my $afpfsd_pid;
 
 GetOptions(
     'user=s'     => \$AFP_USER,
@@ -42,6 +46,51 @@ my $AFP_AUTH_URL = sprintf(
 );
 my $AFP_GUEST_URL = "afp://$AFP_HOST/$AFP_VOL";
 
+sub start_afpfsd_manager {
+    if (!$AFP_FUSE_DEBUG_LOG) {
+        is(system('afpfsd', '--manager'), 0,
+            'prepare: afpfsd daemon started');
+        return;
+    }
+
+    open(my $log_fh, '>>', $AFP_FUSE_DEBUG_LOG)
+        or BAIL_OUT("Cannot open AFP_FUSE_DEBUG_LOG '$AFP_FUSE_DEBUG_LOG': $!");
+    $log_fh->autoflush(1);
+    print $log_fh "\n==> Starting afpfsd debug manager for test_fuse.t pid $$\n";
+
+    my $pid = fork();
+    BAIL_OUT("Cannot fork afpfsd debug manager: $!") unless defined $pid;
+
+    if ($pid == 0) {
+        setsid() or die "setsid: $!";
+        open(STDOUT, '>&', $log_fh) or die "dup stdout: $!";
+        open(STDERR, '>&', $log_fh) or die "dup stderr: $!";
+        close $log_fh;
+        exec('afpfsd', '--debug', '--manager') or die "exec afpfsd: $!";
+    }
+
+    close $log_fh;
+    $afpfsd_pid = $pid;
+    sleep 1;
+
+    my $exited = waitpid($pid, WNOHANG);
+    if ($exited == $pid) {
+        undef $afpfsd_pid;
+        BAIL_OUT("afpfsd debug manager exited early; see $AFP_FUSE_DEBUG_LOG");
+    }
+
+    ok($pid > 0, "prepare: afpfsd debug manager started, logging to $AFP_FUSE_DEBUG_LOG");
+}
+
+END {
+    if ($afpfsd_pid) {
+        my $exit_status = $?;
+        kill 'TERM', -$afpfsd_pid;
+        waitpid($afpfsd_pid, 0);
+        $? = $exit_status;
+    }
+}
+
 sub mount_or_bail {
     my ($description, @cmd) = @_;
     my $rc = system(@cmd);
@@ -57,7 +106,7 @@ sub mount_or_bail {
 mkdir $mnt_dir unless -d $mnt_dir;
 ok(-d $mnt_dir, 'prepare: mount directory exists');
 
-is(system('afpfsd', '--manager'), 0, 'prepare: afpfsd daemon started');
+start_afpfsd_manager();
 
 # -----------------------------------------------------------------------
 # fuse_auth: authenticated mount

--- a/test/test_fuse.t
+++ b/test/test_fuse.t
@@ -14,8 +14,33 @@ use warnings;
 
 use Test::More;
 use Cwd qw(getcwd);
+use Getopt::Long qw(GetOptions);
 
+my $AFP_USER = $ENV{AFP_TEST_USER} // 'test_usr';
+my $AFP_PASS = $ENV{AFP_TEST_PASSWORD} // 'test_pwd';
+my $AFP_HOST = 'localhost';
+my $AFP_VOL  = 'afpfs_test';
 my $mnt_dir = getcwd() . '/afpfs_mnt';
+
+GetOptions(
+    'user=s'     => \$AFP_USER,
+    'password=s' => \$AFP_PASS,
+) or BAIL_OUT('Invalid arguments. Usage: prove test_fuse.t :: --user USER --password PASSWORD');
+
+sub url_escape_component {
+    my ($value) = @_;
+    $value =~ s/([^A-Za-z0-9._~-])/sprintf('%%%02X', ord($1))/eg;
+    return $value;
+}
+
+my $AFP_AUTH_URL = sprintf(
+    'afp://%s:%s@%s/%s',
+    url_escape_component($AFP_USER),
+    url_escape_component($AFP_PASS),
+    $AFP_HOST,
+    $AFP_VOL,
+);
+my $AFP_GUEST_URL = "afp://$AFP_HOST/$AFP_VOL";
 
 sub mount_or_bail {
     my ($description, @cmd) = @_;
@@ -39,7 +64,7 @@ is(system('afpfsd', '--manager'), 0, 'prepare: afpfsd daemon started');
 # -----------------------------------------------------------------------
 sleep 1;
 mount_or_bail('fuse_auth: authenticated mount succeeds',
-    'mount_afpfs', 'afp://test_usr:test_pwd@localhost/afpfs_test', $mnt_dir);
+    'mount_afpfs', $AFP_AUTH_URL, $mnt_dir);
 
 open(my $wfh, '>', "$mnt_dir/sample.txt")
     or BAIL_OUT("Cannot write to mounted share: $!");
@@ -103,7 +128,7 @@ is(system('afp_client', 'unmount', $mnt_dir), 0,
 # -----------------------------------------------------------------------
 sleep 1;
 mount_or_bail('fuse_auth: guest mount succeeds',
-    'mount_afpfs', 'afp://localhost/afpfs_test', $mnt_dir);
+    'mount_afpfs', $AFP_GUEST_URL, $mnt_dir);
 
 ok(-f "$mnt_dir/sample.txt",
     'fuse_auth: guest mount shows previously written file');
@@ -123,7 +148,7 @@ is(system('afp_client', 'unmount', $mnt_dir), 0,
 # -----------------------------------------------------------------------
 sleep 1;
 mount_or_bail('fuse_auth: cleanup mount succeeds',
-    'mount_afpfs', 'afp://test_usr:test_pwd@localhost/afpfs_test', $mnt_dir);
+    'mount_afpfs', $AFP_AUTH_URL, $mnt_dir);
 
 open(my $cfh, '<', "$mnt_dir/sample.txt")
     or BAIL_OUT("Cannot read file on cleanup mount: $!");

--- a/test/test_fuse.t
+++ b/test/test_fuse.t
@@ -100,6 +100,18 @@ sub mount_or_bail {
         if $rc != 0;
 }
 
+sub unmount_or_bail {
+    my ($description) = @_;
+    my @cmd = $^O eq 'darwin'
+        ? ('/sbin/umount', $mnt_dir)
+        : ('afp_client', 'unmount', $mnt_dir);
+    my $rc = system(@cmd);
+
+    is($rc, 0, $description);
+    BAIL_OUT("$description failed: @cmd exited with " . ($rc >> 8))
+        if $rc != 0;
+}
+
 # -----------------------------------------------------------------------
 # prepare test environment: ensure mount directory exists, start afpfsd
 # -----------------------------------------------------------------------
@@ -169,8 +181,7 @@ like($resume_check, qr/^Resume write survived reconnect$/m,
 unlink "$mnt_dir/resume.txt";
 ok(!-e "$mnt_dir/resume.txt", 'fuse_resume: resume check file removed');
 
-is(system('afp_client', 'unmount', $mnt_dir), 0,
-    'fuse_auth: authenticated unmount succeeds');
+unmount_or_bail('fuse_auth: authenticated unmount succeeds');
 
 # -----------------------------------------------------------------------
 # fuse_auth: guest mount
@@ -189,8 +200,7 @@ close $gfh;
 like($guest_content, qr/^You should read this back$/m,
     'fuse_auth: guest mount file content matches');
 
-is(system('afp_client', 'unmount', $mnt_dir), 0,
-    'fuse_auth: guest unmount succeeds');
+unmount_or_bail('fuse_auth: guest unmount succeeds');
 
 # -----------------------------------------------------------------------
 # fuse_auth: authenticated mount cleanup
@@ -210,7 +220,6 @@ is(scalar @lines, 1, 'fuse_auth: file has exactly one line');
 unlink "$mnt_dir/sample.txt";
 ok(!-e "$mnt_dir/sample.txt", 'fuse_auth: sample.txt removed');
 
-is(system('afp_client', 'unmount', $mnt_dir), 0,
-    'fuse_auth: cleanup unmount succeeds');
+unmount_or_bail('fuse_auth: cleanup unmount succeeds');
 
 done_testing;

--- a/test/test_metadata.c
+++ b/test/test_metadata.c
@@ -89,7 +89,10 @@ int main(int argc, char **argv)
     char temporary[] = "afpcmd-metadata-XXXXXX";
     char file[1024], missing[1024], macos_sidecar[1024], netatalk_dir[1024];
     char netatalk_sidecar[1024], ea_header[1024], ea_value[1024];
-    unsigned char finder[32], macos_finder[32], actual_finder[32];
+    unsigned char finder[32], actual_finder[32];
+#ifndef __APPLE__
+    unsigned char macos_finder[32];
+#endif
     unsigned char resource[7000], actual_resource[7000];
     char *list = NULL;
     size_t list_size = 0;


### PR DESCRIPTION
The FUSE suspend/resume operations got broken when we hardened AFP session reconnection recently.

Keep a per-mount FUSE reconnect credential after the initial authenticated login, since the shared AFP server password cache is scrubbed for stateless session safety and resume commands do not carry a fresh password.

Make DSI attention handling generation-aware by copying packets into the worker context and ignoring stale attentions from older connections before they can disconnect a newly resumed socket.

Also register FPZzzzz as a blank-reply AFP command and initialize FUSE reconnect error reporting so suspend and resume diagnostics reflect real failures.

introduce explicit suspended flag for FUSE mounts: before, any file system operation on a suspended mount would reactivate it, but now only an explicit 'resume' command will cause it to wake up

Add FUSE client tests for suspend and resume, while improving the resilience, configurability, and documentation of the FUSE test runner.

Make a number of adjacent improvements and bug fixes:

- prevent double free during FUSE3 unmount process and handle SIGPIPE wakeups safely
- force FUSE demon foreground mode when using stdout log method
- make DSI connection generation access atomic 