### PR TITLE
verify AFP server signatures before session reuse

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,12 +1,6 @@
 Netatalk Client Improvements
 =====================
 
-FUSE client
------------
-
-* do correct address/signature matching; right now we don't actually use
-  the signature.
-
 AFP 3.x
 -------
 

--- a/cmdline/cmdline_afp.c
+++ b/cmdline/cmdline_afp.c
@@ -232,6 +232,12 @@ static int is_recoverable_session_error(int ret)
     return afp_sl_recovery_for_error(ret) != AFP_SL_RECOVERY_NONE;
 }
 
+static void report_reconnect_identity_failure(void)
+{
+    printf("Reconnect refused: AFP server identity could not be verified "
+           "(ServerSignature changed or is unavailable).\n");
+}
+
 static int recover_session(int restore_volume, int restore_dir)
 {
     char mesg[CMDLINE_ERROR_LEN];
@@ -275,15 +281,32 @@ static int recover_session(int restore_volume, int restore_dir)
 
     resume_url = reconnect_url;
     cmdline_secure_clear(resume_url.password, sizeof(resume_url.password));
-
     /*
      * Prefer resuming the daemon's existing AFP session.  This mirrors the
      * manual recovery path of detaching to the volume list, and avoids tearing
      * down a server connection that may still be usable after an idle timeout.
      */
-    if (afp_sl_resume(&resume_url, uam_mask, &new_server_id, mesg) != 0
-            && afp_sl_connect(&reconnect_url, uam_mask, &new_server_id, mesg) != 0) {
-        return -1;
+    ret = afp_sl_resume(&resume_url, uam_mask, &new_server_id, mesg);
+
+    if (ret != 0) {
+        /* A signature mismatch means the daemon found the old session but
+         * refused to reuse it.  Do not silently turn that into a fresh login
+         * to a different AFP server. */
+        if (ret == -EPROTO) {
+            report_reconnect_identity_failure();
+            return -1;
+        }
+
+        ret = afp_sl_connect(&reconnect_url, uam_mask, &new_server_id,
+                             mesg);
+
+        if (ret != 0) {
+            if (ret == -EPROTO) {
+                report_reconnect_identity_failure();
+            }
+
+            return -1;
+        }
     }
 
     if ((restore_volume || had_volume) && saved_volume[0] != '\0') {

--- a/daemon/commands.c
+++ b/daemon/commands.c
@@ -17,6 +17,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 #include <sys/un.h>
 #include <time.h>
 #include <unistd.h>
@@ -1986,14 +1987,6 @@ done:
     return 0;
 }
 
-static int server_name_matches_url(struct afp_server *server,
-                                   const struct afpc_url *url)
-{
-    return strcmp(server->server_name_utf8, url->servername) == 0
-           || strcmp(server->server_name, url->servername) == 0
-           || strcmp(server->server_name_printable, url->servername) == 0;
-}
-
 static int server_address_matches(struct afp_server *server,
                                   struct addrinfo *address)
 {
@@ -2010,28 +2003,6 @@ static int server_address_matches(struct afp_server *server,
     }
 
     return 0;
-}
-
-static int server_auth_matches_resume(struct afp_server *server,
-                                      const struct afpc_url *url,
-                                      unsigned int uam_mask)
-{
-    /*
-     * Resume is not AFP reauthentication. A password-less resume proves only
-     * that the caller can access this daemon's existing session state; it may
-     * omit username/UAM and match by host when exactly one live session exists.
-     */
-    if (url->username[0] != '\0'
-            && strcmp(server->username, url->username) != 0) {
-        return 0;
-    }
-
-    if (uam_mask != 0 && server->using_uam != 0
-            && (server->using_uam & uam_mask) == 0) {
-        return 0;
-    }
-
-    return 1;
 }
 
 static int server_auth_matches_reconnect(struct afp_server *server,
@@ -2055,6 +2026,7 @@ static struct afp_server *find_resumable_server_hold(void *priv,
     struct afp_server *match = NULL;
     struct addrinfo *address = NULL;
     int matches = 0;
+    int invalid_identity = 0;
 
     if (error) {
         *error = ENOTCONN;
@@ -2068,12 +2040,25 @@ static struct afp_server *find_resumable_server_hold(void *priv,
             continue;
         }
 
-        if (!server_name_matches_url(s, url)
-                && !server_address_matches(s, address)) {
+        /* A server name is only a resolver input, not an identity.  A live
+         * session may be reused only for its currently resolved endpoint. */
+        if (!server_address_matches(s, address)) {
             continue;
         }
 
-        if (!server_auth_matches_resume(s, url, uam_mask)) {
+        /* Resume is not AFP reauthentication. A password-less resume proves
+         * only that the caller can access this daemon's existing session
+         * state; it may omit username/UAM and match by host when exactly one
+         * live session exists. */
+        if ((url->username[0] != '\0'
+                && strcmp(s->username, url->username) != 0)
+                || (uam_mask != 0 && s->using_uam != 0
+                    && (s->using_uam & uam_mask) == 0)) {
+            continue;
+        }
+
+        if (!afp_server_has_valid_signature(s)) {
+            invalid_identity = 1;
             continue;
         }
 
@@ -2090,8 +2075,9 @@ static struct afp_server *find_resumable_server_hold(void *priv,
     } else {
         match = NULL;
 
-        if (error && matches > 1) {
-            *error = EEXIST;
+        if (error) {
+            *error = matches > 1 ? EEXIST
+                     : invalid_identity ? EPROTO : ENOTCONN;
         }
     }
 
@@ -2105,17 +2091,57 @@ static struct afp_server *find_resumable_server_hold(void *priv,
 }
 
 static struct afp_server *find_disconnected_server_hold(void *priv,
-        const struct afpc_url *url, unsigned int uam_mask, int *error)
+        const struct afpc_url *url, unsigned int uam_mask,
+        struct addrinfo **resolved_address, int *error)
 {
     struct afp_server *match = NULL;
     struct addrinfo *address = NULL;
+    char signature[AFP_SIGNATURE_LEN];
     int matches = 0;
+    int possible = 0;
+    int identity_mismatch = 0;
 
     if (error) {
         *error = ENOTCONN;
     }
 
+    if (resolved_address) {
+        *resolved_address = NULL;
+    }
+
     address = afp_get_address(priv, url->servername, url->port);
+
+    if (!address) {
+        goto done;
+    }
+
+    afp_lock_server_list();
+
+    /* Do not turn every new connect into a GetStatus probe.  Authentication
+     * narrows the search; the signature below is the actual identity match
+     * and permits a server to have moved to a new address. */
+    for (struct afp_server *s = get_server_base(); s; s = s->next) {
+        if (s->connect_state == SERVER_STATE_DISCONNECTED && s->fd < 0
+                && server_auth_matches_reconnect(s, url, uam_mask)) {
+            possible = 1;
+            break;
+        }
+    }
+
+    afp_unlock_server_list();
+
+    if (!possible) {
+        goto done;
+    }
+
+    if (afp_server_probe_signature(address, signature) != 0) {
+        if (error && errno == EPROTO) {
+            *error = EPROTO;
+        }
+
+        goto done;
+    }
+
     afp_lock_server_list();
 
     for (struct afp_server *s = get_server_base(); s; s = s->next) {
@@ -2123,12 +2149,22 @@ static struct afp_server *find_disconnected_server_hold(void *priv,
             continue;
         }
 
-        if (!server_name_matches_url(s, url)
-                && !server_address_matches(s, address)) {
+        if (!server_auth_matches_reconnect(s, url, uam_mask)) {
             continue;
         }
 
-        if (!server_auth_matches_reconnect(s, url, uam_mask)) {
+        if (!afp_server_has_valid_signature(s)
+                || memcmp(s->signature, signature, sizeof(signature)) != 0) {
+            /* This only associates a reconnect request with a saved session
+             * after the signature probe. AFP's advertised name is not a URL
+             * authority, so it cannot be used here. */
+            if (server_address_matches(s, address)
+                    || (s->requested_port == url->port
+                        && strcasecmp(s->requested_hostname,
+                                      url->servername) == 0)) {
+                identity_mismatch = 1;
+            }
+
             continue;
         }
 
@@ -2142,15 +2178,22 @@ static struct afp_server *find_disconnected_server_hold(void *priv,
 
     if (matches == 1) {
         afp_server_hold(match);
+
+        if (resolved_address) {
+            *resolved_address = address;
+            address = NULL;
+        }
     } else {
         match = NULL;
 
-        if (error && matches > 1) {
-            *error = EEXIST;
+        if (error) {
+            *error = matches > 1 ? EEXIST
+                     : identity_mismatch ? EPROTO : ENOTCONN;
         }
     }
 
     afp_unlock_server_list();
+done:
 
     if (address) {
         freeaddrinfo(address);
@@ -2160,12 +2203,13 @@ static struct afp_server *find_disconnected_server_hold(void *priv,
 }
 
 static int reconnect_disconnected_server(void *priv, struct afp_server *server,
-        const struct afpc_url *url)
+        const struct afpc_url *url, struct addrinfo *address)
 {
     char mesg[MAX_ERROR_LEN];
     unsigned int len = 0;
     int ret;
     memset(mesg, 0, sizeof(mesg));
+    afp_server_replace_address(server, address);
     strlcpy(server->password, url->password, sizeof(server->password));
     errno = 0;
     ret = afp_server_reconnect(server, mesg, &len, sizeof(mesg));
@@ -2189,6 +2233,7 @@ static int process_connect(struct daemon_client * c)
     int error = 0;
     char loginmesg_copy[AFP_LOGINMESG_LEN];
     struct afp_server *server_copy = NULL;
+    struct addrinfo *reconnect_address = NULL;
 
     if ((size_t)(c->completed_packet_size) < sizeof(struct
             afpsl_ipc_connect_request)) {
@@ -2234,14 +2279,17 @@ static int process_connect(struct daemon_client * c)
         goto done;
     }
 
-    s = find_disconnected_server_hold(c, &req->url, req->uam_mask, &error);
+    s = find_disconnected_server_hold(c, &req->url, req->uam_mask,
+                                      &reconnect_address, &error);
 
     if (s) {
         log_for_client((void *) c, AFPFSD, LOG_INFO,
                        "Recovering disconnected session for server %s",
                        req->url.servername);
 
-        if (reconnect_disconnected_server(c, s, &req->url) == 0) {
+        if (reconnect_disconnected_server(c, s, &req->url,
+                                          reconnect_address) == 0) {
+            reconnect_address = NULL;
             response_result = AFPSL_IPC_RESULT_OK;
             server_copy = s;
             memcpy(loginmesg_copy, s->loginmesg, AFP_LOGINMESG_LEN);
@@ -2252,7 +2300,9 @@ static int process_connect(struct daemon_client * c)
         error = errno ? errno : ECONNRESET;
         afp_server_release(s);
         s = NULL;
-    } else if (error == EEXIST) {
+        reconnect_address = NULL;
+        goto error;
+    } else if (error == EEXIST || error == EPROTO) {
         goto error;
     }
 
@@ -2329,6 +2379,11 @@ error:
 
     ret = 0;
 done:
+
+    if (reconnect_address) {
+        freeaddrinfo(reconnect_address);
+    }
+
     memset(&response, 0, sizeof(response));
     /* Use copied data instead of potentially freed server pointer */
     memcpy(response.loginmesg, loginmesg_copy, AFP_LOGINMESG_LEN);

--- a/lib/afp.c
+++ b/lib/afp.c
@@ -54,6 +54,14 @@ static int afp_blank_reply(struct afp_server *server, char * buf,
 static int connect_with_timeout(int fd, const struct sockaddr *addr,
                                 socklen_t addrlen, int timeout);
 
+static void format_server_signature(const char signature[AFP_SIGNATURE_LEN],
+                                    char text[AFP_SIGNATURE_LEN * 2 + 1])
+{
+    for (size_t i = 0; i < AFP_SIGNATURE_LEN; i++) {
+        snprintf(text + (i * 2), 3, "%02x", (unsigned char)signature[i]);
+    }
+}
+
 int (*afp_replies[])(struct afp_server * server, char * buf, unsigned int len,
                      void *other) = {
     NULL, afp_byterangelock_reply, afp_blank_reply, NULL,
@@ -353,6 +361,77 @@ struct afp_server *find_server_by_address(struct addrinfo *address)
     }
 
     return NULL;
+}
+
+int afp_server_has_valid_signature(const struct afp_server *server)
+{
+    static const char zero_signature[AFP_SIGNATURE_LEN] = {0};
+    return server != NULL && memcmp(server->signature, zero_signature,
+                                    sizeof(zero_signature)) != 0;
+}
+
+int afp_server_probe_signature(struct addrinfo *address,
+                               char signature[AFP_SIGNATURE_LEN])
+{
+    struct afp_server *probe;
+    int ret;
+
+    if (!address || !signature) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    probe = afp_server_init(address);
+
+    if (!probe) {
+        errno = ENOMEM;
+        return -1;
+    }
+
+    ret = afp_server_connect(probe, 1);
+
+    if (ret == 0 && afp_server_has_valid_signature(probe)) {
+        memcpy(signature, probe->signature, AFP_SIGNATURE_LEN);
+        /* The caller retains address ownership; loop_disconnect() does not
+         * need it while removing this short-lived status connection. */
+        probe->address = NULL;
+
+        if (afp_server_remove(probe) != 0) {
+            afp_free_server(&probe);
+        }
+
+        return 0;
+    }
+
+    if (ret == 0) {
+        errno = EPROTO;
+    } else if (errno == 0) {
+        errno = ECONNRESET;
+    }
+
+    if (afp_server_remove(probe) != 0) {
+        afp_free_server(&probe);
+    }
+
+    return -1;
+}
+
+void afp_server_replace_address(struct afp_server *server,
+                                struct addrinfo *address)
+{
+    if (!server || !address) {
+        return;
+    }
+
+    if (server->address != address) {
+        if (server->address) {
+            freeaddrinfo(server->address);
+        }
+
+        server->address = address;
+    }
+
+    server->used_address = NULL;
 }
 
 void afp_server_hold(struct afp_server *s)
@@ -934,6 +1013,10 @@ int afp_server_reconnect(struct afp_server * s, char * mesg,
     int i;
     int ret = 0;
     struct afp_volume * v;
+    char expected_signature[AFP_SIGNATURE_LEN];
+    char peer_signature[AFP_SIGNATURE_LEN];
+    char expected_signature_text[AFP_SIGNATURE_LEN * 2 + 1];
+    char peer_signature_text[AFP_SIGNATURE_LEN * 2 + 1];
 
     if (!afp_server_reconnect_try_begin(s)) {
         return 1;
@@ -941,6 +1024,61 @@ int afp_server_reconnect(struct afp_server * s, char * mesg,
 
     /* Flush pending requests before reconnecting to avoid late reply confusion */
     afpc_dsi_flush_request_queue(s);
+
+    /* ServerSignature is optional in AFP, but a nonzero value is mandatory
+     * for automatic session reuse.  FPGetSrvrInfo is performed before login
+     * so a changed endpoint cannot receive the saved credentials. */
+    if (!afp_server_has_valid_signature(s)) {
+        log_for_client(NULL, AFPFSD, LOG_WARNING,
+                       "Refusing to reconnect to %s: saved AFP ServerSignature is zero or unavailable",
+                       s->server_name_printable);
+        *l += snprintf(mesg + *l, max - *l,
+                       "Refusing to resume %s without a valid server signature\n",
+                       s->server_name_printable);
+        errno = EPROTO;
+        goto error;
+    }
+
+    memcpy(expected_signature, s->signature, sizeof(expected_signature));
+    format_server_signature(expected_signature, expected_signature_text);
+    log_for_client(NULL, AFPFSD, LOG_DEBUG,
+                   "Verifying AFP ServerSignature before reconnecting to %s (expected %s)",
+                   s->server_name_printable, expected_signature_text);
+
+    /* DSIGetStatus is a one-shot connection on common AFP servers.  Probe it
+     * on a temporary socket, then open a separate socket for the AFP session. */
+    if (afp_server_probe_signature(s->address, peer_signature) != 0) {
+        log_for_client(NULL, AFPFSD, LOG_WARNING,
+                       "Could not read AFP ServerSignature while reconnecting to %s: %s",
+                       s->server_name_printable, strerror(errno));
+        *l += snprintf(mesg + *l, max - *l,
+                       "Could not verify server signature for %s\n",
+                       s->server_name_printable);
+
+        if (errno == 0) {
+            errno = ECONNRESET;
+        }
+
+        goto error;
+    }
+
+    format_server_signature(peer_signature, peer_signature_text);
+    log_for_client(NULL, AFPFSD, LOG_DEBUG,
+                   "AFP ServerSignature for %s is %s",
+                   s->server_name_printable, peer_signature_text);
+
+    if (memcmp(peer_signature, expected_signature,
+               sizeof(expected_signature)) != 0) {
+        log_for_client(NULL, AFPFSD, LOG_WARNING,
+                       "Refusing to reconnect to %s: AFP ServerSignature mismatch (expected %s, got %s)",
+                       s->server_name_printable, expected_signature_text,
+                       peer_signature_text);
+        *l += snprintf(mesg + *l, max - *l,
+                       "Refusing to resume %s: server signature changed or is invalid\n",
+                       s->server_name_printable);
+        errno = EPROTO;
+        goto error;
+    }
 
     if (afp_server_connect(s, 0))  {
         *l += snprintf(mesg, max - *l, "Error resuming connection to %s\n",

--- a/lib/afp_internal.h
+++ b/lib/afp_internal.h
@@ -168,6 +168,10 @@ struct afp_server {
     char server_name[AFP_SERVER_NAME_LEN];
     char server_name_utf8[AFP_SERVER_NAME_UTF8_LEN];
     char server_name_printable[AFP_SERVER_NAME_UTF8_LEN];
+    /* Authority supplied by the client when this session was created.  This
+     * is distinct from the name advertised by FPGetSrvrInfo. */
+    char requested_hostname[AFP_SERVER_NAME_UTF8_LEN];
+    int requested_port;
 
     char machine_type[17];
     char icon[AFP_SERVER_ICON_LEN];
@@ -393,6 +397,20 @@ int afp_server_destroy(struct afp_server *s) ;
 int afp_server_reconnect(struct afp_server * s, char * mesg,
                          unsigned int *l, unsigned int max);
 int afp_server_connect(struct afp_server *s, int full);
+/* A server identity is usable for session reuse only when FPGetSrvrInfo
+ * supplies a nonzero 16-byte signature.  Some deployed servers omit
+ * kSrvrSig despite supplying a configured signature. */
+int afp_server_has_valid_signature(const struct afp_server *server);
+
+/* Query a peer's FPGetSrvrInfo identity without logging in.  The caller
+ * retains ownership of address. */
+int afp_server_probe_signature(struct addrinfo *address,
+                               char signature[AFP_SIGNATURE_LEN]);
+
+/* Replace the address list used for future connections.  address ownership
+ * transfers to server. */
+void afp_server_replace_address(struct afp_server *server,
+                                struct addrinfo *address);
 
 struct afp_server *afp_server_complete_connection(
     void *priv,

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -109,6 +109,13 @@ struct afp_server *afp_server_full_connect(void * priv,
         goto error;
     }
 
+    /* AFP's advertised server name is not the authority the client used to
+     * reach it.  Keep that authority so reconnect can recognize a changed
+     * DNS endpoint without confusing it with an unrelated saved session. */
+    strlcpy(s->requested_hostname, req->url.servername,
+            sizeof(s->requested_hostname));
+    s->requested_port = req->url.port;
+
     if ((ret = afp_server_connect(s, 0)) != 0) {
         int connect_error = -ret;
         log_for_client(priv, AFPFSD, LOG_INFO,

--- a/lib/dsi.c
+++ b/lib/dsi.c
@@ -284,6 +284,14 @@ int afpc_dsi_send_with_reply(struct afp_server *server, char *msg, int size,
         memset(mesg, 0, sizeof(mesg));
 
         if (afp_server_reconnect(server, mesg, &l, MAX_ERROR_LEN) != 0) {
+            if (mesg[0] != '\0') {
+                log_for_client(NULL, AFPFSD, LOG_WARNING, "%s", mesg);
+            } else {
+                log_for_client(NULL, AFPFSD, LOG_WARNING,
+                               "Could not reconnect to %s",
+                               server->server_name_printable);
+            }
+
             return -EIO;
         }
     }

--- a/test/test_metadata.c
+++ b/test/test_metadata.c
@@ -120,6 +120,7 @@ int main(int argc, char **argv)
     CHECK(afp_sl_recovery_for_error(-ECONNREFUSED)
           == AFP_SL_RECOVERY_RECONNECT);
     CHECK(afp_sl_recovery_for_error(-ESTALE) == AFP_SL_RECOVERY_REATTACH);
+    CHECK(afp_sl_recovery_for_error(-EPROTO) == AFP_SL_RECOVERY_NONE);
     CHECK(afp_sl_recovery_for_error(-ENOATTR) == AFP_SL_RECOVERY_NONE);
     CHECK(mkdtemp(temporary) != NULL);
     CHECK(join_suffix(file, sizeof(file), temporary, "/file") == 0);

--- a/test/test_protocol_replies.c
+++ b/test/test_protocol_replies.c
@@ -27,6 +27,7 @@ int main(int argc, char **argv)
     uint32_t written32 = 99;
     uint64_t written64 = 99;
     struct afp_extattr_info xattr_info;
+    struct afp_server server;
     struct {
         struct dsi_header header __attribute__((__packed__));
         uint16_t bitmap;
@@ -34,6 +35,14 @@ int main(int argc, char **argv)
         char data[4];
     } __attribute__((__packed__)) xattr_reply;
     test_tap_init(argc, argv);
+    memset(&server, 0, sizeof(server));
+    CHECK(!afp_server_has_valid_signature(&server));
+    server.flags = kSrvrSig;
+    CHECK(!afp_server_has_valid_signature(&server));
+    server.signature[0] = 1;
+    CHECK(afp_server_has_valid_signature(&server));
+    server.flags = 0;
+    CHECK(afp_server_has_valid_signature(&server));
     memset(reply, 0, sizeof(reply));
     wire32 = htonl(1234);
     memcpy(reply + sizeof(reply) - sizeof(wire32), &wire32, sizeof(wire32));


### PR DESCRIPTION
Require a valid ServerSignature and compare it via a status probe before resuming a live or disconnected AFP session. Refuse identity mismatches, allow verified address changes, and surface reconnect verification failures to clients.

The afpcmd client gets this error when the signature doesn't match.

```
Reconnect refused: AFP server identity could not be verified (ServerSignature changed or is unavailable).
```

Daemon logs for either client throws messages like this.

```
Identified server debfork as Netatalk
AFP ServerSignature for debfork is 766969335a4f31535432504977545830
Refusing to reconnect to debfork: AFP ServerSignature mismatch (expected 766969335a4f31535432504977545831, got 766969335a4f31535432504977545830)
Refusing to resume debfork: server signature changed or is invalid
```