### PR TITLE
introduce option to force AFP protocol version in afpcmd

### DIFF
--- a/cmdline/cmdline_afp.c
+++ b/cmdline/cmdline_afp.c
@@ -4756,7 +4756,7 @@ void cmdline_afp_setup_logging(void)
 
 
 int cmdline_afp_setup(int batch_mode, char *url_string,
-                      const char *username_override)
+                      const char *username_override, int requested_version)
 {
     if (set_current_directory(DEFAULT_DIRECTORY) != 0) {
         return -1;
@@ -4778,6 +4778,10 @@ int cmdline_afp_setup(int batch_mode, char *url_string,
             if (afp_sl_url_parse(&url, url_string)) {
                 printf("Could not parse url.\n");
                 return -1;
+            }
+
+            if (requested_version) {
+                url.requested_version = requested_version;
             }
 
             if (username_override

--- a/cmdline/cmdline_afp.h
+++ b/cmdline/cmdline_afp.h
@@ -33,7 +33,7 @@ int com_exit(char *unused);
 void cmdline_afp_exit(void);
 int cmdline_afp_quit_requested(void);
 int cmdline_afp_setup(int batch_mode, char *url_string,
-                      const char *username_override);
+                      const char *username_override, int requested_version);
 void cmdline_afp_setup_logging(void);
 void cmdline_set_log_level(int loglevel);
 void cmdline_set_verbose(int verbose);

--- a/cmdline/cmdline_main.c
+++ b/cmdline/cmdline_main.c
@@ -25,7 +25,6 @@
     59 Temple Place, Suite 330, Boston, MA 02111 USA.
 */
 
-#include <errno.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -49,6 +48,8 @@
 #endif
 
 #include "netatalk-client/url.h"
+
+#include "lib/utils.h"
 
 #include "cmdline_afp.h"
 #include "discover.h"
@@ -473,23 +474,25 @@ static void usage(void)
 {
     printf(
         "Netatalk Client %s - AFP command-line client\n"
-        "afpcmd [-V] [-v loglevel] [-M mode] --browse\n"
-        "afpcmd [-V] [-v loglevel] [-M mode] <afp url>\n"
+        "afpcmd [-V] [-f version] [-v loglevel] [-M mode] --browse\n"
+        "afpcmd [-V] [-f version] [-v loglevel] [-M mode] <afp url>\n"
         "afpcmd -h\n"
         "Options:\n"
         "\t-h:          show this help message and exit\n"
         "\t-b, --browse: browse and select an advertised AFP service\n"
         "\t-M mode:     preserve metadata using auto, netatalk, xattr, macos, or none\n"
         "\t-r:          recursively transfer directories in batch mode\n"
-        "\t-V:          verbose mode (show detailed transfer messages)\n"
+        "\t-f, --afpversion version:\n"
+        "\t             set the AFP version, e.g. 3.1\n"
+        "\t-V, --verbose: show detailed transfer messages\n"
         "\t-v loglevel: set log verbosity (debug, info, notice, warning, error)\n"
         "\turl:         an AFP url, in the form of:\n"
         "\t\t         afp://username;AUTH=uamname:password@server:548/volume/path\n"
         "\t             uamname can be a full UAM name or shorthand:\n"
         "\t             guest, clrtxt, randnum, randnum2, dhx, dhx2, srp\n\n"
         "Batch transfer mode:\n"
-        "\tafpcmd [-r] [-V] [-M mode] <afp url> <local path>   (Download from server)\n"
-        "\tafpcmd [-r] [-V] [-M mode] <local path> <afp url>   (Upload to server)\n\n"
+        "\tafpcmd [-r] [-V] [-f version] [-M mode] <afp url> <local path>   (Download from server)\n"
+        "\tafpcmd [-r] [-V] [-f version] [-M mode] <local path> <afp url>   (Upload to server)\n\n"
         "See the afpcmd(1) man page for more information.\n", NETATALK_CLIENT_VERSION
     );
 }
@@ -505,12 +508,14 @@ int main(int argc, char *argv[])
     int discovered = 0;
     int show_usage = 0;
     int log_level = LOG_NOTICE;
+    int requested_version = 0;
     const char *metadata_mode = "auto";
     struct option long_options[] = {
         {"browse", 0, 0, 'b'},
         {"help", 0, 0, 'h'},
         {"metadata", 1, 0, 'M'},
         {"recursive", 0, 0, 'r'},
+        {"afpversion", 1, 0, 'f'},
         {"verbose", 0, 0, 'V'},
         {"loglevel", 1, 0, 'v'},
         {NULL, 0, NULL, 0},
@@ -523,7 +528,7 @@ int main(int argc, char *argv[])
     int direction = 0; /* 0 = GET (remote->local), 1 = PUT (local->remote) */
 
     while (1) {
-        c = getopt_long(argc, argv, "bhM:rVv:",
+        c = getopt_long(argc, argv, "bhM:rf:v:V",
                         long_options, &option_index);
 
         if (c == -1) {
@@ -545,6 +550,14 @@ int main(int argc, char *argv[])
 
         case 'r':
             recursive = 1;
+            break;
+
+        case 'f':
+            if (afp_parse_version(optarg, &requested_version) != 0) {
+                printf("Invalid AFP version format: %s\n", optarg);
+                return -1;
+            }
+
             break;
 
         case 'V':
@@ -677,7 +690,8 @@ int main(int argc, char *argv[])
         }
     }
 
-    if (cmdline_afp_setup(batch_mode, url, discovered_username) != 0) {
+    if (cmdline_afp_setup(batch_mode, url, discovered_username,
+                          requested_version) != 0) {
         free(discovered_url);
         free(discovered_username);
         cmdline_afp_exit();

--- a/docs/manpages/afpc.1
+++ b/docs/manpages/afpc.1
@@ -1,4 +1,4 @@
-.Dd August 5, 2026
+.Dd August 14, 2026
 .Dt AFPC 1
 .Os Netatalk Client
 .Sh NAME
@@ -43,11 +43,7 @@ communicates with
 .Xr afpfsd 1
 and is present only when FUSE support was built. It provides structured
 mounting and FUSE mount lifecycle commands. The mount options are the same as
-the former AFP client mount command: use
-.Fl -service
-to resolve an advertised service, and use
-.Fl -volume
-to select a volume when mounting a service.
+the former AFP client mount command.
 .Pp
 Unqualified controller commands such as
 .Dq afpc status
@@ -58,6 +54,93 @@ are invalid. Use the appropriate
 or
 .Cm sl
 namespace.
+.Sh FS MOUNT OPTIONS
+The following options apply to
+.Cm afpc fs mount .
+They may be used with either a direct
+.Ar server : volume
+mount or a service-based mount unless noted otherwise.
+.Bl -tag -width Ds
+.It Fl s Ar name , Fl -service Ar name
+Resolve the named AFP service advertised through DNS-SD or Avahi.
+Service names containing spaces should be quoted.
+When this option is used, the service's advertised port is used unless
+.Fl o
+is also supplied.
+.It Fl -volume Ar volume
+Select the volume to mount after resolving a service.
+This option is valid only with
+.Fl -service .
+If it is omitted, the command authenticates, lists the available volumes, and
+exits without mounting; a mountpoint is optional in that case.
+.It Fl u Ar username , Fl -user Ar username
+Authenticate as
+.Ar username .
+If the password is omitted, the command prompts for it.
+Without a username, the default authentication methods may select guest access.
+.It Fl p Ar password , Fl -pass Ar password
+Use
+.Ar password
+for AFP authentication.
+Use
+.Sq -
+to request an interactive password prompt.
+.It Fl P Ar password , Fl -volpass Ar password
+Use
+.Ar password
+as the AFP volume password.
+Use
+.Sq -
+to request an interactive volume-password prompt.
+.It Fl o Ar port , Fl -port Ar port
+Connect to TCP
+.Ar port
+instead of the default AFP port, 548.
+.It Fl f Ar version , Fl -afpversion Ar version
+Limit the AFP protocol version used to connect.
+The version may be written with or without a decimal point, for example
+.Cm 3.1
+or
+.Cm 31 .
+.It Fl a Ar uam , Fl -uam Ar uam
+Restrict authentication to the specified UAM.
+Supported shorthands are
+.Cm guest ,
+.Cm clrtxt ,
+.Cm randnum ,
+.Cm randnum2 ,
+.Cm dhx ,
+and
+.Cm dhx2 .
+.It Fl m Ar map , Fl -map Ar map
+Select the UID and GID mapping method.
+Valid values are
+.Cm common
+and
+.Cm loginids .
+.It Fl O Ar flags , Fl -options Ar flags
+Pass a comma-separated set of FUSE mount options to the mount operation.
+Consult the FUSE documentation for supported flags.
+.El
+.Pp
+For a direct mount, specify both
+.Ar server : volume
+and
+.Ar mountpoint .
+For example:
+.Bd -literal -offset indent
+afpc fs mount --user myuser --afpversion 3.1 \\
+    afpserver.local:Files /home/myuser/fusemount
+.Ed
+.Pp
+For a service-based mount, use
+.Fl -service
+and
+.Fl -volume :
+.Bd -literal -offset indent
+afpc fs mount --service "Office File Server" --volume Files \\
+    /home/myuser/fusemount
+.Ed
 .Sh COMPATIBILITY
 When FUSE support is built,
 .Xr mount_afpfs 1

--- a/docs/manpages/afpcmd.1
+++ b/docs/manpages/afpcmd.1
@@ -7,22 +7,28 @@
 .Sh SYNOPSIS
 .Nm
 .Op Fl V
+.Op Fl f Ar version
 .Op Fl v Ar loglevel
 .Op Fl M Ar mode
 .Fl b
 .Nm
 .Op Fl V
+.Op Fl f Ar version
 .Op Fl v Ar loglevel
 .Op Fl M Ar mode
 .Ar afp_url
 .Nm
-.Op Fl rV
+.Op Fl r
+.Op Fl V
+.Op Fl f Ar version
 .Op Fl v Ar loglevel
 .Op Fl M Ar mode
 .Ar afp_url
 .Ar local_path
 .Nm
-.Op Fl rV
+.Op Fl r
+.Op Fl V
+.Op Fl f Ar version
 .Op Fl v Ar loglevel
 .Op Fl M Ar mode
 .Ar local_path
@@ -61,6 +67,12 @@ Recursively transfers directories in batch mode.
 This invocation-level option is not accepted in interactive mode; use
 .Fl r
 after an interactive command name instead.
+.It Fl f Ar version , Fl -afpversion Ar version
+Limits the AFP protocol version used to connect to the server.
+The version may be written with or without a decimal point, for example
+.Cm 3.1
+or
+.Cm 31 .
 .It Fl V , Fl -verbose
 Enables verbose mode for file transfers.
 When enabled, displays detailed messages during upload and download operations,

--- a/fuse/client.c
+++ b/fuse/client.c
@@ -432,7 +432,7 @@ static void usage(void)
         "         -P, --volpass <password>   : use this volume password\n"
         "                                      If password is '-', you get prompted for it\n"
         "         -o, --port <portnum>       : connect using <portnum> instead of 548\n"
-        "         -v, --afpversion <version> : set the AFP version, eg. 3.1\n"
+        "         -f, --afpversion <version> : set the AFP version, eg. 3.1\n"
         "         -a, --uam <uam>            : use this authentication method, one of:\n"
         "                                      guest, clrtxt, randnum, randnum2, dhx, dhx2\n"
         "         -m, --map <mapname>        : use this uid/gid mapping method, one of:\n"
@@ -704,7 +704,7 @@ static int do_mount(int argc, char ** argv)
     const char *volume_name = NULL;
     enum { OPT_VOLUME = 256 };
     struct option long_options[] = {
-        {"afpversion", 1, 0, 'v'},
+        {"afpversion", 1, 0, 'f'},
         {"volpass", 1, 0, 'P'},
         {"user", 1, 0, 'u'},
         {"pass", 1, 0, 'p'},
@@ -730,7 +730,7 @@ static int do_mount(int argc, char ** argv)
 
     while (1) {
         optnum++;
-        c = getopt_long(argc, argv, "a:m:O:o:P:p:s:u:v:", long_options,
+        c = getopt_long(argc, argv, "a:f:m:O:o:P:p:s:u:", long_options,
                         &option_index);
 
         if (c == -1) {
@@ -786,26 +786,16 @@ static int do_mount(int argc, char ** argv)
             snprintf(request.url.username, AFP_MAX_USERNAME_LEN, "%s", optarg);
             break;
 
-        case 'v': {
+        case 'f':
+
             /* Parse AFP version string like "3.1" or "22" to integer format.
              * AFP 2.2 = 22, AFP 3.1 = 31, AFP 3.2 = 32, etc. */
-            int major, minor;
-
-            if (strchr(optarg, '.')) {
-                /* Format like "3.1" */
-                if (sscanf(optarg, "%d.%d", &major, &minor) == 2) {
-                    request.url.requested_version = major * 10 + minor;
-                } else {
-                    printf("Invalid AFP version format: %s\n", optarg);
-                    return -1;
-                }
-            } else {
-                /* Format like "31" or "22" */
-                request.url.requested_version = strtol(optarg, NULL, 10);
+            if (afp_parse_version(optarg, &request.url.requested_version) != 0) {
+                printf("Invalid AFP version format: %s\n", optarg);
+                return -1;
             }
 
             break;
-        }
         }
     }
 

--- a/lib/utils.c
+++ b/lib/utils.c
@@ -6,9 +6,11 @@
  *
  */
 
+#include <errno.h>
+#include <limits.h>
 #include <stdio.h>
-#include <string.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "afp_internal.h"
 #include "afp_protocol.h"
@@ -25,6 +27,43 @@ struct afp_path_header_unicode {
     uint32_t hint;
     uint16_t unicode;
 }  __attribute__((__packed__)) ;
+
+int afp_parse_version(const char *text, int *version_out)
+{
+    long version;
+    char *end;
+
+    if (!text || !version_out) {
+        return -1;
+    }
+
+    if (strchr(text, '.')) {
+        long major, minor;
+        char trailing;
+
+        if (sscanf(text, "%ld.%ld%c", &major, &minor, &trailing) != 2
+                || major < 0 || minor < 0 || minor > 9
+                || major > (INT_MAX - minor) / 10) {
+            return -1;
+        }
+
+        version = major * 10 + minor;
+    } else {
+        errno = 0;
+        version = strtol(text, &end, 10);
+
+        if (errno != 0 || end == text || *end != '\0') {
+            return -1;
+        }
+    }
+
+    if (version < 0 || version > INT_MAX) {
+        return -1;
+    }
+
+    *version_out = (int)version;
+    return 0;
+}
 
 unsigned short utf8_to_string(char * dest, char * buf, unsigned short maxlen)
 {

--- a/lib/utils.h
+++ b/lib/utils.h
@@ -51,6 +51,9 @@ int afp_get_auto_shutdown_on_unmount(void);
 
 void sanitize_text(const char *text, char *sanitized, size_t size);
 
+/* Parse an AFP version such as "3.1" or "31" into its numeric form. */
+int afp_parse_version(const char *text, int *version_out);
+
 /* Log level conversion functions */
 const char *log_level_to_string(int level);
 int string_to_log_level(const char *str, int *level_out);

--- a/test/meson.build
+++ b/test/meson.build
@@ -240,6 +240,23 @@ test(
     verbose: true,
 )
 
+afp_version_test = executable(
+    'test_afp_version',
+    sources: ['test_afp_version.c'],
+    include_directories: incdir,
+    link_with: libafpclient,
+    dependencies: root_dependencies,
+    c_args: cflags,
+)
+
+test(
+    'AFP version parsing',
+    afp_version_test,
+    args: ['--tap'],
+    protocol: 'tap',
+    verbose: true,
+)
+
 identify_test = executable(
     'test_identify',
     sources: ['test_identify.c'],

--- a/test/test_afp_version.c
+++ b/test/test_afp_version.c
@@ -1,0 +1,19 @@
+#include "lib/utils.h"
+#include "tap.h"
+
+int main(int argc, char **argv)
+{
+    int version;
+    test_tap_init(argc, argv);
+    CHECK(afp_parse_version("3.1", &version) == 0);
+    CHECK(version == 31);
+    CHECK(afp_parse_version("31", &version) == 0);
+    CHECK(version == 31);
+    CHECK(afp_parse_version("4.0", &version) == 0);
+    CHECK(version == 40);
+    CHECK(afp_parse_version("31junk", &version) != 0);
+    CHECK(afp_parse_version("3.10", &version) != 0);
+    CHECK(afp_parse_version(NULL, &version) != 0);
+    CHECK(afp_parse_version("3.1", NULL) != 0);
+    return test_tap_finish();
+}


### PR DESCRIPTION
the new -f | --afpversion option argument forces a particular maximum AFP protocol version: takes both 3.1 and 31 for AFP 3.1

rename the equivalent option in the FUSE client to -f as well for consistency

add AFP version validation logic for both afpcmd and the FUSE client

flesh out the afpc manual page with mount options