### PR TITLE
consistent AFP nomenclature in help text and man pages

### DIFF
--- a/cmdline/cmdline_main.c
+++ b/cmdline/cmdline_main.c
@@ -453,7 +453,7 @@ void cmdline_loop_started(void)
 static void usage(void)
 {
     printf(
-        "Netatalk Client %s - Apple Filing Protocol CLI client application\n"
+        "Netatalk Client %s - AFP command-line client\n"
         "afpcmd [-h] [-V] [-v loglevel] [-M mode] <afp url>\n"
         "Options:\n"
         "\t-h:          show this help message and exit\n"

--- a/daemon/daemon.c
+++ b/daemon/daemon.c
@@ -156,12 +156,13 @@ void close_commands(int command_fd)
 
 static void usage(void)
 {
-    printf("Usage: afpsld [OPTION]\n"
+    printf("Netatalk Client %s - AFP Stateless client daemon\n"
+           "Usage: afpsld [OPTION]\n"
            "  -l, --logmethod    Either 'syslog' or 'stdout'\n"
            "  -v, --loglevel     LOG_DEBUG|LOG_INFO|LOG_NOTICE|LOG_WARNING|LOG_ERR\n"
            "  -f, --foreground   Do not fork\n"
-           "  -d, --debug        Do not fork, debug loglevel, logs to stdout\n"
-           "Version %s\n", NETATALK_CLIENT_VERSION);
+           "  -d, --debug        Do not fork, debug loglevel, logs to stdout\n",
+           NETATALK_CLIENT_VERSION);
 }
 
 static struct libafpclient client = {

--- a/docs/manpages/afp_client.1
+++ b/docs/manpages/afp_client.1
@@ -3,7 +3,7 @@
 .Os Netatalk Client
 .Sh NAME
 .Nm afp_client
-.Nd Mount, unmount and control Apple Filing Protocol (AFP) sessions using the FUSE infrastructure
+.Nd Mount, unmount and control AFP sessions using the FUSE infrastructure
 .Sh SYNOPSIS
 .Nm
 .Cm mount Ns | Ns Cm status Ns | Ns Cm unmount Ns | Ns Cm suspend Ns | Ns Cm resume Ns | Ns Cm exit
@@ -11,8 +11,8 @@
 .Sh DESCRIPTION
 The
 .Nm
-command is the user-facing control utility for AFP volumes mounted through
-the Netatalk Client FUSE infrastructure.
+command is the user-facing control utility for AFP (Apple Filing Protocol) volumes
+mounted through the Netatalk Client FUSE infrastructure.
 It mounts AFP volumes, unmounts them, reports mount status, suspends and
 resumes server connections, and shuts down the per-user mount manager.
 .Pp

--- a/docs/manpages/afpcmd.1
+++ b/docs/manpages/afpcmd.1
@@ -3,7 +3,7 @@
 .Os Netatalk Client
 .Sh NAME
 .Nm afpcmd
-.Nd Transfer files over the network using the Apple Filing Protocol (AFP)
+.Nd Command-line AFP client for browsing and transferring files over the network
 .Sh SYNOPSIS
 .Nm
 .Op Fl V
@@ -27,9 +27,9 @@
 .Sh DESCRIPTION
 .Nm
 is a command-line tool to help transfer files to and from a
-server using AFP.
+server using AFP (Apple Filing Protocol).
 This server is typically either Netatalk running on a UNIX-like host,
-or AppleShare Server running on Classic Mac OS or Mac OS X.
+or AppleShare Server or personal file sharing on Classic Mac OS or Mac OS X.
 .Pp
 This can be done as a non-root user.
 It offers either an interactive

--- a/docs/manpages/afpfsd.1
+++ b/docs/manpages/afpfsd.1
@@ -14,7 +14,7 @@
 .Op Fl s | Fl -socket-id Ar socket_name
 .Sh DESCRIPTION
 .Nm
-is the daemon used by the FUSE client.
+is the daemon used by the AFP (Apple Filing Protocol) FUSE client.
 It is typically not run directly by users; rather,
 it is started automatically by
 .Xr afp_client 1

--- a/docs/manpages/afpgetstatus.1
+++ b/docs/manpages/afpgetstatus.1
@@ -14,7 +14,7 @@
 .Sh DESCRIPTION
 .Nm
 is a command-line tool that parses and prints the status
-information of an AFP server.
+information of an AFP (Apple Filing Protocol) server.
 .Pp
 It first queries the server using a DSI GetStatus request (which is the same
 as the AFP FPGetSrvrInfo) to display server name, type, supported AFP

--- a/docs/manpages/afpsld.1
+++ b/docs/manpages/afpsld.1
@@ -12,7 +12,7 @@
 .Op Fl d | Fl -debug
 .Sh DESCRIPTION
 .Nm
-is a daemon that handles remote AFP file operations via a stateless API.
+is a daemon that handles remote AFP (Apple Filing Protocol) file operations via a stateless API.
 It manages server connections and performs file I/O operations on behalf of client applications.
 .Pp
 .Nm

--- a/docs/manpages/mount_afpfs.1
+++ b/docs/manpages/mount_afpfs.1
@@ -3,7 +3,7 @@
 .Os Netatalk Client
 .Sh NAME
 .Nm mount_afpfs
-.Nd mount an Apple Filing Protocol (AFP) filesystem using FUSE
+.Nd mount an AFP filesystem using FUSE
 .Sh SYNOPSIS
 .Nm
 .Op Fl o Ar options
@@ -12,7 +12,7 @@
 .Sh DESCRIPTION
 The
 .Nm
-command is used to mount an AFP volume in the format
+command is used to mount an AFP (Apple Filing Protocol) volume in the format
 .Sm off
 .Ar afp:// Oo Ar user Oo ; No AUTH= Ar uamname Oc Oo : Ar password Oc @ Oc Ar host Oo : Ar port Oc / Ar volumename
 .Sm on

--- a/fuse/client.c
+++ b/fuse/client.c
@@ -785,7 +785,7 @@ static int do_mount(int argc, char ** argv)
 
 static void mount_afpfs_usage(void)
 {
-    printf("Netatalk Client %s - mount an Apple Filing Protocol network filesystem with FUSE\n"
+    printf("Netatalk Client %s - mount an AFP network filesystem with FUSE\n"
            "Usage:\n"
            "\tmount_afpfs [-o volpass=password] <afp url> <mountpoint>\n",
            NETATALK_CLIENT_VERSION);

--- a/fuse/daemon.c
+++ b/fuse/daemon.c
@@ -174,7 +174,7 @@ void close_commands(int command_fd)
 
 static void usage(void)
 {
-    printf("Netatalk Client %s - Apple Filing Protocol client FUSE daemon\n"
+    printf("Netatalk Client %s - AFP client FUSE daemon\n"
            "Usage: afpfsd [OPTION]\n"
            "  -l, --logmethod    Either 'syslog' or 'stdout'\n"
            "  -v, --loglevel     LOG_DEBUG|LOG_INFO|LOG_NOTICE|LOG_WARNING|LOG_ERR\n"


### PR DESCRIPTION
in man pages, always use the AFP acronym in the title, and always spell out the full name of the protocol in the first paragraph

in executable help text, always use the AFP acronym

this mirrors f.e. the convention in Samba man pages