### PR TITLE
add illumos and Solaris build support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
       - 'NEWS'
       - 'README.md'
       - 'TODO'
+
   pull_request:
     branches: ["main"]
     types:
@@ -25,6 +26,10 @@ on:
       - 'NEWS'
       - 'README.md'
       - 'TODO'
+
+env:
+  SMARTOS_BOOTSTRAP_URL: https://pkgsrc.smartos.org/packages/SmartOS/bootstrap/bootstrap-2025Q4-x86_64.tar.gz
+  SMARTOS_BOOTSTRAP_SHA256: 4842f72b610d44cf98560253b6bf16ff4056016e5fe2c6932bc195156ac75772
 
 jobs:
   build-alpine-fuse2:
@@ -416,6 +421,132 @@ jobs:
             meson test -C build
             meson install -C build
             afpcmd -h
+      - name: Upload meson logs
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: meson-logs-${{ github.job }}
+          path: build/meson-logs
+
+  build-omnios:
+    name: OmniOS
+    runs-on: ubuntu-latest
+    timeout-minutes: 24
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Build on VM
+        uses: vmactions/omnios-vm@7f2be0b927aad1a78498c8aeeac4c4ce1fabd322 # v1.3.3
+        with:
+          release: "r151056-build"
+          copyback: true
+          prepare: |
+            set -e
+            pkg install \
+              build-essential \
+              pkg-config
+            curl --proto '=https' --location --fail -o bootstrap.tar.gz "${{ env.SMARTOS_BOOTSTRAP_URL }}"
+            bootstrap_sha256=$(/bin/digest -a sha256 bootstrap.tar.gz)
+            if [ "$bootstrap_sha256" != "${{ env.SMARTOS_BOOTSTRAP_SHA256 }}" ]; then
+              echo "bootstrap.tar.gz SHA-256 mismatch" >&2
+              exit 1
+            fi
+            tar -zxpf bootstrap.tar.gz -C /
+            export PATH=/opt/local/sbin:/opt/local/bin:/usr/gnu/bin:/usr/bin:/usr/sbin:/sbin:$PATH
+            pkgin -y install \
+              meson \
+              libgcrypt
+          run: |
+            set -e
+            export PATH=/opt/local/sbin:/opt/local/bin:/usr/gnu/bin:/usr/bin:/usr/sbin:/sbin:$PATH
+            export LD_LIBRARY_PATH=/opt/local/lib
+            export PKG_CONFIG_PATH=/opt/local/lib/pkgconfig
+            meson setup build \
+              --prefix=/opt/local \
+              -Denable-fuse=false \
+              -Dpkg_config_path=/opt/local/lib/pkgconfig
+            meson compile -C build
+            meson test -C build
+            meson install -C build
+            afpcmd -h
+      - name: Upload meson logs
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: meson-logs-${{ github.job }}
+          path: build/meson-logs
+
+  build-openindiana:
+    name: OpenIndiana
+    runs-on: ubuntu-latest
+    timeout-minutes: 24
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Build on VM
+        uses: vmactions/openindiana-vm@3248e8c61485588528c034a4285242f77efd8b97 # v1.1.3
+        with:
+          release: "202510-build"
+          copyback: true
+          prepare: |
+            set -e
+            pkg install \
+              developer/build/meson \
+              developer/build/ninja \
+              developer/build/pkg-config \
+              developer/gcc-14 \
+              library/libedit \
+              system/library/security/libgcrypt
+          run: |
+            set -e
+            export PKG_CONFIG_PATH=/usr/lib/amd64/pkgconfig
+            meson setup build \
+              -Denable-fuse=false \
+              -Dpkg_config_path=/usr/lib/amd64/pkgconfig
+            meson compile -C build
+            meson test -C build
+            meson install -C build
+            /usr/local/bin/afpcmd -h
+      - name: Upload meson logs
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: meson-logs-${{ github.job }}
+          path: build/meson-logs
+
+  build-solaris:
+    name: Solaris 11
+    runs-on: ubuntu-latest
+    timeout-minutes: 24
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Build on VM
+        uses: vmactions/solaris-vm@d30dd6c228c8661ade859e36ead7660b9a62efcc # v1.3.7
+        with:
+          copyback: true
+          sync-time: true
+          sync: nfs
+          prepare: |
+            set -e
+            pkg install \
+              gcc \
+              library/libedit \
+              libgcrypt \
+              meson \
+              ninja \
+              pkg-config
+          run: |
+            set -e
+            export PKG_CONFIG_PATH=/usr/lib/amd64/pkgconfig
+            meson setup build \
+              --prefix=/usr/local \
+              -Denable-fuse=false \
+              -Dpkg_config_path=/usr/lib/amd64/pkgconfig
+            meson compile -C build
+            meson test -C build
+            meson install -C build
+            /usr/local/bin/afpcmd -h
       - name: Upload meson logs
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/cmdline/meson.build
+++ b/cmdline/meson.build
@@ -3,8 +3,10 @@ executable(
     sources: 'getstatus.c',
     include_directories: incdir,
     link_with: libafpclient,
+    dependencies: root_dependencies,
     c_args: cflags,
     install: true,
+    install_rpath: install_runtime_path,
 )
 
 if with_afpcmd
@@ -19,5 +21,6 @@ if with_afpcmd
         dependencies: [root_dependencies, cmdline_dependencies],
         c_args: cflags,
         install: true,
+        install_rpath: install_runtime_path,
     )
 endif

--- a/daemon/meson.build
+++ b/daemon/meson.build
@@ -24,6 +24,7 @@ executable(
     include_directories: incdir,
     c_args: cflags,
     install: true,
+    install_rpath: install_runtime_path,
 )
 
 libafpsl = shared_library(
@@ -34,6 +35,7 @@ libafpsl = shared_library(
     link_with: libafpclient,
     c_args: cflags,
     install: true,
+    install_rpath: install_runtime_path,
     version: libafpsl_version,
     soversion: libafpsl_version_major,
 )

--- a/fuse/meson.build
+++ b/fuse/meson.build
@@ -8,6 +8,7 @@ executable(
     c_args: cflags,
     dependencies: [root_dependencies],
     install: true,
+    install_rpath: install_runtime_path,
 )
 
 afpfsd_sources = ['commands.c', 'daemon.c', 'fuse_int.c', 'fuse_error.c']
@@ -20,6 +21,7 @@ executable(
     c_args: cflags,
     dependencies: [root_dependencies, fuse_dep, pthread_dep],
     install: true,
+    install_rpath: install_runtime_path,
 )
 
 install_symlink('afp_client', pointing_to: 'mount_afpfs', install_dir: bindir)

--- a/include/compat.h
+++ b/include/compat.h
@@ -1,6 +1,9 @@
 #ifndef _COMPAT_H_
 #define _COMPAT_H_
 
+#include <stddef.h>
+#include <strings.h>
+
 /* Mark a declaration as intentionally unused when the compiler supports it. */
 #ifndef _U_
 #if defined(__has_attribute)
@@ -18,7 +21,6 @@
 
 /* Secure memory clearing - prefer memset_explicit (C23) over explicit_bzero */
 #if !defined(HAVE_MEMSET_EXPLICIT) && !defined(HAVE_EXPLICIT_BZERO)
-#include <stddef.h>
 extern void explicit_bzero(void *s, size_t n);
 #elif defined(HAVE_MEMSET_EXPLICIT) && !defined(HAVE_EXPLICIT_BZERO)
 #include <string.h>

--- a/include/utils.h
+++ b/include/utils.h
@@ -1,17 +1,25 @@
 #ifndef __UTILS_H_
 #define __UTILS_H_
+#include <arpa/inet.h>
+#include <stdint.h>
 #include <stdio.h>
 
 #include "afp.h"
 
-#if BYTE_ORDER == BIG_ENDIAN
-#define hton64(x)       (x)
-#define ntoh64(x)       (x)
-#else /* BYTE_ORDER == BIG_ENDIAN */
-#define hton64(x)       ((u_int64_t) (htonl((((unsigned long long)(x)) >> 32) & 0xffffffffLL)) | \
-                         (u_int64_t) ((htonl((unsigned long long)(x)) & 0xffffffffLL) << 32))
-#define ntoh64(x)       (hton64(x))
-#endif /* BYTE_ORDER == BIG_ENDIAN */
+static inline uint64_t hton64(uint64_t value)
+{
+    if (htonl(UINT32_C(1)) == UINT32_C(1)) {
+        return value;
+    }
+
+    return (uint64_t)htonl((uint32_t)(value >> 32))
+           | ((uint64_t)htonl((uint32_t)value) << 32);
+}
+
+static inline uint64_t ntoh64(uint64_t value)
+{
+    return hton64(value);
+}
 
 #define min(a,b) (((a)<(b)) ? (a) : (b))
 #define max(a,b) (((a)>(b)) ? (a) : (b))

--- a/lib/afp.c
+++ b/lib/afp.c
@@ -28,6 +28,7 @@
 #include "afp_protocol.h"
 #include "libafpclient.h"
 #include "server.h"
+#include "compat.h"
 #include "dsi.h"
 #include "dsi_protocol.h"
 #include "utils.h"

--- a/lib/dsi.c
+++ b/lib/dsi.c
@@ -31,6 +31,10 @@
 #include "afp_replies.h"
 #include "codepage.h"
 
+#ifndef ICONV_CONST
+#define ICONV_CONST
+#endif
+
 /* Define DEBUG_DSI explicitly to get reams of DSI debugging information. */
 
 static int dsi_remove_from_request_queue(struct afp_server *server,
@@ -712,7 +716,7 @@ void dsi_getstatus_reply(struct afp_server * server)
         iconv_t cd;
         size_t inbytesleft = strlen(server->server_name);
         size_t outbytesleft = AFP_SERVER_NAME_UTF8_LEN;
-        char *inbuf = server->server_name;
+        ICONV_CONST char *inbuf = server->server_name;
         char *outbuf = server->server_name_printable;
 
         if ((cd  = iconv_open("MACINTOSH", "UTF-8")) == (iconv_t) -1) {
@@ -800,7 +804,7 @@ void *dsi_incoming_attention(void * other)
                        ((server->using_version && server->using_version->av_number >= 30) ? 1 : 0),
                        DSI_DEFAULT_TIMEOUT, mesg);
 
-        if (bcmp(mesg, "The server is going down for maintenance.", 41) == 0) {
+        if (memcmp(mesg, "The server is going down for maintenance.", 41) == 0) {
             shutdown = 1;
         }
     }

--- a/lib/loop.c
+++ b/lib/loop.c
@@ -27,8 +27,10 @@
 
 static unsigned char exit_program = 0;
 
-static pthread_t ending_thread = (pthread_t)NULL;
-static pthread_t main_thread = (pthread_t)NULL;
+static pthread_t ending_thread;
+static int ending_thread_valid = 0;
+static pthread_t main_thread;
+static int main_thread_valid = 0;
 
 static int loop_started = 0;
 static pthread_cond_t loop_started_condition = PTHREAD_COND_INITIALIZER;
@@ -108,7 +110,7 @@ static int rm_invalid_fds(void)
 void signal_main_thread(void)
 {
     /* Don't signal if we're already in the main thread - we're already awake! */
-    if (main_thread && pthread_equal(pthread_self(), main_thread)) {
+    if (main_thread_valid && pthread_equal(pthread_self(), main_thread)) {
 #ifdef DEBUG_AFP_LOOP
         log_for_client(NULL, AFPFSD, LOG_DEBUG,
                        "signal_main_thread: already in main thread, skipping signal");
@@ -118,10 +120,10 @@ void signal_main_thread(void)
 
 #ifdef DEBUG_AFP_LOOP
     log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                   "signal_main_thread: sending signal to main_thread=%p", (void*)main_thread);
+                   "signal_main_thread: sending signal to main thread");
 #endif
 
-    if (main_thread) {
+    if (main_thread_valid) {
         int ret = pthread_kill(main_thread, SIGNAL_TO_USE);
 #ifdef DEBUG_AFP_LOOP
         log_for_client(NULL, AFPFSD, LOG_DEBUG,
@@ -152,6 +154,14 @@ void *just_end_it_now(void * ignore _U_)
 
 /*This is a hack to handle a problem where the first pthread_kill doesnt' work*/
 static unsigned char firsttime = 0;
+
+static void start_ending_thread(void)
+{
+    if (pthread_create(&ending_thread, NULL, just_end_it_now, NULL) == 0) {
+        ending_thread_valid = 1;
+    }
+}
+
 void add_fd_and_signal(int fd)
 {
 #ifdef DEBUG_AFP_LOOP
@@ -260,7 +270,7 @@ static int process_server_fds(fd_set *set, int **onfd)
 static void deal_with_server_signals(void)
 {
     if (exit_program == 1) {
-        pthread_create(&ending_thread, NULL, just_end_it_now, NULL);
+        start_ending_thread();
     }
 }
 
@@ -301,6 +311,7 @@ int afp_main_loop(int command_fd)
     int fderrors = 0;
     sigset_t sigmask, orig_sigmask;
     main_thread = pthread_self();
+    main_thread_valid = 1;
     FD_ZERO(&rds);
 
     if (command_fd >= 0) {
@@ -380,7 +391,7 @@ int afp_main_loop(int command_fd)
         }
 
         if (exit_program == 1) {
-            pthread_create(&ending_thread, NULL, just_end_it_now, NULL);
+            start_ending_thread();
             continue;
         }
 
@@ -403,7 +414,7 @@ int afp_main_loop(int command_fd)
         }
 
         if (exit_program == 1) {
-            pthread_create(&ending_thread, NULL, just_end_it_now, NULL);
+            start_ending_thread();
             continue;
         }
 
@@ -559,13 +570,15 @@ int afp_main_loop(int command_fd)
 
 #ifdef DEBUG_AFP_LOOP
     log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                   "afp_main_loop -- Exiting main loop (exit_program=%d, ending_thread=%p)",
-                   exit_program, (void*)ending_thread);
+                   "afp_main_loop -- Exiting main loop (exit_program=%d, ending_thread=%s)",
+                   exit_program, ending_thread_valid ? "started" : "not started");
 #endif
 error:
+    main_thread_valid = 0;
 
-    if (ending_thread != (pthread_t)NULL) {
+    if (ending_thread_valid) {
         pthread_detach(ending_thread);
+        ending_thread_valid = 0;
     }
 
     return -1;

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -64,6 +64,7 @@ libafpclient = shared_library(
     dependencies: [root_dependencies, libiconv_dep, gcrypt_dep, pthread_dep],
     include_directories: incdir,
     install: true,
+    install_rpath: install_runtime_path,
     version: libafpclient_version,
     soversion: libafpclient_version_major,
 )

--- a/meson.build
+++ b/meson.build
@@ -10,6 +10,8 @@ project(
 cc = meson.get_compiler('c')
 host_os = host_machine.system()
 pkg = import('pkgconfig')
+uname = find_program('uname', required: false)
+uname_stdout = run_command(uname, '-a', check: false).stdout().strip()
 
 install_prefix = get_option('prefix')
 bindir = install_prefix / get_option('bindir')
@@ -17,6 +19,10 @@ libdir = install_prefix / get_option('libdir')
 mandir = install_prefix / get_option('mandir')
 datadir = install_prefix / get_option('datadir')
 includedir = install_prefix / get_option('includedir')
+
+# The Solaris runtime linker does not search /usr/local/lib by default. Keep
+# installed binaries and libraries pointed at Meson's configured library dir.
+install_runtime_path = host_os == 'sunos' ? libdir : ''
 
 libsearch_dirs = []
 include_dirs = []
@@ -37,6 +43,14 @@ endif
 
 if host_os == 'linux'
     cflags += '-D_GNU_SOURCE'
+elif host_os == 'sunos'
+    # illumos/Solaris hides POSIX and system extension declarations (including
+    # sigaction(), strnlen(), and strlcpy()) when compiling in strict C mode.
+    cflags += '-D__EXTENSIONS__'
+    if uname.found() and uname_stdout.to_lower().contains('omnios')
+        libsearch_dirs += '/opt/local/lib'
+        include_dirs += ['/opt/local/include']
+    endif
 elif host_os in ['dragonfly', 'freebsd', 'openbsd']
     libsearch_dirs += '/usr/local/lib'
     include_dirs += ['/usr/local/include']
@@ -52,8 +66,36 @@ pthread_dep = cc.find_library('pthread', dirs: libsearch_dirs, required: true)
 libiconv_dep = cc.find_library('iconv', dirs: libsearch_dirs, required: false)
 libbsd_dep = cc.find_library('bsd', dirs: libsearch_dirs, required: false)
 
+iconv_check_deps = []
+if libiconv_dep.found()
+    iconv_check_deps += libiconv_dep
+endif
+
+# POSIX specifies char ** for iconv()'s input buffer, while Solaris and some
+# other historical implementations declare it as const char **.
+if cc.compiles(
+    '''
+    #include <stdlib.h>
+    #include <iconv.h>
+    extern size_t iconv(iconv_t cd, const char **inbuf, size_t *inbytesleft,
+                        char **outbuf, size_t *outbytesleft);
+    ''',
+    args: cflags,
+    dependencies: iconv_check_deps,
+    include_directories: include_directories(include_dirs),
+    name: 'iconv with const inbuf',
+)
+    cflags += '-DICONV_CONST=const'
+endif
+
 root_dependencies = []
 cmdline_dependencies = [readline_dep]
+
+if host_os == 'sunos'
+    # illumos/Solaris provides socket(), getaddrinfo(), and related interfaces
+    # in libsocket rather than libc.
+    root_dependencies += cc.find_library('socket', required: true)
+endif
 
 if editline_dep.found()
     cmdline_dependencies += editline_dep
@@ -68,9 +110,17 @@ if libbsd_dep.found()
     cflags += '-DHAVE_LIBBSD'
 endif
 
-if cc.has_function('explicit_bzero')
+if cc.has_function(
+    'explicit_bzero',
+    prefix: '#include <strings.h>',
+    args: cflags,
+)
     cflags += '-DHAVE_EXPLICIT_BZERO'
-elif cc.has_function('memset_explicit')
+elif cc.has_function(
+    'memset_explicit',
+    prefix: '#include <string.h>',
+    args: cflags,
+)
     cflags += '-DHAVE_MEMSET_EXPLICIT'
 endif
 

--- a/test/test_protocol_replies.c
+++ b/test/test_protocol_replies.c
@@ -16,22 +16,14 @@ struct listxattr_reply {
     char data[];
 } __attribute__((__packed__));
 
-static uint64_t host_to_network64(uint64_t value)
-{
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-    return ((uint64_t)htonl((uint32_t)value) << 32)
-           | htonl((uint32_t)(value >> 32));
-#else
-    return value;
-#endif
-}
-
 int main(int argc, char **argv)
 {
     unsigned char reply[sizeof(struct dsi_header) + 16];
     struct dsi_header *header = (struct dsi_header *)reply;
     uint32_t wire32;
-    uint64_t wire64;
+    static const unsigned char wire64[] = {
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08
+    };
     uint32_t written32 = 99;
     uint64_t written64 = 99;
     struct afp_extattr_info xattr_info;
@@ -47,8 +39,7 @@ int main(int argc, char **argv)
     memcpy(reply + sizeof(reply) - sizeof(wire32), &wire32, sizeof(wire32));
     CHECK(afp_write_reply(NULL, (char *)reply, sizeof(reply), &written32) == 0);
     CHECK(written32 == 1234);
-    wire64 = host_to_network64(UINT64_C(0x0102030405060708));
-    memcpy(reply + sizeof(reply) - sizeof(wire64), &wire64, sizeof(wire64));
+    memcpy(reply + sizeof(reply) - sizeof(wire64), wire64, sizeof(wire64));
     CHECK(afp_writeext_reply(NULL, (char *)reply, sizeof(reply), &written64) == 0);
     CHECK(written64 == UINT64_C(0x0102030405060708));
     header->return_code.error_code = 1;


### PR DESCRIPTION
Make the client portable to SunOS-family systems by linking libsocket, exposing platform extensions, detecting the iconv input type, and avoiding assumptions about pthread_t and byte-order macros.

Configure runtime library paths and OmniOS pkgsrc search paths, tighten explicit memory-clearing feature checks, and add CI coverage for OmniOS, OpenIndiana, and Solaris 11 that builds, tests, installs, and smoke-tests afpcmd.