### PR TITLE
uams: fix DHX MPI ownership

### DIFF
--- a/lib/uams_dhx.c
+++ b/lib/uams_dhx.c
@@ -73,22 +73,18 @@ int dhx_login(struct afp_server *server, char *username, char *passwd)
     unsigned char Ra_binary[32], K_binary[16];
     int ai_len, ret;
     const int Ma_len = 16, Mb_len = 16, nonce_len = 16;
-    gcry_mpi_t p, g, Ra, Ma, Mb, K, nonce, new_nonce;
+    gcry_mpi_t p = NULL, g = NULL, Ra = NULL;
+    gcry_mpi_t Ma, Mb = NULL, K, nonce = NULL, new_nonce;
     size_t len;
     struct afp_rx_buffer rbuf;
     unsigned short ID;
     gcry_cipher_hd_t ctx;
     gcry_error_t ctxerror;
     rbuf.data = NULL;
-    /* Initialize all gcry_mpi_t variables, so they can all be uninitialized
-     * in an orderly manner later. */
-    p = gcry_mpi_new(0);
-    g = gcry_mpi_new(0);
-    Ra = gcry_mpi_new(0);
+    /* Allocate MPIs which are written in place; gcry_mpi_scan() creates
+     * the remaining MPIs. */
     Ma = gcry_mpi_new(0);
-    Mb = gcry_mpi_new(0);
     K = gcry_mpi_new(0);
-    nonce = gcry_mpi_new(0);
     new_nonce = gcry_mpi_new(0);
     /* Get p and g into a form that libgcrypt can use */
     gcry_mpi_scan(&p, GCRYMPI_FMT_USG, p_binary, sizeof(p_binary), NULL);
@@ -351,7 +347,8 @@ int dhx_passwd(struct afp_server *server,
     int ai_len, ret;
     const int Ma_len = 16, Mb_len = 16, nonce_len = 16;
     const int changepw_plaintext_len = nonce_len + 64 + 64; /* 144 bytes */
-    gcry_mpi_t p, g, Ra, Ma, Mb, K, nonce, new_nonce;
+    gcry_mpi_t p = NULL, g = NULL, Ra = NULL;
+    gcry_mpi_t Ma, Mb = NULL, K, nonce = NULL, new_nonce;
     size_t len;
     struct afp_rx_buffer rbuf;
     unsigned short ID;
@@ -360,14 +357,10 @@ int dhx_passwd(struct afp_server *server,
     int afp_version = server->using_version->av_number;
     int username_overhead;
     rbuf.data = NULL;
-    /* Initialize all gcry_mpi_t variables */
-    p = gcry_mpi_new(0);
-    g = gcry_mpi_new(0);
-    Ra = gcry_mpi_new(0);
+    /* Allocate MPIs which are written in place; gcry_mpi_scan() creates
+     * the remaining MPIs. */
     Ma = gcry_mpi_new(0);
-    Mb = gcry_mpi_new(0);
     K = gcry_mpi_new(0);
-    nonce = gcry_mpi_new(0);
     new_nonce = gcry_mpi_new(0);
     /* Get p and g into a form that libgcrypt can use */
     gcry_mpi_scan(&p, GCRYMPI_FMT_USG, p_binary, sizeof(p_binary), NULL);

--- a/lib/uams_dhx2.c
+++ b/lib/uams_dhx2.c
@@ -36,7 +36,8 @@ int dhx2_login(struct afp_server *server, char *username, char *passwd)
         assert("libgcrypt initialization failed");
     }
 
-    gcry_mpi_t p, g, Ma, Mb, Ra, K, nonce, new_nonce;
+    gcry_mpi_t p = NULL, g = NULL, Mb = NULL, Ra = NULL, nonce = NULL;
+    gcry_mpi_t Ma, K, new_nonce;
     char *ai = NULL, *d, *Ra_binary = NULL, *K_binary = NULL;
     char *K_hash = NULL, nonce_binary[16];
     int ai_len, hash_len, ret;
@@ -47,13 +48,10 @@ int dhx2_login(struct afp_server *server, char *username, char *passwd)
     gcry_cipher_hd_t ctx;
     gcry_error_t ctxerror;
     rbuf.data = NULL;
-    p = gcry_mpi_new(0);
-    g = gcry_mpi_new(0);
-    Ra = gcry_mpi_new(0);
+    /* Allocate MPIs which are written in place; gcry_mpi_scan() creates
+     * the remaining MPIs. */
     Ma = gcry_mpi_new(0);
-    Mb = gcry_mpi_new(0);
     K = gcry_mpi_new(0);
-    nonce = gcry_mpi_new(0);
     new_nonce = gcry_mpi_new(0);
     /* The DHX2 Pascal username must end on an even AFP-packet boundary. */
     ai_len = (int)strnlen(username, AFP_MAX_USERNAME_LEN) + 1;
@@ -186,7 +184,7 @@ int dhx2_login(struct afp_server *server, char *username, char *passwd)
     }
 
     /* Set the initialization vector for client->server transfer. */
-    ctxerror = gcry_cipher_setiv(ctx, dhx_c2siv, sizeof(dhx_s2civ));
+    ctxerror = gcry_cipher_setiv(ctx, dhx_c2siv, sizeof(dhx_c2siv));
 
     if (gcry_err_code(ctxerror) != GPG_ERR_NO_ERROR) {
         goto dhx2_fail;
@@ -280,6 +278,9 @@ int dhx2_login(struct afp_server *server, char *username, char *passwd)
         goto dhx2_fail;
     }
 
+    /* This MPI is no longer needed; the next scan allocates a new one. */
+    gcry_mpi_release(nonce);
+    nonce = NULL;
     d += sizeof(nonce_binary);
     /* Pull the server's nonce value into an gcry_mpi_t. */
     gcry_mpi_scan(&nonce, GCRYMPI_FMT_USG, d, sizeof(nonce_binary), NULL);
@@ -313,7 +314,7 @@ int dhx2_login(struct afp_server *server, char *username, char *passwd)
     /* Copy the user's password into the plaintext buffer. */
     strlcpy(d, passwd, 256);
     /* Set the initialization vector for client->server transfer. */
-    ctxerror = gcry_cipher_setiv(ctx, dhx_c2siv, sizeof(dhx_s2civ));
+    ctxerror = gcry_cipher_setiv(ctx, dhx_c2siv, sizeof(dhx_c2siv));
 
     if (gcry_err_code(ctxerror) != GPG_ERR_NO_ERROR) {
         goto dhx2_fail;
@@ -380,8 +381,9 @@ int dhx2_passwd(struct afp_server *server,
         assert("libgcrypt initialization failed");
     }
 
-    gcry_mpi_t p, g, Ma, Mb, Rb, K, clientNonce, new_clientNonce;
-    gcry_mpi_t serverNonce, new_serverNonce;
+    gcry_mpi_t p = NULL, g = NULL, Ma = NULL, Rb = NULL;
+    gcry_mpi_t clientNonce = NULL, serverNonce = NULL;
+    gcry_mpi_t Mb, K, new_clientNonce, new_serverNonce;
     char *ai = NULL, *d, *Rb_binary = NULL, *K_binary = NULL;
     char *K_hash = NULL, nonce_binary[16];
     int ai_len, hash_len, ret;
@@ -395,15 +397,11 @@ int dhx2_passwd(struct afp_server *server,
     int afp_version = server->using_version->av_number;
     int have_ctx = 0;
     rbuf.data = NULL;
-    p = gcry_mpi_new(0);
-    g = gcry_mpi_new(0);
-    Rb = gcry_mpi_new(0);
-    Ma = gcry_mpi_new(0);
+    /* Allocate MPIs which are written in place; gcry_mpi_scan() creates
+     * the remaining MPIs. */
     Mb = gcry_mpi_new(0);
     K = gcry_mpi_new(0);
-    clientNonce = gcry_mpi_new(0);
     new_clientNonce = gcry_mpi_new(0);
-    serverNonce = gcry_mpi_new(0);
     new_serverNonce = gcry_mpi_new(0);
 
     /*
@@ -625,8 +623,7 @@ int dhx2_passwd(struct afp_server *server,
     gcry_mpi_scan(&clientNonce, GCRYMPI_FMT_USG, nonce_binary,
                   sizeof(nonce_binary), NULL);
     gcry_mpi_add_ui(new_clientNonce, clientNonce, 1);
-    gcry_mpi_t retNonce;
-    retNonce = gcry_mpi_new(0);
+    gcry_mpi_t retNonce = NULL;
     gcry_mpi_scan(&retNonce, GCRYMPI_FMT_USG, d, 16, NULL);
 
     if (gcry_mpi_cmp(new_clientNonce, retNonce) != 0) {


### PR DESCRIPTION
gcry_mpi_scan() allocates its output MPI, so stop preallocating values that are subsequently scanned over. Keep explicit allocations only for MPI values written in place, and initialize scan targets to NULL for cleanup.

Also use the client-to-server IV's size for both DHX2 client-to-server cipher setup calls.