### PR TITLE
meson: allow builds with only libraries, no client executables

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -179,8 +179,8 @@ if with_crypt
 endif
 
 if not with_afpcmd and not with_fuse
-    error(
-        'At least one of AFP command line client or FUSE client must be buildable.',
+    message(
+        'neither afpcmd nor the FUSE client will be built.',
     )
 endif
 


### PR DESCRIPTION
we previously prevented the build system from proceeding when neither libfuse nor readline/libedit were found; however, building only the libraries is a valid use case for instance on minimal servers or containers that use libafpclient / libafpsl as dependencies for other software