### PR TITLE
libafpclient: a number of adjustments for AFP 2.x compatiblity

### DIFF
--- a/cmdline/cmdline_afp.c
+++ b/cmdline/cmdline_afp.c
@@ -70,6 +70,9 @@ static char last_log_message[CMDLINE_ERROR_LEN];
 
 int full_url = 0;
 
+static void cmdline_stateless_log(void *user_data, int loglevel,
+                                  const char *message);
+
 #define DEFAULT_DIRECTORY "/"
 #define METADATA_OUTPUT_MODE 0600
 #define DIRECTORY_PAGE_SIZE 256
@@ -4445,6 +4448,27 @@ void cmdline_set_verbose(int verbose)
 int cmdline_set_metadata_mode(const char *mode)
 {
     return afp_metadata_mode_parse(mode, &transfer_metadata_mode);
+}
+
+void cmdline_log_metadata_mode(void)
+{
+    char message[CMDLINE_ERROR_LEN];
+    const char *mode;
+
+    if (transfer_metadata_mode != AFP_METADATA_AUTO) {
+        mode = afp_metadata_mode_name(transfer_metadata_mode);
+    } else {
+#if defined(__APPLE__)
+        mode = "native macOS extended attributes";
+#else
+        mode = "filesystem extended attributes, with Netatalk AppleDouble fallback";
+#endif
+    }
+
+    snprintf(message, sizeof(message),
+             "Selected metadata transfer format: %s",
+             mode);
+    cmdline_stateless_log(NULL, LOG_DEBUG, message);
 }
 
 static void cmdline_stateless_log(void *user_data, int loglevel,

--- a/cmdline/cmdline_afp.c
+++ b/cmdline/cmdline_afp.c
@@ -2129,6 +2129,16 @@ static int retrieve_file(const char *arg, int fd, struct stat *stat,
         offset += received;
     }
 
+    /* A server can return a short kFPNoErr response.  Do not present the
+     * resulting partial local file as a successful download: the remote
+     * catalog size captured above is the expected data-fork length. */
+    if (stat->st_size < 0 || total != (unsigned long long)stat->st_size) {
+        fprintf(stderr, "Incomplete download of %s: received %llu of %lld bytes\n",
+                path, total, (long long)stat->st_size);
+        ret = -EIO;
+        goto out;
+    }
+
     if (verbose_mode) {
         gettimeofday(&endtv, NULL);
         printdiff(&starttv, &endtv, &total);

--- a/cmdline/cmdline_afp.c
+++ b/cmdline/cmdline_afp.c
@@ -798,7 +798,7 @@ static int apply_remote_posix_metadata(const char *path, const struct stat *st)
 {
     int ret = afp_sl_chmod(&vol_id, path, NULL, st->st_mode & 07777);
 
-    if (ret != 0 && ret != -ENOTSUP && ret != -EACCES) {
+    if (ret != 0 && ret != -ENOTSUP && ret != -ENOSYS && ret != -EACCES) {
         return ret;
     }
 
@@ -806,7 +806,8 @@ static int apply_remote_posix_metadata(const char *path, const struct stat *st)
 
     ret = afp_sl_utime(&vol_id, path, NULL, &times);
 
-    return ret == 0 || ret == -ENOTSUP || ret == -EACCES ? 0 : ret;
+    return ret == 0 || ret == -ENOTSUP || ret == -ENOSYS || ret == -EACCES
+           ? 0 : ret;
 }
 
 static int copy_local_metadata_to_remote(const char *local_path,

--- a/cmdline/cmdline_afp.c
+++ b/cmdline/cmdline_afp.c
@@ -3154,7 +3154,7 @@ int com_appl(char *arg)
             printf("index=%u creator=%s creator_hex=%08" PRIx32
                    " tag=%" PRIu32 " directory_id=%" PRIu32
                    " pathname=%s file_bitmap=%04x file_id=%" PRIu32
-                   " created=%" PRIu32 " modified=%" PRIu32
+                   " created=%" PRId64 " modified=%" PRId64
                    " data_bytes=%" PRIu64 " resource_bytes=%" PRIu64 "\n",
                    index, creator_text, creator, appl.tag, appl.directory_id,
                    display_text(appl.pathname, pathname, sizeof(pathname)),

--- a/cmdline/cmdline_afp.h
+++ b/cmdline/cmdline_afp.h
@@ -38,6 +38,7 @@ void cmdline_afp_setup_logging(void);
 void cmdline_set_log_level(int loglevel);
 void cmdline_set_verbose(int verbose);
 int cmdline_set_metadata_mode(const char *mode);
+void cmdline_log_metadata_mode(void);
 int cmdline_batch_transfer(char * local_path, int direction, int recursive);
 char *afp_remote_file_generator(const char *text, int state);
 

--- a/cmdline/cmdline_main.c
+++ b/cmdline/cmdline_main.c
@@ -598,6 +598,8 @@ int main(int argc, char *argv[])
         return 1;
     }
 
+    cmdline_log_metadata_mode();
+
     if (browse && optind < argc) {
         printf("--browse cannot be combined with an AFP URL or batch arguments.\n");
         usage();

--- a/daemon/commands.c
+++ b/daemon/commands.c
@@ -1078,11 +1078,19 @@ static unsigned char process_chmod(struct daemon_client * c)
             result = AFPSL_IPC_RESULT_ENOENT;
         } else if (ret == -EACCES || ret == -EPERM) {
             result = AFPSL_IPC_RESULT_ACCESS;
+        } else if (ret == -ENOSYS || ret == -ENOTSUP
+                   || ret == -EOPNOTSUPP) {
+            /* AFP 2.x servers, including Classic Mac OS, cannot expose
+             * POSIX Unix privileges.  Preserve this capability result so
+             * transfer callers can keep copying AFP metadata. */
+            result = AFPSL_IPC_RESULT_NOTSUPPORTED;
         } else {
             result = AFPSL_IPC_RESULT_ERROR;
         }
 
-        log_for_client((void *) c, AFPFSD, LOG_ERR,
+        log_for_client((void *) c, AFPFSD,
+                       result == AFPSL_IPC_RESULT_NOTSUPPORTED
+                       ? LOG_DEBUG : LOG_ERR,
                        "Failed to chmod file %s: %d (%s)", path, ret,
                        strerror(-ret));
     }

--- a/daemon/commands.c
+++ b/daemon/commands.c
@@ -2128,7 +2128,7 @@ static unsigned char process_readdir(struct daemon_client * c)
 
         size_t name_len = strlen(fp->name);
         size_t entry_size = sizeof(uint32_t) + name_len +
-                            sizeof(uint32_t) * 2 +
+                            sizeof(int64_t) * 2 +
                             sizeof(struct afpc_unix_privileges) +
                             sizeof(uint64_t);
 
@@ -2142,10 +2142,14 @@ static unsigned char process_readdir(struct daemon_client * c)
         p += sizeof(uint32_t);
         memcpy(p, fp->name, name_len);
         p += name_len;
-        memcpy(p, &fp->creation_date, sizeof(uint32_t));
-        p += sizeof(uint32_t);
-        memcpy(p, &fp->modification_date, sizeof(uint32_t));
-        p += sizeof(uint32_t);
+        {
+            int64_t creation_date = fp->creation_date;
+            int64_t modification_date = fp->modification_date;
+            memcpy(p, &creation_date, sizeof(creation_date));
+            p += sizeof(creation_date);
+            memcpy(p, &modification_date, sizeof(modification_date));
+            p += sizeof(modification_date);
+        }
         memcpy(p, &fp->unixprivs, sizeof(struct afpc_unix_privileges));
         p += sizeof(struct afpc_unix_privileges);
         memcpy(p, &fp->size, sizeof(uint64_t));

--- a/daemon/stateless.c
+++ b/daemon/stateless.c
@@ -2377,7 +2377,7 @@ int afp_sl_readdir(afpc_volume_t * volid, const char * path,
         if (batch_received > 0) {
             const char *p = ((const char *) mainrep) + sizeof(*mainrep);
             const char *end = ((const char *) mainrep) + content_len;
-            const size_t fixed_entry_size = sizeof(uint32_t) * 2U
+            const size_t fixed_entry_size = sizeof(int64_t) * 2U
                                             + sizeof(struct afpc_unix_privileges)
                                             + sizeof(uint64_t);
 
@@ -2437,10 +2437,12 @@ int afp_sl_readdir(afpc_volume_t * volid, const char * path,
                 memcpy(current_basic->name, p, name_len);
                 current_basic->name[name_len] = '\0';
                 p += name_len;
-                memcpy(&current_basic->creation_date, p, sizeof(uint32_t));
-                p += sizeof(uint32_t);
-                memcpy(&current_basic->modification_date, p, sizeof(uint32_t));
-                p += sizeof(uint32_t);
+                memcpy(&current_basic->creation_date, p,
+                       sizeof(current_basic->creation_date));
+                p += sizeof(current_basic->creation_date);
+                memcpy(&current_basic->modification_date, p,
+                       sizeof(current_basic->modification_date));
+                p += sizeof(current_basic->modification_date);
                 memcpy(&current_basic->unixprivs, p, sizeof(struct afpc_unix_privileges));
                 p += sizeof(struct afpc_unix_privileges);
                 memcpy(&current_basic->size, p, sizeof(uint64_t));

--- a/daemon/stateless_ipc.h
+++ b/daemon/stateless_ipc.h
@@ -499,8 +499,8 @@ struct afpsl_ipc_desktop_appl_response {
     uint32_t tag;
     uint32_t directory_id;
     uint32_t file_id;
-    uint32_t creation_date;
-    uint32_t modification_date;
+    int64_t creation_date;
+    int64_t modification_date;
     uint64_t data_fork_size;
     uint64_t resource_fork_size;
     char pathname[AFPC_MAX_NAME_BYTES];

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -229,14 +229,13 @@ to log in.  'status' will show you this also.
 
 The detection is done in order to deal with some details.
 
-### Mac OS 8
+### Mac OS 8 and earlier
 
-Netatalk Client has never been used with Mac OS 8, so there's no data.  You could do
-this with AFP over TCP/IP, but this could be difficult. Email me if you have any info.
+Netatalk Client has never been used with Mac OS 8 and earlier versions, so there's no data.
 
 ### Mac OS 9
 
-This speaks AFP 2.1, so this presents certain restrictions, such as:
+This speaks AFP 2.1 or 2.2, which presents certain restrictions, such as:
 
 - smaller limits on file and disk sizes (4GB)
   - creating files larger than 2GB isn't possible and isn't handled properly
@@ -246,7 +245,7 @@ This speaks AFP 2.1, so this presents certain restrictions, such as:
 - for directories, timestamps are reported as the mount times, which is what
   the Mac OS X client does.
 
-There is no proper charset conversions for filenames.  Patches accepted.
+Out of the classic Mac OS charsets, only MacRoman is supported presently.
 
 ### Mac OS X
 
@@ -291,9 +290,10 @@ being developed as a companion client to the Netatalk AFP server project.
 You must use Netatalk 2.0.4 or later because earlier versions of the server has
 broken Unix privilege support, notably when setting the execute bit.
 
-### LaCie devices
+### NAS devices by LaCie, Synology, and other vendors
 
-The LaCie device has an ARM processor in it, and speaks Netatalk.
+Historically, most NAS devices with AFP support have bundled Netatalk 2.x or 3.x,
+so they are expected to work with Netatalk Client.
 
 ## I. FUSE-specific bugs
 

--- a/include/netatalk-client/afpsl.h
+++ b/include/netatalk-client/afpsl.h
@@ -47,8 +47,8 @@ struct afp_sl_desktop_appl {
     uint32_t tag;
     uint32_t directory_id;
     uint32_t file_id;
-    uint32_t creation_date;
-    uint32_t modification_date;
+    int64_t creation_date;
+    int64_t modification_date;
     uint64_t data_fork_size;
     uint64_t resource_fork_size;
     char pathname[AFPC_MAX_NAME_BYTES];

--- a/include/netatalk-client/types.h
+++ b/include/netatalk-client/types.h
@@ -75,8 +75,8 @@ struct afpc_unix_privileges {
 
 struct afpc_file_info {
     char name[AFPC_MAX_NAME_BYTES];
-    unsigned int creation_date;
-    unsigned int modification_date;
+    int64_t creation_date;
+    int64_t modification_date;
     struct afpc_unix_privileges unixprivs;
     unsigned long long size;
 };

--- a/lib/afp_internal.h
+++ b/lib/afp_internal.h
@@ -2,6 +2,7 @@
 #define AFPCLIENT_INTERNAL_H
 
 #include <arpa/inet.h>
+#include <stdint.h>
 #include <pthread.h>
 #include <netdb.h>
 #include <sys/statvfs.h>
@@ -10,6 +11,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <netinet/in.h>
+#include <time.h>
 
 #include "netatalk-client/types.h"
 #include "netatalk-client/url.h"
@@ -39,9 +41,13 @@ struct afp_rx_buffer {
 struct afp_file_info {
     unsigned short attributes;
     unsigned int did;
-    unsigned int creation_date;
-    unsigned int modification_date;
-    unsigned int backup_date;
+    time_t creation_date;
+    time_t modification_date;
+    time_t backup_date;
+    /* The signed AFP date value 0x80000000 denotes an unset date. */
+    unsigned char creation_date_is_unset;
+    unsigned char modification_date_is_unset;
+    unsigned char backup_date_is_unset;
     unsigned int fileid;
     unsigned short offspring;
     unsigned char sync;
@@ -88,9 +94,9 @@ struct afp_volume {
     char flags;  /* This is from afpGetSrvrParms */
     unsigned short attributes; /* This is from VolOpen */
     unsigned short signature;  /* This is fixed or variable */
-    unsigned int creation_date;
-    unsigned int modification_date;
-    unsigned int backup_date;
+    time_t creation_date;
+    time_t modification_date;
+    time_t backup_date;
     struct statvfs stat;
     unsigned char mounted;
     unsigned char attached;
@@ -184,6 +190,10 @@ struct afp_server {
 
     /* This is the time we connected */
     time_t connect_time;
+
+    /* AFP 2.x timestamps use the server's local clock.  This is the
+     * server-minus-client offset calculated from FPGetSrvrParms. */
+    time_t time_offset;
 
     /* UAMs */
     unsigned int supported_uams;
@@ -672,9 +682,11 @@ int afp_removeextattr(struct afp_volume * volume, unsigned int dirid,
 char *afp_get_command_name(unsigned char code);
 
 /* From Netatalk's adouble.h. */
-#define AD_DATE_DELTA         946684800
-#define AD_DATE_FROM_UNIX(x)  (htonl((x) - AD_DATE_DELTA))
-#define AD_DATE_TO_UNIX(x)    (ntohl(x) + AD_DATE_DELTA)
+#define AD_DATE_DELTA 946684800LL
+
+/* AFP dates are signed, network-order, seconds from 2000-01-01. */
+time_t afp_date_to_unix(const struct afp_server *server, uint32_t date);
+uint32_t afp_date_from_unix(const struct afp_server *server, time_t date);
 
 void add_file_by_name(struct afp_file_info **base, const char *filename);
 

--- a/lib/lowlevel.c
+++ b/lib/lowlevel.c
@@ -241,6 +241,7 @@ int ll_open(struct afp_volume * volume,
     int ret;
     int dsi_ret;
     int rc;
+    unsigned int resource = fp->resource;
     unsigned char aflags = 0;
     /* O_RDONLY is 0, so we need to check access mode bits properly */
     int access_mode = flags & O_ACCMODE;
@@ -270,11 +271,6 @@ int ll_open(struct afp_volume * volume,
        O_APPEND
        O_NOATIME - we have no way to handle this anyway
     */
-    /*this will be used later for caching*/
-    fp->sync = (unsigned char)(flags & (O_SYNC));
-    fp->writable = (aflags & AFP_OPENFORK_ALLOWWRITE) ? 1 : 0;
-    fp->dirty = 0;
-
     /* Handle file creation properly when O_CREAT is set */
     if ((flags & O_CREAT) && (aflags & AFP_OPENFORK_ALLOWWRITE)) {
         if (flags & O_EXCL) {
@@ -305,7 +301,7 @@ int ll_open(struct afp_volume * volume,
     if (volume->server->using_version->av_number < 30) {
         switch (ll_get_directory_entry(volume, fp->basename, fp->did,
                                        kFPParentDirIDBit | kFPNodeIDBit |
-                                       (fp->resource ? kFPRsrcForkLenBit : kFPDataForkLenBit),
+                                       (resource ? kFPRsrcForkLenBit : kFPDataForkLenBit),
                                        0, fp)) {
         case kFPAccessDenied:
             ret = EACCES;
@@ -326,8 +322,8 @@ int ll_open(struct afp_volume * volume,
             goto error;
         }
 
-        if ((fp->resource ? (fp->resourcesize >= (AFP_MAX_AFP2_FILESIZE - 1)) :
-                (fp->size >= AFP_MAX_AFP2_FILESIZE - 1))) {
+        if (resource ? (fp->resourcesize >= (AFP_MAX_AFP2_FILESIZE - 1)) :
+                (fp->size >= AFP_MAX_AFP2_FILESIZE - 1)) {
             /* According to p.30, if the server doesn't support >4GB files
                and the file being opened is >4GB, then resourcesize or size
                will return 4GB.  How can it return 4GB in 32 bits?  I
@@ -336,9 +332,19 @@ int ll_open(struct afp_volume * volume,
             ret = EOVERFLOW;
             goto error;
         }
+
+        /* parse_reply_block() clears the complete result structure.  Keep
+         * the caller's fork type: resource forks need it for both the AFP
+         * open and appledouble_close(), which unregisters the open fork. */
+        fp->resource = resource;
     }
 
-    dsi_ret = afp_openfork(volume, fp->resource ? 1 : 0, fp->did,
+    /* These are client-side open state, not AFP reply parameters.  Set them
+     * after the AFP 2.x parameter query, whose reply parser clears fp. */
+    fp->sync = (unsigned char)(flags & O_SYNC);
+    fp->writable = (aflags & AFP_OPENFORK_ALLOWWRITE) ? 1 : 0;
+    fp->dirty = 0;
+    dsi_ret = afp_openfork(volume, resource ? 1 : 0, fp->did,
                            aflags, fp->basename, fp);
 
     switch (dsi_ret) {
@@ -389,7 +395,7 @@ int ll_open(struct afp_volume * volume,
     /* Handle O_TRUNC flag: truncate existing files (but not newly created ones) */
     /* Skip truncation if O_CREAT was set (file just created, already empty) */
     if ((flags & O_TRUNC) && !(flags & O_CREAT)) {
-        ret = ll_zero_file(volume, fp->forkid, fp->resource);
+        ret = ll_zero_file(volume, fp->forkid, resource);
 
         if (ret != 0) {
             goto error;

--- a/lib/lowlevel.c
+++ b/lib/lowlevel.c
@@ -502,12 +502,11 @@ int ll_read(struct afp_volume * volume,
             break;
         }
 
+        /* A short successful AFP read is not EOF.  In particular, Classic
+         * Mac OS AFP servers may cap a kFPNoErr reply below the requested
+         * count. Continue from the returned offset; only an explicit
+         * kFPEOFErr above establishes EOF. */
         totalsize += buffer.size;
-
-        if ((size_t)buffer.size < chunksize) {
-            *eof = 1;
-            break;
-        }
     }
 
 done:

--- a/lib/lowlevel.c
+++ b/lib/lowlevel.c
@@ -667,6 +667,20 @@ int ll_readdir(struct afp_volume * volume, const char *path,
             unsigned int temp_permissions = p->unixprivs.permissions;
             set_nonunix_perms(&temp_permissions, p);
             p->unixprivs.permissions = temp_permissions;
+
+            /* Some AFP 2.x servers return the unset-date sentinel for
+             * directory times.  Preserve every real server timestamp; only
+             * use the connection time where the protocol says no date exists.
+             */
+            if (p->isdir) {
+                if (p->creation_date_is_unset) {
+                    p->creation_date = volume->server->connect_time;
+                }
+
+                if (p->modification_date_is_unset) {
+                    p->modification_date = volume->server->connect_time;
+                }
+            }
         }
     }
 
@@ -685,8 +699,8 @@ int ll_getattr(struct afp_volume * volume, const char *path, struct stat *stbuf,
     int rc;
     unsigned int filebitmap, dirbitmap;
     char basename[AFPC_MAX_NAME_BYTES];
-    unsigned int creation_date;
-    unsigned int modification_date;
+    time_t creation_date;
+    time_t modification_date;
     memset(stbuf, 0, sizeof(struct stat));
 
     if ((volume->server) &&

--- a/lib/midlevel.c
+++ b/lib/midlevel.c
@@ -273,7 +273,7 @@ static int map_filebase_uidgid_to_client(struct afp_volume * volume,
     return 0;
 }
 
-static void update_time(unsigned int * newtime)
+static void update_time(time_t *newtime)
 {
     struct timeval tv;
     gettimeofday(&tv, NULL);

--- a/lib/proto_directory.c
+++ b/lib/proto_directory.c
@@ -8,6 +8,7 @@
 
 #include <string.h>
 #include <stdlib.h>
+#include <limits.h>
 
 #include "afp_internal.h"
 #include "afp_protocol.h"
@@ -28,7 +29,11 @@ typedef struct ext2_reply_entry {
     uint8_t pad;
 } __attribute__((__packed__)) ext2_reply_entry;
 
-#define AFP_ENUMERATE_MAX_REPLY_SIZE 32768
+/* FPEnumerate and FPEnumerateExt carry MaxReplySize in a legacy signed
+ * 16-bit field.  Classic AFP servers reject 0x8000 and above, so keep the
+ * common cap within INT16_MAX even though the local receive buffer is larger.
+ */
+#define AFP_ENUMERATE_MAX_REPLY_SIZE INT16_MAX
 
 static unsigned int enumerate_max_reply_size(struct afp_server *server)
 {

--- a/lib/proto_files.c
+++ b/lib/proto_files.c
@@ -82,7 +82,7 @@ static int afp_setparms_lowlevel(struct afp_volume * volume,
 
     if (bitmap & kFPCreateDateBit) {
         unsigned int *date = (void *) p;
-        *date = AD_DATE_FROM_UNIX(fp->creation_date);
+        *date = afp_date_from_unix(volume->server, fp->creation_date);
 #if 0
         result_bitmap |= kFPCreateDateBit;
 #endif
@@ -91,7 +91,7 @@ static int afp_setparms_lowlevel(struct afp_volume * volume,
 
     if (bitmap & kFPModDateBit) {
         unsigned int *date = (void *) p;
-        *date = AD_DATE_FROM_UNIX(fp->modification_date);
+        *date = afp_date_from_unix(volume->server, fp->modification_date);
 #if 0
         result_bitmap |= kFPModDateBit;
 #endif
@@ -100,7 +100,7 @@ static int afp_setparms_lowlevel(struct afp_volume * volume,
 
     if (bitmap & kFPBackupDateBit) {
         unsigned int *date = (void *) p;
-        *date = AD_DATE_FROM_UNIX(fp->backup_date);
+        *date = afp_date_from_unix(volume->server, fp->backup_date);
         p += 4;
 #if 0
         result_bitmap |= kFPBackupDateBit;

--- a/lib/proto_replyblock.c
+++ b/lib/proto_replyblock.c
@@ -144,7 +144,9 @@ int parse_reply_block(struct afp_server *server _U_,
             return -1;
         }
 
-        filecur->creation_date = AD_DATE_TO_UNIX(*date);
+        filecur->creation_date = afp_date_to_unix(server, *date);
+        filecur->creation_date_is_unset =
+            ntohl(*date) == UINT32_C(0x80000000);
         p2 += 4;
     }
 
@@ -155,7 +157,9 @@ int parse_reply_block(struct afp_server *server _U_,
             return -1;
         }
 
-        filecur->modification_date = AD_DATE_TO_UNIX(*date);
+        filecur->modification_date = afp_date_to_unix(server, *date);
+        filecur->modification_date_is_unset =
+            ntohl(*date) == UINT32_C(0x80000000);
         p2 += 4;
     }
 
@@ -166,7 +170,9 @@ int parse_reply_block(struct afp_server *server _U_,
             return -1;
         }
 
-        filecur->backup_date = AD_DATE_TO_UNIX(*date);
+        filecur->backup_date = afp_date_to_unix(server, *date);
+        filecur->backup_date_is_unset =
+            ntohl(*date) == UINT32_C(0x80000000);
         p2 += 4;
     }
 

--- a/lib/proto_server.c
+++ b/lib/proto_server.c
@@ -8,6 +8,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 #include "afp_internal.h"
 #include "afp_protocol.h"
@@ -16,6 +17,44 @@
 #include "dsi.h"
 #include "dsi_protocol.h"
 #include "utils.h"
+
+static int server_uses_local_time(const struct afp_server *server)
+{
+    return server && server->using_version
+           && server->using_version->av_number < 30;
+}
+
+time_t afp_date_to_unix(const struct afp_server *server, uint32_t date)
+{
+    uint32_t wire_seconds = ntohl(date);
+    int64_t seconds = wire_seconds;
+
+    /* AFP defines this field as a signed long.  Do the sign extension before
+     * applying the 2000 epoch; 0x80000000 is the protocol's unset-date
+     * sentinel, not a date in 2068. */
+    if (wire_seconds & UINT32_C(0x80000000)) {
+        seconds -= INT64_C(0x100000000);
+    }
+
+    seconds += AD_DATE_DELTA;
+
+    if (server_uses_local_time(server)) {
+        seconds -= server->time_offset;
+    }
+
+    return (time_t)seconds;
+}
+
+uint32_t afp_date_from_unix(const struct afp_server *server, time_t date)
+{
+    int64_t seconds = (int64_t)date - AD_DATE_DELTA;
+
+    if (server_uses_local_time(server)) {
+        seconds += server->time_offset;
+    }
+
+    return htonl((uint32_t)seconds);
+}
 
 int afp_getsrvrparms(struct afp_server *server)
 {
@@ -53,7 +92,16 @@ int afp_getsrvrparms_reply(struct afp_server *server, char * msg,
         return -1;
     }
 
-    server->connect_time = AD_DATE_TO_UNIX(afp_getsrvparm_reply->time);
+    server->connect_time = afp_date_to_unix(NULL, afp_getsrvparm_reply->time);
+
+    if (server_uses_local_time(server)) {
+        /* AFP 2.x dates use the server's local clock.  Express subsequent
+         * dates on the client's Unix time base, using the server time sampled
+         * in this reply. */
+        server->time_offset = server->connect_time - time(NULL);
+        server->connect_time -= server->time_offset;
+    }
+
     server->num_volumes = afp_getsrvparm_reply->numvolumes;
     newvolumes = malloc(afp_getsrvparm_reply->numvolumes * sizeof(
                             struct afp_volume));

--- a/lib/proto_volume.c
+++ b/lib/proto_volume.c
@@ -43,19 +43,19 @@ static int parse_volbitmap_reply(struct afp_server *server _U_,
 
     if (bitmap & kFPVolCreateDateBit) {
         unsigned int *date = (void *) p;
-        tmpvol->creation_date = AD_DATE_TO_UNIX(*date);
+        tmpvol->creation_date = afp_date_to_unix(server, *date);
         p += 4;
     }
 
     if (bitmap & kFPVolModDateBit) {
         unsigned int *date = (void *) p;
-        tmpvol->modification_date = AD_DATE_TO_UNIX(*date);
+        tmpvol->modification_date = afp_date_to_unix(server, *date);
         p += 4;
     }
 
     if (bitmap & kFPVolBackupDateBit) {
         unsigned int *date = (void *) p;
-        tmpvol->backup_date = AD_DATE_TO_UNIX(*date);
+        tmpvol->backup_date = afp_date_to_unix(server, *date);
         p += 4;
     }
 

--- a/lib/server.c
+++ b/lib/server.c
@@ -90,7 +90,7 @@ struct afp_server *afp_server_complete_connection(
     }
 
     /* If we haven't gotten a proper date back, so set it to the connect time. */
-    if (server->connect_time == AD_DATE_TO_UNIX(0)) {
+    if (server->connect_time == afp_date_to_unix(NULL, 0)) {
         struct timeval tv;
         gettimeofday(&tv, NULL);
         server->connect_time = tv.tv_sec;

--- a/test/test_protocol_replies.c
+++ b/test/test_protocol_replies.c
@@ -32,6 +32,8 @@ int main(int argc, char **argv)
     struct afp_comment comment;
     struct afp_icon_info icon_info;
     struct afp_appl appl;
+    struct afp_file_info file_info;
+    struct afp_versions afp2 = { "AFP2.2", 22 };
     struct {
         struct dsi_header header __attribute__((__packed__));
         uint16_t bitmap;
@@ -40,6 +42,24 @@ int main(int argc, char **argv)
     } __attribute__((__packed__)) xattr_reply;
     test_tap_init(argc, argv);
     memset(&server, 0, sizeof(server));
+    CHECK(afp_date_to_unix(NULL, htonl(UINT32_C(0x80000000)))
+          == (time_t)(AD_DATE_DELTA - INT64_C(0x80000000)));
+    server.using_version = &afp2;
+    server.time_offset = 3600;
+    CHECK(afp_date_to_unix(&server, htonl(UINT32_C(0x80000000)))
+          == (time_t)(AD_DATE_DELTA - INT64_C(0x80000000) - 3600));
+    CHECK(afp_date_to_unix(&server,
+                           afp_date_from_unix(&server, (time_t)1700000000))
+          == (time_t)1700000000);
+    memset(&file_info, 0, sizeof(file_info));
+    wire32 = htonl(UINT32_C(0x80000000));
+    CHECK(parse_reply_block(&server, (const char *)&wire32, sizeof(wire32),
+                            0, kFPModDateBit, 0, &file_info) == 0);
+    CHECK(file_info.modification_date
+          == (time_t)(AD_DATE_DELTA - INT64_C(0x80000000) - 3600));
+    CHECK(file_info.modification_date_is_unset);
+    server.using_version = NULL;
+    server.time_offset = 0;
     CHECK(!afp_server_has_valid_signature(&server));
     server.flags = kSrvrSig;
     CHECK(!afp_server_has_valid_signature(&server));


### PR DESCRIPTION
**use 16 bit field for enumation for AFP 2.x compatibility**: Limit FPEnumerate's legacy 16-bit MaxReplySize to INT16_MAX so classic AFP servers do not receive 0x8000.

**preserve AFP 2.x resource fork state**: AFP 2.x parameter replies clear afp_file_info, losing the resource fork tag and client-side open state. Preserve the tag across the lookup and initialize the client state afterwards so resource forks close and unregister correctly.

**don't error out on POSIX failures**: unlike AFP 3.x the earlier protocol doesn't handle POSIX operations like chmod, we should file a log message but not flag a file transfer as failed (ex. `Failed to chmod file /upload2/Disk Copy: -78 (Function not implemented)`)

**handle short successful reads**: Classic Mac OS AFP servers can return a short kFPNoErr response instead of EOF. Continue reading until kFPEOFErr rather than treating the short reply as end of file, and reject downloads whose byte count differs from the remote data fork size.

**decode signed timestamps correctly for AFP 2.x sessions**: AFP date fields are signed seconds relative to 2000-01-01. Decode them before applying the epoch and retain the AFP 2.x server-to-client clock offset from FPGetSrvrParms. Use the unset-date sentinel only as a directory fallback, preserving real timestamps.

Widen public and IPC date fields to retain valid pre-2000 values and add protocol coverage for signed values, the offset, and the sentinel.

also adds some useful debug logging