### PR TITLE
libafpclient: make pathname encoding volume-specific

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,23 +1,17 @@
 Netatalk Client Improvements
-=====================
+============================
 
-AFP 3.x
--------
+Protocol features
+-----------------
 
 * ACL support
-
-AFP 2.x
--------
-
-* use getsrvrinfo to get connection IP address to make room for AT
 * connection recovery
   * open files
   * locked files
 * desktop database support
-* UTF8 flag is now server-specific, but it should be volume-specific
 
-Authentitcation
----------------
+Authentication
+--------------
 
 * ClientKRB
 * reconnection

--- a/lib/afp.c
+++ b/lib/afp.c
@@ -709,7 +709,6 @@ struct afp_server *afp_server_init(struct addrinfo * address)
 
     memset((void *) s, 0, sizeof(*s));
     s->exit_flag = 0;
-    s->path_encoding = kFPUTF8Name; /* This is a default */
     s->dsi_default_timeout = DSI_DEFAULT_TIMEOUT;
     s->next = NULL;
     s->bufsize = 128 * 1024;
@@ -966,13 +965,7 @@ int afp_connect_volume(struct afp_volume * volume, struct afp_server * server,
         new_encoding = kFPLongName;
     }
 
-    if (new_encoding != server->path_encoding) {
-        *l += snprintf(mesg, max - *l,
-                       "Volume %s changes the server's encoding\n",
-                       volume->volume_name_printable);
-    }
-
-    server->path_encoding = new_encoding;
+    volume->path_encoding = new_encoding;
 
     if (volume->signature != AFP_VOL_FIXED) {
         *l += snprintf(mesg, max - *l,

--- a/lib/afp_internal.h
+++ b/lib/afp_internal.h
@@ -98,6 +98,8 @@ struct afp_volume {
     struct afp_server *server;
     char volume_name[AFP_VOLUME_NAME_UTF8_LEN];
     char volume_name_printable[AFP_VOLUME_NAME_UTF8_LEN];
+    /* AFP pathname format is advertised by each volume, not the server. */
+    unsigned char path_encoding;
     unsigned short dtrefnum;
     char volpassword[AFP_VOLPASS_LEN];
     unsigned int extra_flags; /* This is a Netatalk Client specific field */
@@ -223,7 +225,6 @@ struct afp_server {
 
 
     char loginmesg[200];
-    char path_encoding;
 
     /* This is the data for the incoming buffer */
     char *incoming_buffer;

--- a/lib/lowlevel.c
+++ b/lib/lowlevel.c
@@ -537,7 +537,7 @@ int ll_readdir(struct afp_volume * volume, const char *path,
     char converted_name[AFPC_MAX_NAME_BYTES];
     unsigned int dirid;
 
-    if (invalid_filename(volume->server, path)) {
+    if (invalid_filename(volume, path)) {
         return -ENAMETOOLONG;
     }
 
@@ -650,7 +650,7 @@ int ll_readdir(struct afp_volume * volume, const char *path,
     for (p = filebase; p; p = p->next) {
         /* Convert all the names back to precomposed */
         convert_path_to_unix(
-            volume->server->path_encoding,
+            volume->path_encoding,
             converted_name, p->name, sizeof(converted_name));
         snprintf(p->name, sizeof(p->name), "%s", converted_name);
         p->name[sizeof(p->name) - 1U] = '\0';
@@ -685,7 +685,7 @@ int ll_getattr(struct afp_volume * volume, const char *path, struct stat *stbuf,
     memset(stbuf, 0, sizeof(struct stat));
 
     if ((volume->server) &&
-            (invalid_filename(volume->server, path))) {
+            (invalid_filename(volume, path))) {
         return -ENAMETOOLONG;
     }
 

--- a/lib/midlevel.c
+++ b/lib/midlevel.c
@@ -288,14 +288,14 @@ int ml_open(struct afp_volume * volume, const char *path, int flags,
     int ret;
     unsigned int dirid;
     char *converted_path;
-    ret = convert_path_to_afp_alloc(volume->server->path_encoding, path,
+    ret = convert_path_to_afp_alloc(volume->path_encoding, path,
                                     &converted_path);
 
     if (ret) {
         return ret;
     }
 
-    if (invalid_filename(volume->server, converted_path)) {
+    if (invalid_filename(volume, converted_path)) {
         free(converted_path);
         return -ENAMETOOLONG;
     }
@@ -355,7 +355,7 @@ int ml_creat(struct afp_volume * volume, const char *path, mode_t mode)
     unsigned int dirid;
     int rc;
     char *converted_path;
-    ret = convert_path_to_afp_alloc(volume->server->path_encoding, path,
+    ret = convert_path_to_afp_alloc(volume->path_encoding, path,
                                     &converted_path);
 
     if (ret) {
@@ -379,7 +379,7 @@ int ml_creat(struct afp_volume * volume, const char *path, mode_t mode)
         return 0;
     }
 
-    if (invalid_filename(volume->server, converted_path)) {
+    if (invalid_filename(volume, converted_path)) {
         free(converted_path);
         return -ENAMETOOLONG;
     }
@@ -443,7 +443,7 @@ int ml_readdir(struct afp_volume * volume,
 {
     int ret = 0;
     char *converted_path;
-    ret = convert_path_to_afp_alloc(volume->server->path_encoding, path,
+    ret = convert_path_to_afp_alloc(volume->path_encoding, path,
                                     &converted_path);
 
     if (ret) {
@@ -490,7 +490,7 @@ int ml_read(struct afp_volume * volume, const char *path,
     *eof = 0;
 
     if (path) {
-        ret = convert_path_to_afp_alloc(volume->server->path_encoding, path,
+        ret = convert_path_to_afp_alloc(volume->path_encoding, path,
                                         &converted_path);
 
         if (ret) {
@@ -546,7 +546,7 @@ int ml_chmod(struct afp_volume * vol, const char * path, mode_t mode)
     uid_t uid;
     gid_t gid;
 
-    if (invalid_filename(vol->server, path)) {
+    if (invalid_filename(vol, path)) {
         return -ENAMETOOLONG;
     }
 
@@ -554,7 +554,7 @@ int ml_chmod(struct afp_volume * vol, const char * path, mode_t mode)
         return -EACCES;
     }
 
-    ret = convert_path_to_afp_alloc(vol->server->path_encoding, path,
+    ret = convert_path_to_afp_alloc(vol->path_encoding, path,
                                     &converted_path);
 
     if (ret) {
@@ -639,7 +639,7 @@ int ml_unlink(struct afp_volume * vol, const char *path)
     unsigned int dirid;
     char basename[AFPC_MAX_NAME_BYTES];
     char *converted_path;
-    ret = convert_path_to_afp_alloc(vol->server->path_encoding, path,
+    ret = convert_path_to_afp_alloc(vol->path_encoding, path,
                                     &converted_path);
 
     if (ret) {
@@ -670,7 +670,7 @@ int ml_unlink(struct afp_volume * vol, const char *path)
         return -EISDIR;
     }
 
-    if (invalid_filename(vol->server, converted_path)) {
+    if (invalid_filename(vol, converted_path)) {
         free(converted_path);
         return -ENAMETOOLONG;
     }
@@ -721,14 +721,14 @@ int ml_mkdir(struct afp_volume * vol, const char * path, mode_t mode)
     char basename[AFPC_MAX_NAME_BYTES];
     char *converted_path;
     unsigned int dirid;
-    ret = convert_path_to_afp_alloc(vol->server->path_encoding, path,
+    ret = convert_path_to_afp_alloc(vol->path_encoding, path,
                                     &converted_path);
 
     if (ret) {
         return ret;
     }
 
-    if (invalid_filename(vol->server, path)) {
+    if (invalid_filename(vol, path)) {
         free(converted_path);
         return -ENAMETOOLONG;
     }
@@ -796,14 +796,14 @@ int ml_close(struct afp_volume * volume, const char * path,
     char *converted_path = NULL;
 
     if (path) {
-        ret = convert_path_to_afp_alloc(volume->server->path_encoding, path,
+        ret = convert_path_to_afp_alloc(volume->path_encoding, path,
                                         &converted_path);
 
         if (ret) {
             return ret;
         }
 
-        if (invalid_filename(volume->server, converted_path)) {
+        if (invalid_filename(volume, converted_path)) {
             free(converted_path);
             return -ENAMETOOLONG;
         }
@@ -849,7 +849,7 @@ int ml_getattr(struct afp_volume * volume, const char *path, struct stat *stbuf)
     char *converted_path;
     int ret;
     memset(stbuf, 0, sizeof(struct stat));
-    ret = convert_path_to_afp_alloc(volume->server->path_encoding, path,
+    ret = convert_path_to_afp_alloc(volume->path_encoding, path,
                                     &converted_path);
 
     if (ret) {
@@ -898,7 +898,7 @@ int ml_write(struct afp_volume * volume, const char * path,
     }
 
     if (path) {
-        ret = convert_path_to_afp_alloc(volume->server->path_encoding, path,
+        ret = convert_path_to_afp_alloc(volume->path_encoding, path,
                                         &converted_path);
 
         if (ret) {
@@ -978,7 +978,7 @@ int ml_readlink(struct afp_volume * vol, const char * path,
     buffer.data = link_path;
     buffer.maxsize = size;
     buffer.size = 0;
-    ret = convert_path_to_afp_alloc(vol->server->path_encoding, path,
+    ret = convert_path_to_afp_alloc(vol->path_encoding, path,
                                     &converted_path);
 
     if (ret) {
@@ -1073,7 +1073,7 @@ int ml_readlink(struct afp_volume * vol, const char * path,
 
     remove_opened_fork(vol, &fp);
     /* Convert the name back precomposed UTF8 */
-    convert_path_to_unix(vol->server->path_encoding,
+    convert_path_to_unix(vol->path_encoding,
                          buf, link_path, (int)size);
     free(converted_path);
     free(link_path);
@@ -1094,11 +1094,11 @@ int ml_rmdir(struct afp_volume * vol, const char *path)
     char basename[AFPC_MAX_NAME_BYTES];
     char *converted_path;
 
-    if (invalid_filename(vol->server, path)) {
+    if (invalid_filename(vol, path)) {
         return -ENAMETOOLONG;
     }
 
-    ret = convert_path_to_afp_alloc(vol->server->path_encoding, path,
+    ret = convert_path_to_afp_alloc(vol->path_encoding, path,
                                     &converted_path);
 
     if (ret) {
@@ -1177,14 +1177,14 @@ int ml_chown(struct afp_volume * vol, const char * path,
     unsigned int dirid;
     char basename[AFPC_MAX_NAME_BYTES];
     char *converted_path;
-    ret = convert_path_to_afp_alloc(vol->server->path_encoding, path,
+    ret = convert_path_to_afp_alloc(vol->path_encoding, path,
                                     &converted_path);
 
     if (ret) {
         return ret;
     }
 
-    if (invalid_filename(vol->server, converted_path)) {
+    if (invalid_filename(vol, converted_path)) {
         free(converted_path);
         return -ENAMETOOLONG;
     }
@@ -1269,7 +1269,7 @@ int ml_truncate(struct afp_volume * vol, const char * path, off_t offset)
     char *converted_path;
     struct afp_file_info *fp;
     int flags;
-    ret = convert_path_to_afp_alloc(vol->server->path_encoding, path,
+    ret = convert_path_to_afp_alloc(vol->path_encoding, path,
                                     &converted_path);
 
     if (ret) {
@@ -1280,7 +1280,7 @@ int ml_truncate(struct afp_volume * vol, const char * path, off_t offset)
        (and not afp_openfork).  Note the fake afp_file_info used
        just to grab this forkid. */
 
-    if (invalid_filename(vol->server, converted_path)) {
+    if (invalid_filename(vol, converted_path)) {
         free(converted_path);
         return -ENAMETOOLONG;
     }
@@ -1347,11 +1347,11 @@ int ml_utime(struct afp_volume * vol, const char * path,
     memset(&fp, 0, sizeof(struct afp_file_info));
     fp.modification_date = timebuf->modtime;
 
-    if (invalid_filename(vol->server, path)) {
+    if (invalid_filename(vol, path)) {
         return -ENAMETOOLONG;
     }
 
-    ret = convert_path_to_afp_alloc(vol->server->path_encoding, path,
+    ret = convert_path_to_afp_alloc(vol->path_encoding, path,
                                     &converted_path);
 
     if (ret) {
@@ -1424,14 +1424,14 @@ int ml_symlink(struct afp_volume *vol, const char * path1, const char * path2)
     }
 
     /* Yes, you can create symlinks for AFP >=30.  Tested with 10.3.2 */
-    ret = convert_path_to_afp_alloc(vol->server->path_encoding, path1,
+    ret = convert_path_to_afp_alloc(vol->path_encoding, path1,
                                     &converted_path1);
 
     if (ret) {
         return ret;
     }
 
-    ret = convert_path_to_afp_alloc(vol->server->path_encoding, path2,
+    ret = convert_path_to_afp_alloc(vol->path_encoding, path2,
                                     &converted_path2);
 
     if (ret) {
@@ -1648,14 +1648,14 @@ int ml_rename(struct afp_volume * vol,
     char *converted_path_from;
     char *converted_path_to;
     unsigned int dirid_from, dirid_to;
-    ret = convert_path_to_afp_alloc(vol->server->path_encoding, path_from,
+    ret = convert_path_to_afp_alloc(vol->path_encoding, path_from,
                                     &converted_path_from);
 
     if (ret) {
         return ret;
     }
 
-    ret = convert_path_to_afp_alloc(vol->server->path_encoding, path_to,
+    ret = convert_path_to_afp_alloc(vol->path_encoding, path_to,
                                     &converted_path_to);
 
     if (ret) {
@@ -1840,14 +1840,14 @@ int ml_exchange(struct afp_volume * vol,
         return -ENOSYS;
     }
 
-    ret = convert_path_to_afp_alloc(vol->server->path_encoding, path_from,
+    ret = convert_path_to_afp_alloc(vol->path_encoding, path_from,
                                     &converted_path_from);
 
     if (ret) {
         return ret;
     }
 
-    ret = convert_path_to_afp_alloc(vol->server->path_encoding, path_to,
+    ret = convert_path_to_afp_alloc(vol->path_encoding, path_to,
                                     &converted_path_to);
 
     if (ret) {
@@ -1965,14 +1965,14 @@ static int open_appledouble_meta(struct afp_volume *volume, const char *path,
         return -EINVAL;
     }
 
-    ret = convert_path_to_afp_alloc(volume->server->path_encoding, path,
+    ret = convert_path_to_afp_alloc(volume->path_encoding, path,
                                     &converted_path);
 
     if (ret) {
         return ret;
     }
 
-    if (invalid_filename(volume->server, converted_path)) {
+    if (invalid_filename(volume, converted_path)) {
         free(converted_path);
         return -ENAMETOOLONG;
     }
@@ -2069,7 +2069,7 @@ int ml_getresourcefork(struct afp_volume * volume, const char *path,
         return -EINVAL;
     }
 
-    ret = convert_path_to_afp_alloc(volume->server->path_encoding, path,
+    ret = convert_path_to_afp_alloc(volume->path_encoding, path,
                                     &converted_path);
 
     if (ret) {

--- a/lib/proto_attr.c
+++ b/lib/proto_attr.c
@@ -39,7 +39,7 @@ int afp_listextattr(struct afp_volume * volume,
         } __attribute__((__packed__)) *request_packet;
         struct afp_server * server = volume->server;
         unsigned int len = sizeof(*request_packet) + sizeof_path_header(
-                               server) + strlen(pathname);
+                               volume) + strlen(pathname);
         char *pathptr;
         char *msg = malloc(len);
 
@@ -64,8 +64,8 @@ int afp_listextattr(struct afp_volume * volume,
         request_packet->startindex = 0;
         request_packet->bitmap = htons(bitmap);
         request_packet->maxreplysize = htonl(info->maxsize);
-        copy_path(server, pathptr, pathname, strlen(pathname));
-        unixpath_to_afppath(server, pathptr);
+        copy_path(volume, pathptr, pathname, strlen(pathname));
+        unixpath_to_afppath(volume, pathptr);
         ret = afpc_dsi_send(server, (char *) request_packet, len, DSI_DEFAULT_TIMEOUT,
                             afpListExtAttrs, (void *) info);
         free(msg);
@@ -213,7 +213,7 @@ int afp_getextattr(struct afp_volume * volume, unsigned int dirid,
             uint32_t maxreplysize;
         } __attribute__((__packed__)) *request_packet;
         struct afp_server * server = volume->server;
-        unsigned int pathlen = sizeof_path_header(server) + strlen(pathname);
+        unsigned int pathlen = sizeof_path_header(volume) + strlen(pathname);
         unsigned int path_offset = sizeof(*request_packet);
         unsigned int padding = (path_offset + pathlen) & 1;
         unsigned int len = sizeof(*request_packet) + pathlen + padding + 2 + namelen;
@@ -243,8 +243,8 @@ int afp_getextattr(struct afp_volume * volume, unsigned int dirid,
         request_packet->reqcount = UINT64_MAX;
         request_packet->maxreplysize = htonl(replysize);
         /* Copy path */
-        copy_path(server, p, pathname, strlen(pathname));
-        unixpath_to_afppath(server, p);
+        copy_path(volume, p, pathname, strlen(pathname));
+        unixpath_to_afppath(volume, p);
         p2 = p + pathlen;
 
         /* Pad the following EA name field to an even packet offset. */
@@ -281,7 +281,7 @@ int afp_setextattr(struct afp_volume * volume, unsigned int dirid,
             uint64_t offset ;
         } __attribute__((__packed__)) *request_packet;
         struct afp_server * server = volume->server;
-        unsigned int pathlen = sizeof_path_header(server) + strlen(pathname);
+        unsigned int pathlen = sizeof_path_header(volume) + strlen(pathname);
         unsigned int path_offset = sizeof(*request_packet);
         unsigned int padding = (path_offset + pathlen) & 1;
         unsigned int len = sizeof(*request_packet) + pathlen + padding + 2 + namelen +
@@ -309,8 +309,8 @@ int afp_setextattr(struct afp_volume * volume, unsigned int dirid,
         request_packet->bitmap = htons(bitmap);
         request_packet->offset = hton64(offset);
         /* Copy path */
-        copy_path(server, p, pathname, strlen(pathname));
-        unixpath_to_afppath(server, p);
+        copy_path(volume, p, pathname, strlen(pathname));
+        unixpath_to_afppath(volume, p);
         p2 = p + pathlen;
 
         /* Pad the following EA name field to an even packet offset. */
@@ -355,7 +355,7 @@ int afp_removeextattr(struct afp_volume * volume, unsigned int dirid,
             uint16_t bitmap;
         } __attribute__((__packed__)) *request_packet;
         struct afp_server * server = volume->server;
-        unsigned int pathlen = sizeof_path_header(server) + strlen(pathname);
+        unsigned int pathlen = sizeof_path_header(volume) + strlen(pathname);
         unsigned int path_offset = sizeof(*request_packet);
         unsigned int padding = (path_offset + pathlen) & 1;
         unsigned int len = sizeof(*request_packet) + pathlen + padding + 2 + namelen;
@@ -378,8 +378,8 @@ int afp_removeextattr(struct afp_volume * volume, unsigned int dirid,
         request_packet->dirid = htonl(dirid);
         request_packet->bitmap = htons(bitmap);
         /* Copy path */
-        copy_path(server, p, pathname, strlen(pathname));
-        unixpath_to_afppath(server, p);
+        copy_path(volume, p, pathname, strlen(pathname));
+        unixpath_to_afppath(volume, p);
         p2 = p + pathlen;
 
         /* Pad the following EA name field to an even packet offset. */

--- a/lib/proto_desktop.c
+++ b/lib/proto_desktop.c
@@ -81,7 +81,7 @@ int afp_addcomment(struct afp_volume *volume, unsigned int did,
         uint32_t dirid ;
     } __attribute__((__packed__)) * request_packet;
     unsigned int len = sizeof(*request_packet) +
-                       sizeof_path_header(volume->server) + strlen(pathname)
+                       sizeof_path_header(volume) + strlen(pathname)
                        + strlen(comment) +1;
     char *msg, *p;
     int rc;
@@ -96,9 +96,9 @@ int afp_addcomment(struct afp_volume *volume, unsigned int did,
     request_packet->pad = 0;
     request_packet->dtrefnum = htons(volume->dtrefnum);
     request_packet->dirid = htonl(did);
-    copy_path(volume->server, p, pathname, strlen(pathname));
-    unixpath_to_afppath(volume->server, p);
-    p = msg + sizeof(*request_packet) + sizeof_path_header(volume->server) + strlen(
+    copy_path(volume, p, pathname, strlen(pathname));
+    unixpath_to_afppath(volume, p);
+    p = msg + sizeof(*request_packet) + sizeof_path_header(volume) + strlen(
             pathname);
 
     if (((uintptr_t) p) & 0x1) {
@@ -126,7 +126,7 @@ int afp_getcomment(struct afp_volume *volume, unsigned int did,
         uint32_t dirid ;
     } __attribute__((__packed__)) * request_packet;
     unsigned int len = sizeof(*request_packet) +
-                       sizeof_path_header(volume->server) + strlen(pathname);
+                       sizeof_path_header(volume) + strlen(pathname);
     char *msg, *path;
     int rc;
     msg = malloc(len);
@@ -139,8 +139,8 @@ int afp_getcomment(struct afp_volume *volume, unsigned int did,
     request_packet->pad = 0;
     request_packet->dtrefnum = htons(volume->dtrefnum);
     request_packet->dirid = htonl(did);
-    copy_path(volume->server, path, pathname, strlen(pathname));
-    unixpath_to_afppath(volume->server, path);
+    copy_path(volume, path, pathname, strlen(pathname));
+    unixpath_to_afppath(volume, path);
     rc = afpc_dsi_send(volume->server, (char *)msg, len, DSI_DEFAULT_TIMEOUT,
                        afpGetComment, (void *) comment);
     free(msg);
@@ -228,4 +228,3 @@ int afp_opendt_reply(struct afp_server *server _U_,
     *refnum = ntohs(reply_packet->refnum);
     return 0;
 }
-

--- a/lib/proto_directory.c
+++ b/lib/proto_directory.c
@@ -71,7 +71,7 @@ int afp_exchangefiles(struct afp_volume *volume,
     struct afp_server * server = volume->server;
     size_t slen = src_path ? strnlen(src_path, AFP_MAX_UTF8_PATH_STORAGE) : 0;
     size_t dlen = dst_path ? strnlen(dst_path, AFP_MAX_UTF8_PATH_STORAGE) : 0;
-    unsigned short header_len = sizeof_path_header(server);
+    unsigned short header_len = sizeof_path_header(volume);
     size_t len = sizeof(*request_packet) + (2 * header_len) + slen + dlen;
     int ret;
 
@@ -89,11 +89,11 @@ int afp_exchangefiles(struct afp_volume *volume,
     request_packet->src_did = htonl(src_did);
     request_packet->dst_did = htonl(dst_did);
     p = msg + sizeof(*request_packet);
-    copy_path(server, p, src_path, slen);
-    unixpath_to_afppath(server, p);
+    copy_path(volume, p, src_path, slen);
+    unixpath_to_afppath(volume, p);
     p += header_len + slen;
-    copy_path(server, p, dst_path, dlen);
-    unixpath_to_afppath(server, p);
+    copy_path(volume, p, dst_path, dlen);
+    unixpath_to_afppath(volume, p);
     ret = afpc_dsi_send(server, msg, (int)len, DSI_DEFAULT_TIMEOUT,
                         afpExchangeFiles,
                         NULL);
@@ -120,7 +120,7 @@ int afp_moveandrename(struct afp_volume *volume,
     size_t len;
     size_t dlen = 0, slen = 0, nlen = 0;
     int ret;
-    unsigned short header_len = sizeof_path_header(server);
+    unsigned short header_len = sizeof_path_header(volume);
     char null_path[255];
 
     if (dst_path == NULL) {
@@ -157,14 +157,14 @@ int afp_moveandrename(struct afp_volume *volume,
     request_packet->src_did = htonl(src_did);
     request_packet->dst_did = htonl(dst_did);
     p = msg + sizeof(*request_packet);
-    copy_path(server, p, src_path, slen);
-    unixpath_to_afppath(server, p);
-    p += sizeof_path_header(server) + slen;
-    copy_path(server, p, dst_path, dlen);
-    unixpath_to_afppath(server, p);
-    p += sizeof_path_header(server) + dlen;
-    copy_path(server, p, new_name, nlen);
-    unixpath_to_afppath(server, p);
+    copy_path(volume, p, src_path, slen);
+    unixpath_to_afppath(volume, p);
+    p += sizeof_path_header(volume) + slen;
+    copy_path(volume, p, dst_path, dlen);
+    unixpath_to_afppath(volume, p);
+    p += sizeof_path_header(volume) + dlen;
+    copy_path(volume, p, new_name, nlen);
+    unixpath_to_afppath(volume, p);
     ret = afpc_dsi_send(server, msg, (int)len, DSI_DEFAULT_TIMEOUT,
                         afpMoveAndRename,
                         NULL);
@@ -187,8 +187,8 @@ int afp_rename(struct afp_volume *volume,
     char *msg;
     struct afp_server * server = volume->server;
     unsigned int len = sizeof(*request_packet) +
-                       sizeof_path_header(server) + strlen(path_from) +
-                       sizeof_path_header(server) + strlen(path_to);
+                       sizeof_path_header(volume) + strlen(path_from) +
+                       sizeof_path_header(volume) + strlen(path_to);
     int ret;
 
     if ((msg = malloc(len)) == NULL) {
@@ -204,11 +204,11 @@ int afp_rename(struct afp_volume *volume,
     request_packet->volid = htons(volume->volid);
     request_packet->dirid = htonl(dirid);
     pathfromptr = msg + sizeof(*request_packet);
-    copy_path(server, pathfromptr, path_from, strlen(path_from));
-    unixpath_to_afppath(server, pathfromptr);
-    pathtoptr = pathfromptr + sizeof_path_header(server) + strlen(path_from);
-    copy_path(server, pathtoptr, path_to, strlen(path_to));
-    unixpath_to_afppath(server, pathtoptr);
+    copy_path(volume, pathfromptr, path_from, strlen(path_from));
+    unixpath_to_afppath(volume, pathfromptr);
+    pathtoptr = pathfromptr + sizeof_path_header(volume) + strlen(path_from);
+    copy_path(volume, pathtoptr, path_to, strlen(path_to));
+    unixpath_to_afppath(volume, pathtoptr);
     ret = afpc_dsi_send(server, msg, len, DSI_DEFAULT_TIMEOUT, afpRename, NULL);
     free(msg);
     return ret;
@@ -228,7 +228,7 @@ int afp_createdir(struct afp_volume * volume, unsigned int dirid,
     char *msg;
     struct afp_server * server = volume->server;
     unsigned int len = sizeof(*request_packet) +
-                       sizeof_path_header(server) + strlen(pathname);
+                       sizeof_path_header(volume) + strlen(pathname);
     int ret;
 
     if ((msg = malloc(len)) == NULL) {
@@ -244,8 +244,8 @@ int afp_createdir(struct afp_volume * volume, unsigned int dirid,
     request_packet->pad = 0;
     request_packet->volid = htons(volume->volid);
     request_packet->dirid = htonl(dirid);
-    copy_path(server, pathptr, pathname, strlen(pathname));
-    unixpath_to_afppath(server, pathptr);
+    copy_path(volume, pathptr, pathname, strlen(pathname));
+    unixpath_to_afppath(volume, pathptr);
     ret = afpc_dsi_send(server, msg, len, DSI_DEFAULT_TIMEOUT,
                         afpCreateDir, (void *)did_p);
     free(msg);
@@ -460,7 +460,7 @@ int afp_enumerate(
     struct afp_file_info * files = NULL;
     struct afp_server * server = volume->server;
     char *path;
-    len = sizeof_path_header(server) + strlen(pathname) +
+    len = sizeof_path_header(volume) + strlen(pathname) +
           sizeof(*afp_enumerate_request_packet);
 
     if ((data = malloc(len)) == NULL) {
@@ -483,8 +483,8 @@ int afp_enumerate(
     afp_enumerate_request_packet->startindex = htons(startindex);
     afp_enumerate_request_packet->maxreplysize =
         htons((uint16_t)enumerate_max_reply_size(server));
-    copy_path(server, path, pathname, strlen(pathname));
-    unixpath_to_afppath(server, path);
+    copy_path(volume, path, pathname, strlen(pathname));
+    unixpath_to_afppath(volume, path);
     rc = afpc_dsi_send(server, data, len, DSI_DEFAULT_TIMEOUT,
                        afpEnumerate, (void **) &files);
     *file_p = files;
@@ -519,7 +519,7 @@ int afp_enumerateext(
     struct afp_file_info * files = NULL;
     struct afp_server * server = volume->server;
     char *path;
-    len = sizeof_path_header(server) + strlen(pathname) +
+    len = sizeof_path_header(volume) + strlen(pathname) +
           sizeof(*afp_enumerateext_request_packet);
 
     if ((data = malloc(len)) == NULL) {
@@ -542,8 +542,8 @@ int afp_enumerateext(
     afp_enumerateext_request_packet->startindex = htons(startindex);
     afp_enumerateext_request_packet->maxreplysize =
         htons((uint16_t)enumerate_max_reply_size(server));
-    copy_path(server, path, pathname, strlen(pathname));
-    unixpath_to_afppath(server, path);
+    copy_path(volume, path, pathname, strlen(pathname));
+    unixpath_to_afppath(volume, path);
     rc = afpc_dsi_send(server, data, len, DSI_DEFAULT_TIMEOUT,
                        afpEnumerateExt, (void **) &files);
     *file_p = files;
@@ -578,7 +578,7 @@ int afp_enumerateext2(
     struct afp_file_info * files = NULL;
     struct afp_server * server = volume->server;
     char *path;
-    len = sizeof_path_header(server) + strlen(pathname) +
+    len = sizeof_path_header(volume) + strlen(pathname) +
           sizeof(*afp_enumerateext2_request_packet);
 
     if ((data = malloc(len)) == NULL) {
@@ -601,8 +601,8 @@ int afp_enumerateext2(
     afp_enumerateext2_request_packet->startindex = htonl(startindex);
     afp_enumerateext2_request_packet->maxreplysize =
         htonl(enumerate_max_reply_size(server));
-    copy_path(server, path, pathname, strlen(pathname));
-    unixpath_to_afppath(server, path);
+    copy_path(volume, path, pathname, strlen(pathname));
+    unixpath_to_afppath(volume, path);
     rc = afpc_dsi_send(server, data, len, DSI_DEFAULT_TIMEOUT,
                        afpEnumerateExt2, (void **) &files);
     *file_p = files;

--- a/lib/proto_files.c
+++ b/lib/proto_files.c
@@ -37,7 +37,7 @@ static int afp_setparms_lowlevel(struct afp_volume * volume,
     unsigned short result_bitmap = 0;
 #endif
     unsigned int len = sizeof(*request_packet) +
-                       sizeof_path_header(server) + strlen(pathname) +
+                       sizeof_path_header(volume) + strlen(pathname) +
                        200 +  /* This is the max size of a data block */
                        1; /* In case we're not on an even boundary */
     char *msg, *pathptr, *p;
@@ -48,7 +48,7 @@ static int afp_setparms_lowlevel(struct afp_volume * volume,
     }
 
     pathptr = msg + sizeof(*request_packet);
-    p = pathptr + sizeof_path_header(server) + strlen(pathname);
+    p = pathptr + sizeof_path_header(volume) + strlen(pathname);
 
     if (((uintptr_t) p) & 0x1) {
         p++;    /* Make sure we're on an even boundary */
@@ -64,8 +64,8 @@ static int afp_setparms_lowlevel(struct afp_volume * volume,
     request_packet->volid = htons(volume->volid);
     request_packet->dirid = htonl(dirid);
     request_packet->bitmap = htons(bitmap);
-    copy_path(server, pathptr, pathname, strlen(pathname));
-    unixpath_to_afppath(server, pathptr);
+    copy_path(volume, pathptr, pathname, strlen(pathname));
+    unixpath_to_afppath(volume, pathptr);
 
     if (bitmap & kFPAttributeBit) {
         /* Todo:
@@ -172,7 +172,7 @@ int afp_delete(struct afp_volume * volume,
     }  __attribute__((__packed__)) *request_packet;
     struct afp_server * server = volume->server;
     unsigned int len = sizeof(*request_packet) + sizeof_path_header(
-                           server) + strlen(pathname);
+                           volume) + strlen(pathname);
     char *pathptr, *msg;
     int ret = 0;
 
@@ -194,8 +194,8 @@ int afp_delete(struct afp_volume * volume,
     request_packet->pad = 0;
     request_packet->volid = htons(volume->volid);
     request_packet->dirid = htonl(dirid);
-    copy_path(server, pathptr, pathname, strlen(pathname));
-    unixpath_to_afppath(server, pathptr);
+    copy_path(volume, pathptr, pathname, strlen(pathname));
+    unixpath_to_afppath(volume, pathptr);
     ret = afpc_dsi_send(server, (char *) request_packet, len, DSI_DEFAULT_TIMEOUT,
                         afpDelete, NULL);
     free(msg);
@@ -377,7 +377,7 @@ int afp_getfiledirparms(struct afp_volume *volume, unsigned int did,
         return -1;
     }
 
-    len = sizeof(*getfiledirparms) + sizeof_path_header(server) + strlen(pathname);
+    len = sizeof(*getfiledirparms) + sizeof_path_header(volume) + strlen(pathname);
 
     if ((msg = malloc(len)) == NULL) {
         return -1;
@@ -394,8 +394,8 @@ int afp_getfiledirparms(struct afp_volume *volume, unsigned int did,
     getfiledirparms->did = htonl(did);
     getfiledirparms->file_bitmap = htons(filebitmap);
     getfiledirparms->directory_bitmap = htons(dirbitmap);
-    copy_path(server, path, pathname, strlen(pathname));
-    unixpath_to_afppath(server, path);
+    copy_path(volume, path, pathname, strlen(pathname));
+    unixpath_to_afppath(volume, path);
     ret = afpc_dsi_send(server, (char *) getfiledirparms, len, DSI_DEFAULT_TIMEOUT,
                         afpGetFileDirParms, (void *) fpp);
     free(msg);
@@ -416,7 +416,7 @@ int afp_createfile(struct afp_volume * volume, unsigned char flag,
     char *path, *msg;
     struct afp_server * server = volume->server;
     unsigned int len = sizeof(*request_packet) +
-                       sizeof_path_header(server) + strlen(pathname);
+                       sizeof_path_header(volume) + strlen(pathname);
     int ret = 0;
 
     if ((msg = malloc(len)) == NULL) {
@@ -432,8 +432,8 @@ int afp_createfile(struct afp_volume * volume, unsigned char flag,
     request_packet->flag = flag;
     request_packet->volid = htons(volume->volid);
     request_packet->did = htonl(did);
-    copy_path(server, path, pathname, strlen(pathname));
-    unixpath_to_afppath(server, path);
+    copy_path(volume, path, pathname, strlen(pathname));
+    unixpath_to_afppath(volume, path);
     ret = afpc_dsi_send(server, (char *) request_packet, len, DSI_DEFAULT_TIMEOUT,
                         afpCreateFile, NULL);
     free(msg);

--- a/lib/proto_fork.c
+++ b/lib/proto_fork.c
@@ -155,7 +155,7 @@ int afp_openfork(struct afp_volume * volume,
     char *pathptr;
     struct afp_server * server = volume->server;
     unsigned int len = sizeof(*afp_openfork_request) +
-                       sizeof_path_header(server) + strlen(filename);
+                       sizeof_path_header(volume) + strlen(filename);
     int ret;
 
     if ((msg = malloc(len)) == NULL) {
@@ -174,8 +174,8 @@ int afp_openfork(struct afp_volume * volume,
     afp_openfork_request->volid = htons(volume->volid);
     afp_openfork_request->dirid = htonl(dirid);
     afp_openfork_request->accessmode = htons(accessmode);
-    copy_path(server, pathptr, filename, strlen(filename));
-    unixpath_to_afppath(server, pathptr);
+    copy_path(volume, pathptr, filename, strlen(filename));
+    unixpath_to_afppath(volume, pathptr);
     ret = afpc_dsi_send(server, (char *) msg, len, DSI_DEFAULT_TIMEOUT,
                         afpOpenFork, (void *) fp);
     free(msg);

--- a/lib/utils.c
+++ b/lib/utils.c
@@ -32,10 +32,10 @@ unsigned short utf8_to_string(char * dest, char * buf, unsigned short maxlen)
 }
 
 unsigned char unixpath_to_afppath(
-    struct afp_server * server,
+    const struct afp_volume *volume,
     char *buf)
 {
-    unsigned char encoding = server->path_encoding;
+    unsigned char encoding = volume->path_encoding;
     char *p = NULL, *end;
     unsigned short len = 0;
 
@@ -164,9 +164,9 @@ unsigned short copy_to_pascal_two(char *dest, const char *src)
     return len;
 }
 
-unsigned char sizeof_path_header(struct afp_server * server)
+unsigned char sizeof_path_header(const struct afp_volume *volume)
 {
-    switch (server->path_encoding) {
+    switch (volume->path_encoding) {
     case kFPUTF8Name:
         return (sizeof(struct afp_path_header_unicode));
 
@@ -179,13 +179,13 @@ unsigned char sizeof_path_header(struct afp_server * server)
 
 
 void copy_path(
-    struct afp_server * server,
+    const struct afp_volume *volume,
     char *dest,
     const char *pathname,
     size_t len
 )
 {
-    unsigned char encoding = server->path_encoding;
+    unsigned char encoding = volume->path_encoding;
     struct afp_path_header_unicode * header_unicode = (void *) dest;
     struct afp_path_header_long * header_long = (void *) dest;
 
@@ -217,14 +217,18 @@ void copy_path(
     }
 }
 
-int invalid_filename(struct afp_server * server, const char * filename)
+int invalid_filename(const struct afp_volume *volume, const char *filename)
 {
+    const struct afp_server *server;
     size_t maxlen;
     const char *p, *q;
 
-    if (!server || !server->using_version || !filename) {
+    if (!volume || !volume->server || !volume->server->using_version
+            || !filename) {
         return 1;
     }
+
+    server = volume->server;
 
     if ((filename[0] == '/') && (filename[1] == '\0')) {
         return 0;
@@ -232,7 +236,7 @@ int invalid_filename(struct afp_server * server, const char * filename)
 
     if (server->using_version->av_number < 30) {
         maxlen = 31;
-    } else if (server->path_encoding == kFPUTF8Name) {
+    } else if (volume->path_encoding == kFPUTF8Name) {
         maxlen = AFP_MAX_UTF8_NAME_CHARS;
     } else {
         maxlen = 255;
@@ -251,7 +255,7 @@ int invalid_filename(struct afp_server * server, const char * filename)
 
         q = strchr(p, '/');
 
-        if (server->path_encoding == kFPUTF8Name
+        if (volume->path_encoding == kFPUTF8Name
                 && server->using_version->av_number >= 30) {
             size_t component_len = q ? (size_t)(q - p) : strlen(p);
 

--- a/lib/utils.h
+++ b/lib/utils.h
@@ -26,9 +26,9 @@ static inline uint64_t ntoh64(uint64_t value)
 #define max(a,b) (((a)>(b)) ? (a) : (b))
 
 unsigned char unixpath_to_afppath(
-    struct afp_server * server,
+    const struct afp_volume *volume,
     char *buf);
-unsigned char sizeof_path_header(struct afp_server * server);
+unsigned char sizeof_path_header(const struct afp_volume *volume);
 
 unsigned char copy_from_pascal(char *dest, char *pascal, unsigned int max_len) ;
 unsigned short copy_from_pascal_two(char *dest, char *pascal,
@@ -37,12 +37,13 @@ unsigned short copy_from_pascal_two(char *dest, char *pascal,
 unsigned char copy_to_pascal(char *dest, const char *src);
 unsigned short copy_to_pascal_two(char *dest, const char *src);
 
-void copy_path(struct afp_server * server, char * dest, const char * pathname,
+void copy_path(const struct afp_volume *volume, char * dest,
+               const char *pathname,
                size_t len);
 char *create_path(struct afp_server * server, char * pathname,
                   unsigned short *len);
 
-int invalid_filename(struct afp_server * server, const char * filename);
+int invalid_filename(const struct afp_volume *volume, const char *filename);
 
 void trigger_exit(void);
 void afp_set_auto_shutdown_on_unmount(int enabled);

--- a/test/test_filename_validation.c
+++ b/test/test_filename_validation.c
@@ -57,6 +57,10 @@ int main(int argc, char **argv)
 {
     struct afp_versions afp3 = { .av_name = "AFP3.0", .av_number = 30 };
     struct afp_server server;
+    struct afp_volume utf8_volume;
+    struct afp_volume legacy_volume;
+    char utf8_path[16] = { 0 };
+    char legacy_path[16] = { 0 };
     char *name_255;
     char *name_256;
     char *supplementary_name_255;
@@ -71,8 +75,13 @@ int main(int argc, char **argv)
     const size_t long_path_len = 20000U;
     test_tap_init(argc, argv);
     memset(&server, 0, sizeof(server));
+    memset(&utf8_volume, 0, sizeof(utf8_volume));
+    memset(&legacy_volume, 0, sizeof(legacy_volume));
     server.using_version = &afp3;
-    server.path_encoding = kFPUTF8Name;
+    utf8_volume.server = &server;
+    utf8_volume.path_encoding = kFPUTF8Name;
+    legacy_volume.server = &server;
+    legacy_volume.path_encoding = kFPLongName;
     name_255 = utf8_name(AFP_MAX_UTF8_NAME_CHARS);
     name_256 = utf8_name(AFP_MAX_UTF8_NAME_CHARS + 1U);
     supplementary_name_255 = supplementary_utf8_name(AFP_MAX_UTF8_NAME_CHARS);
@@ -92,9 +101,10 @@ int main(int argc, char **argv)
 
     if (name_255 && name_256 && supplementary_name_255
             && converted_supplementary_name) {
-        CHECK(!invalid_filename(&server, name_255));
-        CHECK(invalid_filename(&server, name_256));
-        CHECK(!invalid_filename(&server, supplementary_name_255));
+        CHECK(!invalid_filename(&utf8_volume, name_255));
+        CHECK(invalid_filename(&utf8_volume, name_256));
+        CHECK(!invalid_filename(&utf8_volume, supplementary_name_255));
+        CHECK(invalid_filename(&legacy_volume, name_255));
         CHECK(convert_path_to_afp(kFPUTF8Name, converted_supplementary_name,
                                   supplementary_name_255,
                                   AFPC_MAX_NAME_BYTES + 1U) == 0);
@@ -113,6 +123,14 @@ int main(int argc, char **argv)
                                   sizeof(legacy_long_name)) < 0);
     }
 
+    CHECK(sizeof_path_header(&utf8_volume) == 7);
+    CHECK(sizeof_path_header(&legacy_volume) == 2);
+    copy_path(&utf8_volume, utf8_path, "abc", 3);
+    copy_path(&legacy_volume, legacy_path, "abc", 3);
+    CHECK((unsigned char)utf8_path[0] == kFPUTF8Name);
+    CHECK((unsigned char)utf8_path[6] == 3);
+    CHECK((unsigned char)legacy_path[0] == kFPLongName);
+    CHECK((unsigned char)legacy_path[1] == 3);
     free(name_255);
     free(name_256);
     free(supplementary_name_255);


### PR DESCRIPTION
AFP servers can expose volumes with different kSupportsUTF8Names capabilities. The client previously recorded the selected pathname encoding on the shared server object, so opening a second volume could change the AFP path header format, pathname conversion, and validation limits used by an already-open volume.

Store the encoding on afp_volume and select it when the volume is opened. Pass the volume through pathname-header generation, AFP packet builders, midlevel conversion, and filename validation so every request uses the target volume's protocol format. Remove the completed TODO entry.

Add regression coverage for UTF-8 and legacy volumes sharing one AFP server, including independent filename limits and wire path headers.