### PR TITLE
libafpclient: respect requested AFP version ceiling

### DIFF
--- a/lib/afp.c
+++ b/lib/afp.c
@@ -1141,31 +1141,28 @@ error:
 struct afp_versions *pick_version(unsigned char *versions,
                                   unsigned char requested)
 {
-    /* Pick the right version number.  This means either the
-       one requested or the last one. Set both the number and the
-       string. */
+    /* Pick the highest mutually supported AFP version, bounded by the
+       requested version when one was supplied. */
     int i;
     char version_num = 0;
-    char found_version = 0;
     struct afp_versions * p;
-    char highest = 0;
 
     if (requested) {
         requested = min(requested, AFP_MAX_SUPPORTED_VERSION);
     }
 
-    for (i = 0; versions[i] && (i < SERVER_MAX_VERSIONS); i++) {
-        version_num = versions[i];
-        highest = max(highest, version_num);
+    i = 0;
 
-        if (versions[i] == requested) {
-            found_version = 1;
+    while (i < SERVER_MAX_VERSIONS) {
+        if (!versions[i]) {
             break;
         }
-    };
 
-    if (!found_version) {
-        version_num = highest;
+        if (!requested || versions[i] <= requested) {
+            version_num = max(version_num, versions[i]);
+        }
+
+        i++;
     }
 
     for (p = afp_versions; p->av_name; p++) {

--- a/test/meson.build
+++ b/test/meson.build
@@ -66,6 +66,23 @@ test(
     verbose: true,
 )
 
+versions_test = executable(
+    'test_versions',
+    sources: ['test_versions.c'],
+    include_directories: incdir,
+    link_with: libafpclient,
+    dependencies: root_dependencies,
+    c_args: cflags,
+)
+
+test(
+    'AFP version selection',
+    versions_test,
+    args: ['--tap'],
+    protocol: 'tap',
+    verbose: true,
+)
+
 stateless_log_test = executable(
     'test_stateless_log',
     sources: ['test_stateless_log.c'],

--- a/test/test_versions.c
+++ b/test/test_versions.c
@@ -1,0 +1,31 @@
+#include "afp.h"
+#include "tap.h"
+
+static int version_number(unsigned char *versions, unsigned char requested)
+{
+    const struct afp_versions *version = pick_version(versions, requested);
+    return version ? version->av_number : 0;
+}
+
+int main(int argc, char **argv)
+{
+    unsigned char modern_versions[SERVER_MAX_VERSIONS] = {
+        22, 30, 31, 32, 33, 34, 0
+    };
+    unsigned char all_versions[SERVER_MAX_VERSIONS] = {
+        11, 20, 21, 22, 30, 31, 32, 33, 34, 0
+    };
+    unsigned char full_versions[SERVER_MAX_VERSIONS] = {
+        11, 20, 21, 22, 30, 31, 32, 33, 34, 34
+    };
+    test_tap_init(argc, argv);
+    CHECK(version_number(modern_versions, 21) == 0);
+    CHECK(version_number(modern_versions, 22) == 22);
+    CHECK(version_number(modern_versions, 29) == 22);
+    CHECK(version_number(modern_versions, 34) == 34);
+    CHECK(version_number(modern_versions, 0) == 34);
+    CHECK(version_number(all_versions, 21) == 21);
+    CHECK(version_number(all_versions, 35) == 34);
+    CHECK(version_number(full_versions, 0) == 34);
+    return test_tap_finish();
+}


### PR DESCRIPTION
Treat requested AFP versions as an upper bound when selecting a mutually supported protocol version. This prevents AFP 2.1 requests from silently negotiating AFP 3.x when the server does not advertise AFP 2.1.

Add a TAP regression test for version selection, including the modern-server case that previously fell through to AFP 3.4.