### PR TITLE
enforce -Werror compiler flag and fix compiler warnings

### DIFF
--- a/cmdline/cmdline_main.c
+++ b/cmdline/cmdline_main.c
@@ -457,7 +457,8 @@ void earlyexit_handler(int signum)
 
     if (interrupt_count > 0) {
         const char msg[] = "\nImmediate exit requested.\n";
-        write(STDERR_FILENO, msg, sizeof(msg) - 1);
+        ssize_t bytes_written = write(STDERR_FILENO, msg, sizeof(msg) - 1);
+        (void)bytes_written;
         tty_reset(STDIN_FILENO);
         _exit(1);
     }

--- a/daemon/stateless.c
+++ b/daemon/stateless.c
@@ -79,6 +79,18 @@ static int send_command(unsigned int len, const char *data, unsigned int num);
 static int read_answer(void);
 static int ipc_handshake(void);
 
+/* After fork(), only use async-signal-safe functions before _exit(). */
+static void report_exec_failure(int fd, int child_errno)
+{
+    ssize_t bytes_written;
+
+    do {
+        bytes_written = write(fd, &child_errno, sizeof(child_errno));
+    } while (bytes_written < 0 && errno == EINTR);
+
+    _exit(1);
+}
+
 static int wire_path_length(const char *path, size_t *len)
 {
     return afpc_path_validate(path, AFPC_MAX_UTF8_PATH_BYTES, len);
@@ -333,8 +345,7 @@ static int start_afpsld(void)
         execv(filename, argv);
         /* exec failed */
         child_errno = errno;
-        (void) write(error_pipe[1], &child_errno, sizeof(child_errno));
-        _exit(1);
+        report_exec_failure(error_pipe[1], child_errno);
     }
 
     close(error_pipe[1]);
@@ -351,9 +362,16 @@ static int start_afpsld(void)
         return -1;
     }
 
-    if (bytes_read > 0) {
+    if (bytes_read == (ssize_t)sizeof(child_errno)) {
         (void) waitpid(child, NULL, 0);
         stateless_log_errno(LOG_ERR, "Could not execute afpsld", child_errno);
+        return -1;
+    }
+
+    if (bytes_read != 0) {
+        (void) waitpid(child, NULL, 0);
+        stateless_log_message(LOG_ERR,
+                              "Invalid afpsld startup status from child");
         return -1;
     }
 

--- a/fuse/client.c
+++ b/fuse/client.c
@@ -80,50 +80,6 @@ static void clear_outgoing_mount_url_path(void)
     afpc_path_clear(&request->url.path);
 }
 
-static int write_all(int fd, const void *buffer, size_t length)
-{
-    const char *cursor = buffer;
-
-    while (length != 0) {
-        ssize_t written = write(fd, cursor, length);
-
-        if (written < 0 && errno == EINTR) {
-            continue;
-        }
-
-        if (written <= 0) {
-            return -1;
-        }
-
-        cursor += written;
-        length -= (size_t)written;
-    }
-
-    return 0;
-}
-
-static int read_all(int fd, void *buffer, size_t length)
-{
-    char *cursor = buffer;
-
-    while (length != 0) {
-        ssize_t received = read(fd, cursor, length);
-
-        if (received < 0 && errno == EINTR) {
-            continue;
-        }
-
-        if (received <= 0) {
-            return -1;
-        }
-
-        cursor += received;
-        length -= (size_t)received;
-    }
-
-    return 0;
-}
-
 /* Log handler that filters by log level */
 static void client_log_for_client(void *priv _U_,
                                   enum logtypes logtype _U_,
@@ -314,19 +270,19 @@ static int start_afpfsd(const char *mountpoint, const char *volumename)
     snprintf(req.volumename, sizeof(req.volumename), "%s",
              volumename ? volumename : "");
 
-    if (write_all(sock, &command, sizeof(command)) != 0) {
+    if (afpfsd_ipc_write_all(sock, &command, sizeof(command)) != 0) {
         close(sock);
         return -1;
     }
 
-    if (write_all(sock, &req, sizeof(req)) != 0) {
+    if (afpfsd_ipc_write_all(sock, &req, sizeof(req)) != 0) {
         close(sock);
         return -1;
     }
 
     /* Wait for response */
     if (wait_readable(sock) != 0
-            || read_all(sock, &result, sizeof(result)) != 0) {
+            || afpfsd_ipc_read_all(sock, &result, sizeof(result)) != 0) {
         close(sock);
         return -1;
     }
@@ -532,7 +488,7 @@ static int copy_secret(char *dst, size_t dstlen, const char *src,
 
 static int send_command(int sock, char * msg, int len)
 {
-    return write_all(sock, msg, (size_t)len);
+    return afpfsd_ipc_write_all(sock, msg, (size_t)len);
 }
 
 static int do_exit(int argc _U_, char **argv _U_)

--- a/fuse/commands.c
+++ b/fuse/commands.c
@@ -851,9 +851,9 @@ static void *process_command_thread(void * other)
     response.len = fuse_client_response_len(c);
     bcopy(&response, tosend, sizeof(response));
     bcopy(c->client_string, tosend + sizeof(response), response.len);
-    ret = write(c->fd, tosend, sizeof(response) + response.len);
 
-    if (ret < 0) {
+    if (afpfsd_ipc_write_all(c->fd, tosend,
+                             sizeof(response) + response.len) < 0) {
         perror("Writing");
     }
 

--- a/fuse/daemon.c
+++ b/fuse/daemon.c
@@ -237,6 +237,30 @@ static int append_text(char *text, size_t size, int *pos, const char *src)
     return 0;
 }
 
+static int send_response(int client_fd, char result, const void *data,
+                         size_t data_len)
+{
+    if (data_len > UINT_MAX) {
+        return -1;
+    }
+
+    struct afpfsd_ipc_response response = {
+        .result = result,
+        .len = (unsigned int)data_len,
+    };
+
+    if (afpfsd_ipc_write_all(client_fd, &response, sizeof(response)) < 0) {
+        return -1;
+    }
+
+    if (data_len != 0
+            && afpfsd_ipc_write_all(client_fd, data, data_len) < 0) {
+        return -1;
+    }
+
+    return 0;
+}
+
 /* Send exit command to a socket path */
 static void send_exit_to_socket(const char *socket_path)
 {
@@ -261,7 +285,11 @@ static void send_exit_to_socket(const char *socket_path)
     if (connect(sock, (struct sockaddr *)&sa,
                 sizeof(sa.sun_family) + len + 1) == 0) {
         unsigned char cmd = AFPFSD_IPC_COMMAND_EXIT;
-        (void)write(sock, &cmd, 1);
+
+        if (afpfsd_ipc_write_all(sock, &cmd, sizeof(cmd)) < 0) {
+            log_for_client(NULL, AFPFSD, LOG_WARNING,
+                           "Could not send exit command to child daemon");
+        }
     }
 
 out:
@@ -281,7 +309,6 @@ static struct manager_child *find_child_by_mountpoint(const char *mountpoint,
 
     /* Not found - send error if client_fd provided */
     if (client_fd >= 0) {
-        struct afpfsd_ipc_response response;
         char text[1024];
         int len = sizeof(text);
         int pos = 0;
@@ -297,10 +324,12 @@ static struct manager_child *find_child_by_mountpoint(const char *mountpoint,
         append_text(text, sizeof(text), &pos, "No mount found at ");
         append_text(text, sizeof(text), &pos, safe_mountpoint);
         append_text(text, sizeof(text), &pos, "\n");
-        response.result = AFPFSD_IPC_RESULT_ERROR;
-        response.len = strlen(text);
-        (void)write(client_fd, &response, sizeof(response));
-        (void)write(client_fd, text, response.len);
+
+        if (send_response(client_fd, AFPFSD_IPC_RESULT_ERROR, text,
+                          strlen(text)) < 0) {
+            log_for_client(NULL, AFPFSD, LOG_WARNING,
+                           "Failed to send mount-not-found response to client");
+        }
     }
 
     return NULL;
@@ -314,11 +343,11 @@ static int connect_to_child_socket(const char *socket_path,
     int child_sock = socket(AF_UNIX, SOCK_STREAM, 0);
 
     if (child_sock < 0) {
-        if (client_fd >= 0) {
-            struct afpfsd_ipc_response response;
-            response.result = AFPFSD_IPC_RESULT_ERROR;
-            response.len = 0;
-            (void)write(client_fd, &response, sizeof(response));
+        if (client_fd >= 0 &&
+                send_response(client_fd, AFPFSD_IPC_RESULT_ERROR,
+                              NULL, 0) < 0) {
+            log_for_client(NULL, AFPFSD, LOG_WARNING,
+                           "Failed to send socket error response to client");
         }
 
         return -1;
@@ -332,7 +361,6 @@ static int connect_to_child_socket(const char *socket_path,
     if (strlcpy(child_addr.sun_path, socket_path,
                 sizeof(child_addr.sun_path)) >= sizeof(child_addr.sun_path)) {
         if (client_fd >= 0) {
-            struct afpfsd_ipc_response response;
             char text[1024];
             char safe_mountpoint[PATH_MAX * 4];
             int pos = 0;
@@ -343,10 +371,12 @@ static int connect_to_child_socket(const char *socket_path,
                         "Socket path too long for ");
             append_text(text, sizeof(text), &pos, safe_mountpoint);
             append_text(text, sizeof(text), &pos, "\n");
-            response.result = AFPFSD_IPC_RESULT_ERROR;
-            response.len = strlen(text);
-            (void)write(client_fd, &response, sizeof(response));
-            (void)write(client_fd, text, response.len);
+
+            if (send_response(client_fd, AFPFSD_IPC_RESULT_ERROR, text,
+                              strlen(text)) < 0) {
+                log_for_client(NULL, AFPFSD, LOG_WARNING,
+                               "Failed to send socket-path error response to client");
+            }
         }
 
         close(child_sock);
@@ -356,7 +386,6 @@ static int connect_to_child_socket(const char *socket_path,
     if (connect(child_sock, (struct sockaddr *)&child_addr,
                 sizeof(child_addr.sun_family) + strlen(child_addr.sun_path) + 1) < 0) {
         if (client_fd >= 0) {
-            struct afpfsd_ipc_response response;
             char text[1024];
             int len = sizeof(text);
             int pos = 0;
@@ -367,10 +396,12 @@ static int connect_to_child_socket(const char *socket_path,
 
             snprintf(text + pos, sizeof(text) - pos,
                      "Could not connect to daemon\n");
-            response.result = AFPFSD_IPC_RESULT_ERROR;
-            response.len = strlen(text);
-            (void)write(client_fd, &response, sizeof(response));
-            (void)write(client_fd, text, response.len);
+
+            if (send_response(client_fd, AFPFSD_IPC_RESULT_ERROR, text,
+                              strlen(text)) < 0) {
+                log_for_client(NULL, AFPFSD, LOG_WARNING,
+                               "Failed to send connection error response to client");
+            }
         }
 
         close(child_sock);
@@ -384,62 +415,45 @@ static int connect_to_child_socket(const char *socket_path,
 static int forward_child_response(int child_sock, int client_fd)
 {
     struct afpfsd_ipc_response response;
+    char *buffer = NULL;
 
-    if (read(child_sock, &response, sizeof(response)) != sizeof(response)) {
-        response.result = AFPFSD_IPC_RESULT_ERROR;
-        response.len = 0;
-
-        if (write(client_fd, &response, sizeof(response)) != sizeof(response)) {
-            log_for_client(NULL, AFPFSD, LOG_WARNING,
-                           "Failed to send error response to client");
-        }
-
-        return -1;
+    if (afpfsd_ipc_read_all(child_sock, &response, sizeof(response)) < 0) {
+        goto child_error;
     }
 
     if (response.len > AFPFSD_IPC_MAX_RESPONSE) {
         log_for_client(NULL, AFPFSD, LOG_WARNING,
                        "Child response exceeds maximum allowed size");
-        response.result = AFPFSD_IPC_RESULT_ERROR;
-        response.len = 0;
-
-        if (write(client_fd, &response, sizeof(response)) != sizeof(response)) {
-            log_for_client(NULL, AFPFSD, LOG_WARNING,
-                           "Failed to send error response to client");
-        }
-
-        return -1;
-    }
-
-    if (write(client_fd, &response, sizeof(response)) != sizeof(response)) {
-        log_for_client(NULL, AFPFSD, LOG_WARNING,
-                       "Failed to forward response header to client");
-        return -1;
+        goto child_error;
     }
 
     if (response.len > 0) {
-        char *buffer = malloc(response.len);
+        buffer = malloc(response.len);
 
-        if (buffer) {
-            ssize_t bytes_read = read(child_sock, buffer, response.len);
-
-            if (bytes_read > 0) {
-                ssize_t bytes_written = write(client_fd, buffer, bytes_read);
-
-                if (bytes_written != bytes_read) {
-                    log_for_client(NULL, AFPFSD, LOG_WARNING,
-                                   "Failed to forward response data to client (%zd/%zd bytes)",
-                                   bytes_written < 0 ? 0 : bytes_written, bytes_read);
-                    free(buffer);
-                    return -1;
-                }
-            }
-
+        if (!buffer || afpfsd_ipc_read_all(child_sock, buffer,
+                                           response.len) < 0) {
             free(buffer);
+            goto child_error;
         }
     }
 
+    if (send_response(client_fd, response.result, buffer, response.len) < 0) {
+        log_for_client(NULL, AFPFSD, LOG_WARNING,
+                       "Failed to forward response to client");
+        free(buffer);
+        return -1;
+    }
+
+    free(buffer);
     return 0;
+child_error:
+
+    if (send_response(client_fd, AFPFSD_IPC_RESULT_ERROR, NULL, 0) < 0) {
+        log_for_client(NULL, AFPFSD, LOG_WARNING,
+                       "Failed to send error response to client");
+    }
+
+    return -1;
 }
 
 static void add_child(pid_t pid, const char *socket_id, const char *mountpoint,
@@ -577,76 +591,88 @@ static int start_mount_daemon(char *socket_id, const char *mountpoint,
 static int handle_manager_command(int client_fd)
 {
     unsigned char command;
-    ssize_t n = read(client_fd, &command, 1);
 
-    if (n <= 0) {
+    if (afpfsd_ipc_read_all(client_fd, &command, sizeof(command)) < 0) {
         return -1;
     }
 
     switch (command) {
     case AFPFSD_IPC_COMMAND_SPAWN_MOUNT: {
         struct afpfsd_ipc_spawn_mount_request req;
-        n = read(client_fd, &req, sizeof(req));
+        unsigned char result = AFPFSD_IPC_RESULT_ERROR;
+        int command_result = 0;
+        int request_is_valid;
 
-        if (n != sizeof(req)) {
+        if (afpfsd_ipc_read_all(client_fd, &req, sizeof(req)) < 0) {
             return -1;
         }
 
-        if (memchr(req.mountpoint, '\0', sizeof(req.mountpoint)) == NULL ||
-                memchr(req.socket_id, '\0', sizeof(req.socket_id)) == NULL ||
-                memchr(req.volumename, '\0', sizeof(req.volumename)) == NULL) {
-            unsigned char result = AFPFSD_IPC_RESULT_ERROR;
-            (void)write(client_fd, &result, 1);
-            break;
+        request_is_valid = memchr(req.mountpoint, '\0', sizeof(req.mountpoint)) != NULL
+                           &&
+                           memchr(req.socket_id, '\0', sizeof(req.socket_id)) != NULL &&
+                           memchr(req.volumename, '\0', sizeof(req.volumename)) != NULL;
+
+        if (request_is_valid) {
+            command_result = start_mount_daemon(req.socket_id, req.mountpoint,
+                                                req.volumename);
+
+            if (command_result == 0) {
+                sleep(1);
+                result = AFPFSD_IPC_RESULT_OK;
+            }
         }
 
-        if (start_mount_daemon(req.socket_id, req.mountpoint, req.volumename) < 0) {
-            unsigned char result = AFPFSD_IPC_RESULT_ERROR;
-            (void)write(client_fd, &result, 1);
+        if (afpfsd_ipc_write_all(client_fd, &result, sizeof(result)) < 0) {
             return -1;
         }
 
-        sleep(1);
-        unsigned char result = AFPFSD_IPC_RESULT_OK;
-        (void)write(client_fd, &result, 1);
+        if (command_result < 0) {
+            return -1;
+        }
+
         break;
     }
 
     case AFPFSD_IPC_COMMAND_EXIT: {
-        struct afpfsd_ipc_response response;
-        response.result = AFPFSD_IPC_RESULT_OK;
-        response.len = 0;
-        (void)write(client_fd, &response, sizeof(response));
+        if (send_response(client_fd, AFPFSD_IPC_RESULT_OK, NULL, 0) < 0) {
+            return -1;
+        }
+
         cleanup_all_children();
         return -2;  /* Signal to exit manager; caller closes client_fd */
     }
 
     case AFPFSD_IPC_COMMAND_PING: {
         unsigned char result = AFPFSD_IPC_RESULT_OK;
-        (void)write(client_fd, &result, 1);
+
+        if (afpfsd_ipc_write_all(client_fd, &result, sizeof(result)) < 0) {
+            return -1;
+        }
+
         break;
     }
 
     case AFPFSD_IPC_COMMAND_STATUS: {
         struct afpfsd_ipc_status_request req;
-        n = read(client_fd, &req, sizeof(req));
 
-        if (n != sizeof(req)) {
+        if (afpfsd_ipc_read_all(client_fd, &req, sizeof(req)) < 0) {
             /* Read error */
-            struct afpfsd_ipc_response response;
-            response.result = AFPFSD_IPC_RESULT_ERROR;
-            response.len = 0;
-            (void)write(client_fd, &response, sizeof(response));
+            if (send_response(client_fd, AFPFSD_IPC_RESULT_ERROR,
+                              NULL, 0) < 0) {
+                return -1;
+            }
+
             break;
         }
 
         if (memchr(req.volumename, '\0', sizeof(req.volumename)) == NULL ||
                 memchr(req.servername, '\0', sizeof(req.servername)) == NULL ||
                 memchr(req.mountpoint, '\0', sizeof(req.mountpoint)) == NULL) {
-            struct afpfsd_ipc_response response;
-            response.result = AFPFSD_IPC_RESULT_ERROR;
-            response.len = 0;
-            (void)write(client_fd, &response, sizeof(response));
+            if (send_response(client_fd, AFPFSD_IPC_RESULT_ERROR,
+                              NULL, 0) < 0) {
+                return -1;
+            }
+
             break;
         }
 
@@ -670,14 +696,17 @@ static int handle_manager_command(int client_fd)
             /* Send command to child */
             unsigned char cmd = AFPFSD_IPC_COMMAND_STATUS;
 
-            if (write(child_sock, &cmd, 1) != 1 ||
-                    write(child_sock, &req, sizeof(req)) != sizeof(req)) {
+            if (afpfsd_ipc_write_all(child_sock, &cmd, sizeof(cmd)) < 0 ||
+                    afpfsd_ipc_write_all(child_sock, &req, sizeof(req)) < 0) {
                 log_for_client(NULL, AFPFSD, LOG_WARNING,
                                "Failed to send status command to child daemon");
-                struct afpfsd_ipc_response response;
-                response.result = AFPFSD_IPC_RESULT_ERROR;
-                response.len = 0;
-                (void)write(client_fd, &response, sizeof(response));
+
+                if (send_response(client_fd, AFPFSD_IPC_RESULT_ERROR,
+                                  NULL, 0) < 0) {
+                    close(child_sock);
+                    return -1;
+                }
+
                 close(child_sock);
                 break;
             }
@@ -686,7 +715,6 @@ static int handle_manager_command(int client_fd)
             close(child_sock);
         } else {
             /* Manager daemon: return overview with header and list of mounts */
-            struct afpfsd_ipc_response response;
             char text[4096];
             int len = sizeof(text);
             int pos = 0;
@@ -824,13 +852,12 @@ static int handle_manager_command(int client_fd)
             }
 
             append_text(text, sizeof(text), &pos, "\n");
-            response.result = AFPFSD_IPC_RESULT_OK;
-            response.len = strlen(text);
 
-            if (write(client_fd, &response, sizeof(response)) != sizeof(response) ||
-                    write(client_fd, text, response.len) != (ssize_t)response.len) {
+            if (send_response(client_fd, AFPFSD_IPC_RESULT_OK, text,
+                              strlen(text)) < 0) {
                 log_for_client(NULL, AFPFSD, LOG_WARNING,
                                "Failed to send status response to client");
+                return -1;
             }
         }
 
@@ -841,21 +868,22 @@ static int handle_manager_command(int client_fd)
     case AFPFSD_IPC_COMMAND_RESUME: {
         /* These commands must be forwarded to the appropriate child daemon */
         struct afpfsd_ipc_suspend_request req;
-        n = read(client_fd, &req, sizeof(req));
 
-        if (n != sizeof(req)) {
-            struct afpfsd_ipc_response response;
-            response.result = AFPFSD_IPC_RESULT_ERROR;
-            response.len = 0;
-            (void)write(client_fd, &response, sizeof(response));
+        if (afpfsd_ipc_read_all(client_fd, &req, sizeof(req)) < 0) {
+            if (send_response(client_fd, AFPFSD_IPC_RESULT_ERROR,
+                              NULL, 0) < 0) {
+                return -1;
+            }
+
             break;
         }
 
         if (memchr(req.mountpoint, '\0', sizeof(req.mountpoint)) == NULL) {
-            struct afpfsd_ipc_response response;
-            response.result = AFPFSD_IPC_RESULT_ERROR;
-            response.len = 0;
-            (void)write(client_fd, &response, sizeof(response));
+            if (send_response(client_fd, AFPFSD_IPC_RESULT_ERROR,
+                              NULL, 0) < 0) {
+                return -1;
+            }
+
             break;
         }
 
@@ -874,14 +902,17 @@ static int handle_manager_command(int client_fd)
         }
 
         /* Send command to child */
-        if (write(child_sock, &command, 1) != 1 ||
-                write(child_sock, &req, sizeof(req)) != sizeof(req)) {
+        if (afpfsd_ipc_write_all(child_sock, &command, sizeof(command)) < 0 ||
+                afpfsd_ipc_write_all(child_sock, &req, sizeof(req)) < 0) {
             log_for_client(NULL, AFPFSD, LOG_WARNING,
                            "Failed to send suspend/resume command to child daemon");
-            struct afpfsd_ipc_response response;
-            response.result = AFPFSD_IPC_RESULT_ERROR;
-            response.len = 0;
-            (void)write(client_fd, &response, sizeof(response));
+
+            if (send_response(client_fd, AFPFSD_IPC_RESULT_ERROR,
+                              NULL, 0) < 0) {
+                close(child_sock);
+                return -1;
+            }
+
             close(child_sock);
             break;
         }

--- a/fuse/fuse_fs.c
+++ b/fuse/fuse_fs.c
@@ -84,7 +84,7 @@
 #define FUSE_NEW_API 0
 #endif
 
-#ifdef __APPLE__
+#if defined(__APPLE__) && FUSE_USE_VERSION >= 30
 static uint16_t finderinfo_get_flags(const char finderinfo[32])
 {
     return ((uint16_t)(unsigned char)finderinfo[8] << 8)
@@ -910,7 +910,7 @@ static int fuse_rename(const char * path_from, const char * path_to)
 
 #endif
 
-#if defined(__APPLE__) && !FUSE_NEW_API
+#if defined(__APPLE__) && FUSE_USE_VERSION >= 30 && !FUSE_NEW_API
 static int fuse_renamex(const char *path_from, const char *path_to,
                         unsigned int flags)
 {

--- a/fuse/fuse_ipc.c
+++ b/fuse/fuse_ipc.c
@@ -1,0 +1,54 @@
+/*
+ *  fuse_ipc.c - FUSE manager IPC helpers
+ *
+ *  Copyright (C) 2026 Daniel Markstedt <daniel@mindani.net>
+ */
+
+#include <errno.h>
+#include <unistd.h>
+
+#include "fuse_ipc.h"
+
+int afpfsd_ipc_write_all(int fd, const void *buffer, size_t length)
+{
+    const char *cursor = buffer;
+
+    while (length != 0) {
+        ssize_t written = write(fd, cursor, length);
+
+        if (written < 0 && errno == EINTR) {
+            continue;
+        }
+
+        if (written <= 0) {
+            return -1;
+        }
+
+        cursor += written;
+        length -= (size_t)written;
+    }
+
+    return 0;
+}
+
+int afpfsd_ipc_read_all(int fd, void *buffer, size_t length)
+{
+    char *cursor = buffer;
+
+    while (length != 0) {
+        ssize_t received = read(fd, cursor, length);
+
+        if (received < 0 && errno == EINTR) {
+            continue;
+        }
+
+        if (received <= 0) {
+            return -1;
+        }
+
+        cursor += received;
+        length -= (size_t)received;
+    }
+
+    return 0;
+}

--- a/fuse/fuse_ipc.h
+++ b/fuse/fuse_ipc.h
@@ -1,6 +1,7 @@
 #ifndef NETATALK_CLIENT_FUSE_IPC_H
 #define NETATALK_CLIENT_FUSE_IPC_H
 
+#include <stddef.h>
 #include <limits.h>
 
 #include "netatalk-client/types.h"
@@ -65,5 +66,9 @@ struct afpfsd_ipc_response {
     char result;
     unsigned int len;
 };
+
+/* Read or write an entire IPC message, retrying interrupted syscalls. */
+int afpfsd_ipc_write_all(int fd, const void *buffer, size_t length);
+int afpfsd_ipc_read_all(int fd, void *buffer, size_t length);
 
 #endif

--- a/fuse/meson.build
+++ b/fuse/meson.build
@@ -1,6 +1,8 @@
-afpc_fs_sources = files('client.c')
+fuse_ipc_sources = files('fuse_ipc.c')
 
-afpfsd_sources = ['commands.c', 'daemon.c', 'fuse_fs.c', 'fuse_error.c']
+afpc_fs_sources = files('client.c') + fuse_ipc_sources
+
+afpfsd_sources = ['commands.c', 'daemon.c', 'fuse_fs.c', 'fuse_error.c'] + fuse_ipc_sources
 
 executable(
     'afpfsd',

--- a/lib/afp_internal.h
+++ b/lib/afp_internal.h
@@ -16,6 +16,7 @@
 #include "netatalk-client/types.h"
 #include "netatalk-client/url.h"
 #include "afp_protocol.h"
+#include "compat.h"
 #include "client.h"
 #include "xattr.h"
 

--- a/lib/compat.h
+++ b/lib/compat.h
@@ -4,6 +4,10 @@
 #include <stddef.h>
 #include <strings.h>
 
+#ifdef HAVE_LIBBSD
+#include <bsd/string.h>
+#endif
+
 /* Mark a declaration as intentionally unused when the compiler supports it. */
 #ifndef _U_
 #if defined(__has_attribute)

--- a/lib/status.c
+++ b/lib/status.c
@@ -86,8 +86,9 @@ int afp_status_server(struct afp_server * s, char * text, int * len)
     }
 
     for (j = 0; j < AFP_SIGNATURE_LEN; j++)
-        sprintf(signature_string + (j * 2), "%02x",
-                (unsigned int)((unsigned char) s->signature[j]));
+        snprintf(signature_string + (j * 2),
+                 sizeof(signature_string) - (j * 2), "%02x",
+                 (unsigned int)((unsigned char) s->signature[j]));
 
     switch (s->used_address->ai_family) {
     case AF_INET6:

--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@ project(
     'c',
     version: '0.9.5',
     license: 'GPLv2',
-    default_options: ['warning_level=3', 'c_std=c11'],
+    default_options: ['warning_level=3', 'werror=true', 'c_std=c11'],
     meson_version: '>=0.62',
 )
 


### PR DESCRIPTION
fixing a handful of minor compiler warnings in order for the build to pass on all supported platforms in strict mode

## stateless client: validate daemon startup status

The afpsld child reports exec failure by writing its saved errno to a close-on-exec pipe. Retry an interrupted write using only async-signal-safe operations after fork().

The parent now accepts only a complete errno record as an exec failure and EOF as successful exec. Treat any other startup-pipe result as malformed rather than accidentally reporting success.

## fuse client: handle complete IPC reads and writes 

FUSE manager messages travel over SOCK_STREAM sockets, where a single read() or write() may transfer only part of a request or response. Add shared complete-I/O helpers that retry EINTR and fail on short or zero-progress operations, and use them in the control client, manager, and child-daemon protocol paths.

Keep response framing intact by sending complete headers and payloads, and treat a failed client write as a broken connection instead of attempting further replies. The command daemon now also rejects partial response writes.

## afpcmd client: handle immediate-exit write result for Ctrl+C signal

the result is discarded not to block any signal during immediate shutdown