### PR TITLE
libafpclient: use FPLoginExt for AFP 3.x initial logins

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -36,6 +36,5 @@ Protocol bugs
 * reconnect isn't reliable
 * If a DSI stream gets broken or there's a protocol error, the connection
   should be reset
-* for logins, fpLoginExt should be used instead of fpLogin
 * for fpCreateFile, use soft creates
 * honour volume's HasConfigInfo flag

--- a/cmdline/cmdline_afp.c
+++ b/cmdline/cmdline_afp.c
@@ -57,6 +57,7 @@
 
 #include "netatalk-client/afpsl.h"
 
+#include "lib/utils.h"
 #include "cmdline_afp.h"
 
 #define CMDLINE_ERROR_LEN 1024
@@ -4819,11 +4820,15 @@ int cmdline_afp_setup(int batch_mode, char *url_string,
                 url.requested_version = requested_version;
             }
 
-            if (username_override
-                    && strlcpy(url.username, username_override,
-                               sizeof(url.username)) >= sizeof(url.username)) {
-                fprintf(stderr, "Username is too long.\n");
-                return -1;
+            if (username_override) {
+                if (afp_validate_username(username_override, NULL) != 0
+                        || strlcpy(url.username, username_override,
+                                   sizeof(url.username))
+                        >= sizeof(url.username)) {
+                    fprintf(stderr,
+                            "Username must be valid UTF-8 and no more than 255 characters.\n");
+                    return -1;
+                }
             }
 
             /* If no username was specified in URL, use AFP guest user */

--- a/cmdline/cmdline_main.c
+++ b/cmdline/cmdline_main.c
@@ -684,9 +684,9 @@ int main(int argc, char *argv[])
             exit(0);
         }
 
-        if (strnlen(discovered_username, AFPC_MAX_USERNAME_LEN)
-                >= AFPC_MAX_USERNAME_LEN) {
-            fprintf(stderr, "Username is too long.\n");
+        if (afp_validate_username(discovered_username, NULL) != 0) {
+            fprintf(stderr,
+                    "Username must be valid UTF-8 and no more than 255 characters.\n");
             free(discovered_username);
             tty_reset(STDIN_FILENO);
             exit(1);

--- a/daemon/commands.c
+++ b/daemon/commands.c
@@ -511,9 +511,17 @@ static unsigned char process_changepw(struct daemon_client * c)
         goto done;
     }
 
-    /* Force null-termination of string fields from untrusted client data */
+    if (afp_validate_username(req->url.username, NULL) != 0) {
+        log_for_client((void *)c, AFPFSD, LOG_WARNING,
+                       "Password-change request contains an invalid username");
+        response.header.result = AFPSL_IPC_RESULT_ERROR;
+        goto done;
+    }
+
+    /* Force null-termination of the remaining string fields from untrusted
+     * client data.  Usernames are validated without modifying the request so
+     * an unterminated value cannot be accepted as a truncated credential. */
     req->url.servername[AFP_SERVER_NAME_UTF8_LEN - 1] = '\0';
-    req->url.username[AFP_MAX_USERNAME_LEN - 1] = '\0';
     req->oldpasswd[AFP_MAX_PASSWORD_LEN - 1] = '\0';
     req->newpasswd[AFP_MAX_PASSWORD_LEN - 1] = '\0';
     server = afp_server_find_by_name_hold(req->url.servername);
@@ -533,8 +541,7 @@ static unsigned char process_changepw(struct daemon_client * c)
         response.afp_error = 0;
     } else {
         log_for_client((void *)c, AFPFSD, LOG_WARNING,
-                       "Password change failed for user %s (error %d)",
-                       req->url.username, ret);
+                       "Password change failed (error %d)", ret);
         response.header.result = AFPSL_IPC_RESULT_ERROR;
         response.afp_error = ret;
     }
@@ -617,8 +624,12 @@ static unsigned char process_getvolid(struct daemon_client * c)
         goto done;
     }
 
-    /* Force null-termination of all string fields from untrusted client data */
-    req->url.username[AFP_MAX_USERNAME_LEN - 1] = '\0';
+    if (afp_validate_username(req->url.username, NULL) != 0) {
+        ret = AFPSL_IPC_RESULT_ERROR;
+        goto done;
+    }
+
+    /* Force null-termination of the remaining string fields from untrusted client data */
     req->url.uamname[49] = '\0';
     req->url.password[AFP_MAX_PASSWORD_LEN - 1] = '\0';
     req->url.servername[AFP_SERVER_NAME_UTF8_LEN - 1] = '\0';
@@ -671,8 +682,12 @@ static unsigned char process_serverinfo(struct daemon_client * c)
         return AFPSL_IPC_RESULT_ERROR;
     }
 
-    /* Force null-termination of all string fields from untrusted client data */
-    req->url.username[AFP_MAX_USERNAME_LEN - 1] = '\0';
+    if (afp_validate_username(req->url.username, NULL) != 0) {
+        response.header.result = AFPSL_IPC_RESULT_ERROR;
+        goto done;
+    }
+
+    /* Force null-termination of the remaining string fields from untrusted client data */
     req->url.uamname[49] = '\0';
     req->url.password[AFP_MAX_PASSWORD_LEN - 1] = '\0';
     req->url.servername[AFP_SERVER_NAME_UTF8_LEN - 1] = '\0';
@@ -749,8 +764,12 @@ static unsigned char process_getvols(struct daemon_client * c)
         goto error;
     }
 
-    /* Force null-termination of all string fields from untrusted client data */
-    request->url.username[AFP_MAX_USERNAME_LEN - 1] = '\0';
+    if (afp_validate_username(request->url.username, NULL) != 0) {
+        result = AFPSL_IPC_RESULT_ERROR;
+        goto error;
+    }
+
+    /* Force null-termination of the remaining string fields from untrusted client data */
     request->url.uamname[49] = '\0';
     request->url.password[AFP_MAX_PASSWORD_LEN - 1] = '\0';
     request->url.servername[AFP_SERVER_NAME_UTF8_LEN - 1] = '\0';
@@ -2587,8 +2606,13 @@ static int process_connect(struct daemon_client * c)
     }
 
     req = (void *) c->complete_packet;
-    /* Force null-termination of all string fields from untrusted client data */
-    req->url.username[AFP_MAX_USERNAME_LEN - 1] = '\0';
+
+    if (afp_validate_username(req->url.username, NULL) != 0) {
+        error = EINVAL;
+        goto error;
+    }
+
+    /* Force null-termination of the remaining string fields from untrusted client data */
     req->url.uamname[49] = '\0';
     req->url.password[AFP_MAX_PASSWORD_LEN - 1] = '\0';
     req->url.servername[AFP_SERVER_NAME_UTF8_LEN - 1] = '\0';
@@ -2754,8 +2778,12 @@ static int process_attach(struct daemon_client * c)
         goto error;
     }
 
-    /* Force null-termination of all string fields from untrusted client data */
-    req->url.username[AFP_MAX_USERNAME_LEN - 1] = '\0';
+    if (afp_validate_username(req->url.username, NULL) != 0) {
+        response_result = AFPSL_IPC_RESULT_ERROR;
+        goto error;
+    }
+
+    /* Force null-termination of the remaining string fields from untrusted client data */
     req->url.uamname[49] = '\0';
     req->url.password[AFP_MAX_PASSWORD_LEN - 1] = '\0';
     req->url.servername[AFP_SERVER_NAME_UTF8_LEN - 1] = '\0';

--- a/daemon/stateless.c
+++ b/daemon/stateless.c
@@ -2555,6 +2555,11 @@ static int afp_sl_connect_with_flags(struct afpc_url *url,
     struct afpsl_ipc_connect_request req;
     const struct afpsl_ipc_connect_response *resp;
     int ret;
+
+    if (url == NULL || afp_validate_username(url->username, NULL) != 0) {
+        return -EINVAL;
+    }
+
     ret = ensure_daemon_connection();
 
     if (ret) {
@@ -2730,7 +2735,8 @@ int afp_sl_changepw(struct afpc_url *url, const char *old_password,
     struct afpsl_ipc_changepw_response response;
     int ret;
 
-    if (!url || !old_password || !new_password) {
+    if (!url || !old_password || !new_password
+            || afp_validate_username(url->username, NULL) != 0) {
         return -EINVAL;
     }
 

--- a/fuse/client.c
+++ b/fuse/client.c
@@ -739,7 +739,15 @@ static int do_mount(int argc, char ** argv)
             break;
 
         case 'u':
-            snprintf(request.url.username, AFP_MAX_USERNAME_LEN, "%s", optarg);
+            if (afp_validate_username(optarg, NULL) != 0
+                    || strlcpy(request.url.username, optarg,
+                               sizeof(request.url.username))
+                    >= sizeof(request.url.username)) {
+                fprintf(stderr,
+                        "Username must be valid UTF-8 and no more than 255 characters.\n");
+                return -1;
+            }
+
             break;
 
         case 'f':

--- a/fuse/commands.c
+++ b/fuse/commands.c
@@ -52,7 +52,8 @@
 #define FUSE_DEVICE "/dev/fuse"
 #endif
 
-#define AFPFSD_CLIENT_INCOMING_BUF (2048 + 256)
+#define AFPFSD_CLIENT_INCOMING_BUF \
+    (sizeof(struct afpfsd_ipc_mount_request) + 1U)
 
 struct afpfsd_client {
     char incoming_string[AFPFSD_CLIENT_INCOMING_BUF];
@@ -637,6 +638,13 @@ static int process_mount(struct afpfsd_client * c)
     }
 
     memcpy(&req, (void *)((uintptr_t)c->incoming_string + 1), sizeof(req));
+
+    if (afp_validate_username(req.url.username, NULL) != 0) {
+        log_for_client((void *)c, AFPFSD, LOG_ERR,
+                       "Mount request contains an invalid username");
+        goto error;
+    }
+
     /* Check that the mount point exists and is a directory with proper permissions */
     struct stat mountpoint_stat;
 

--- a/include/netatalk-client/types.h
+++ b/include/netatalk-client/types.h
@@ -9,7 +9,12 @@
 #define AFPC_SIGNATURE_LEN 16
 #define AFPC_MACHINE_TYPE_LEN 16
 #define AFPC_SERVER_ICON_LEN 256
-#define AFPC_MAX_USERNAME_LEN 127
+#define AFPC_MAX_USERNAME_CHARS 255U
+/* Storage for a NUL-terminated AFP 3.x username.  AFPName permits a 16-bit
+ * byte length, while the protocol's 255-character limit is tighter for
+ * well-formed UTF-8 (at most four bytes per Unicode scalar value). */
+#define AFPC_MAX_USERNAME_BYTES (AFPC_MAX_USERNAME_CHARS * 4U)
+#define AFPC_MAX_USERNAME_LEN (AFPC_MAX_USERNAME_BYTES + 1U)
 #define AFPC_MAX_PASSWORD_LEN 127
 #define AFPC_ZONE_LEN 32
 /* AFP 3.x UTF-8 names are limited to 255 Unicode characters per component.

--- a/lib/afp_internal.h
+++ b/lib/afp_internal.h
@@ -509,14 +509,11 @@ int afp_getappl(struct afp_volume *volume, unsigned int filecreator,
 int afp_getsrvrmsg(struct afp_server *server, unsigned short messagetype,
                    unsigned char utf8, unsigned char block, char *mesg);
 
-int afp_login(struct afp_server *server, const char * uaname,
-              char *userauthinfo, unsigned int userauthinfo_len,
-              struct afp_rx_buffer *rx);
-
-int afp_loginext(struct afp_server *server, const char *uaname,
-                 const char *username,
-                 char *userauthinfo, unsigned int userauthinfo_len,
-                 struct afp_rx_buffer *rx);
+int afp_login_initial(struct afp_server *server, const char *uaname,
+                      const char *username, int pad_before_authinfo,
+                      const void *userauthinfo,
+                      unsigned int userauthinfo_len,
+                      struct afp_rx_buffer *rx);
 
 int afp_changepassword(struct afp_server *server, const char * uaname,
                        char *userauthinfo, unsigned int userauthinfo_len,

--- a/lib/afp_protocol.h
+++ b/lib/afp_protocol.h
@@ -25,14 +25,17 @@
 #define AFP_HOSTNAME_LEN 255
 #define AFP_ZONE_LEN 32
 #define AFP_SERVER_ICON_LEN 256
-#define AFP_MAX_USERNAME_LEN 127
+#define AFP_MAX_USERNAME_LEN AFPC_MAX_USERNAME_LEN
 #define AFP_MAX_PASSWORD_LEN 127
 
 /* This is the maximum length of any UAM string */
 #define AFP_UAM_LENGTH 24
 
 /* AFP 3.x UTF-8 pathnames are limited to 255 Unicode characters. */
-#define AFP_MAX_UTF8_NAME_CHARS 255
+#define AFP_MAX_UTF8_NAME_CHARS AFPC_MAX_USERNAME_CHARS
+
+/* FPLogin represents a username as a one-byte-length Pascal string. */
+#define AFP_LEGACY_MAX_USERNAME_BYTES UINT8_MAX
 
 /* AFP 3.x UTF-8 pathname headers use a 16-bit byte length.  This is a wire
  * limit, not a recommendation to put full paths in fixed-size buffers. */
@@ -52,6 +55,9 @@ enum {
     kFPLongName = 2,
     kFPUTF8Name = 3
 };
+
+/* AFP's UTF-8 text-encoding hint, including the decomposed-name variant. */
+#define AFP_TEXT_ENCODING_UTF8 UINT32_C(0x08000103)
 
 /* fork types */
 #define AFP_FORKTYPE_DATA 0x0

--- a/lib/afp_url.c
+++ b/lib/afp_url.c
@@ -18,6 +18,7 @@
 #include "afp_internal.h"
 #include "client.h"
 #include "uam_registry.h"
+#include "utils.h"
 
 void afp_default_url(struct afpc_url *url)
 {
@@ -58,31 +59,22 @@ static int check_uamname(char * uam)
     return !uam_string_to_bitmap(uam);
 }
 
-static void escape_string(char * string, char c)
+static void escape_string(char *string, char c)
 {
-    char d;
-    int inescape = 0;
-    char tmpstring[1024];
-    char *p = tmpstring;
-    memset(tmpstring, 0, 1024);
+    char *read_cursor = string;
+    char *write_cursor = string;
 
-    for (unsigned long i = 0; i < strlen(string); i++) {
-        d = string[i]; /* convenience */
+    while (*read_cursor != '\0') {
+        *write_cursor++ = *read_cursor;
 
-        if ((inescape) && (d == c)) {
-            inescape = 0;
-            continue;
-        }
-
-        *p = d;
-        p++;
-
-        if (d == c) {
-            inescape = 1;
+        if (*read_cursor == c && read_cursor[1] == c) {
+            read_cursor += 2;
+        } else {
+            read_cursor++;
         }
     }
 
-    strcpy(string, tmpstring);
+    *write_cursor = '\0';
 }
 
 static void escape_url(struct afpc_url * url)
@@ -156,7 +148,11 @@ static char *escape_strchr(const char * haystack, int c, const char * toescape)
 static int parse_url(struct afpc_url *url, const char *toparse,
                      int log_messages)
 {
-    char firstpart[AFP_HOSTNAME_LEN];
+    /* Escaped delimiters can make the authority longer than any individual
+     * decoded field. */
+    char firstpart[AFPC_MAX_USERNAME_BYTES
+                   + (2U * AFPC_MAX_PASSWORD_LEN)
+                   + AFP_HOSTNAME_LEN + 128U];
     char *secondpart = NULL;
     const char *path_part;
     char *p, *q;
@@ -177,7 +173,8 @@ static int parse_url(struct afpc_url *url, const char *toparse,
             log_for_client(NULL, AFPFSD, level, __VA_ARGS__); \
         } \
     } while (0)
-    URL_LOG(LOG_DEBUG, "Parsing AFP URL: %s", toparse);
+    /* Never log the URL: its authority may contain authentication data. */
+    URL_LOG(LOG_DEBUG, "Parsing AFP URL");
 
     /* if there is a ://, make sure it is preceeded by afp */
 
@@ -312,7 +309,8 @@ static int parse_url(struct afpc_url *url, const char *toparse,
         q++;
 
         if (strlcpy(url->password, q, sizeof(url->password)) >= sizeof(url->password)) {
-            URL_LOG(LOG_WARNING, "Warning: password truncated");
+            URL_LOG(LOG_ERR, "Password is too long");
+            return -1;
         }
     }
 
@@ -324,7 +322,8 @@ static int parse_url(struct afpc_url *url, const char *toparse,
         q += 6;
 
         if (strlcpy(url->uamname, q, sizeof(url->uamname)) >= sizeof(url->uamname)) {
-            URL_LOG(LOG_WARNING, "Warning: uamname truncated");
+            URL_LOG(LOG_ERR, "UAM name is too long");
+            return -1;
         }
 
         if (check_uamname(url->uamname)) {
@@ -335,7 +334,8 @@ static int parse_url(struct afpc_url *url, const char *toparse,
 
     if (*p != '\0'
             && strlcpy(url->username, p, sizeof(url->username)) >= sizeof(url->username)) {
-        URL_LOG(LOG_WARNING, "Warning: username truncated");
+        URL_LOG(LOG_ERR, "Username is too long");
+        return -1;
     }
 
 parse_secondpart:
@@ -383,6 +383,13 @@ parse_secondpart:
 
 done:
     escape_url(url);
+
+    if (afp_validate_username(url->username, NULL) != 0) {
+        URL_LOG(LOG_ERR, "Username is not valid UTF-8 or exceeds 255 characters");
+        free(secondpart);
+        return -1;
+    }
+
     free(secondpart);
     URL_LOG(LOG_DEBUG, "Successful parsing of URL");
 #undef URL_LOG

--- a/lib/codepage.c
+++ b/lib/codepage.c
@@ -169,8 +169,8 @@ static unsigned char unicode_to_mac_roman(char16 uc)
  * codepoint to Mac Roman using the reverse page tables.
  * Unmappable characters are replaced with '?'.
  */
-static int convert_utf8_to_mac_roman(const char *src, int src_len,
-                                     char *dest, int dest_len)
+int convert_utf8_to_mac_roman(const char *src, int src_len,
+                              char *dest, int dest_len)
 {
     char16 *ucs2;
     size_t bytes_consumed;

--- a/lib/codepage.h
+++ b/lib/codepage.h
@@ -6,6 +6,8 @@ int convert_utf8pre_to_utf8dec(const char * src, int src_len,
                                char *dest, int dest_len);
 int convert_mac_roman_to_utf8(const char *src, int src_len,
                               char *dest, int dest_len);
+int convert_utf8_to_mac_roman(const char *src, int src_len,
+                              char *dest, int dest_len);
 int convert_path_to_unix(char encoding, char * dest,
                          char *src, int dest_len);
 int convert_path_to_afp(char encoding, char * dest,

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -61,6 +61,12 @@ struct afp_server *afp_server_full_connect(void * priv,
     unsigned int rx_quantum;
     char icon[AFP_SERVER_ICON_LEN];
 
+    if (req == NULL
+            || afp_validate_username(req->url.username, NULL) != 0) {
+        errno = EINVAL;
+        return NULL;
+    }
+
     if ((address = afp_get_address(priv, req->url.servername,
                                    req->url.port)) == NULL) {
         goto error;

--- a/lib/proto_login.c
+++ b/lib/proto_login.c
@@ -7,14 +7,278 @@
  *
  */
 
+#include <errno.h>
+#include <limits.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include "afp_internal.h"
+#include "codepage.h"
 #include "compat.h"
 #include "dsi.h"
 #include "dsi_protocol.h"
+#include "proto_login.h"
 #include "utils.h"
+
+static void write_uint16_be(uint8_t **cursor, uint16_t value)
+{
+    uint16_t encoded = htons(value);
+    memcpy(*cursor, &encoded, sizeof(encoded));
+    *cursor += sizeof(encoded);
+}
+
+static void write_uint32_be(uint8_t **cursor, uint32_t value)
+{
+    uint32_t encoded = htonl(value);
+    memcpy(*cursor, &encoded, sizeof(encoded));
+    *cursor += sizeof(encoded);
+}
+
+static void write_pascal_string(uint8_t **cursor, const char *value,
+                                size_t value_len)
+{
+    *(*cursor)++ = (uint8_t)value_len;
+    memcpy(*cursor, value, value_len);
+    *cursor += value_len;
+}
+
+static void write_afp_name(uint8_t **cursor, const char *value,
+                           size_t value_len)
+{
+    write_uint32_be(cursor, AFP_TEXT_ENCODING_UTF8);
+    write_uint16_be(cursor, (uint16_t)value_len);
+    memcpy(*cursor, value, value_len);
+    *cursor += value_len;
+}
+
+int afp_loginext_build_payload(const char *afp_version,
+                               const char *uam_name,
+                               const char *username,
+                               const char *directory_domain,
+                               const void *userauthinfo,
+                               size_t userauthinfo_len,
+                               uint8_t **payload_out,
+                               size_t *payload_len_out)
+{
+    const size_t fixed_len = 4; /* command + pad + flags */
+    size_t version_len;
+    size_t uam_len;
+    size_t username_len;
+    size_t domain_len;
+    size_t prefix_len;
+    size_t payload_len;
+    size_t path_pad;
+    uint8_t *payload;
+    uint8_t *p;
+    int ret;
+
+    if (payload_out == NULL || payload_len_out == NULL) {
+        return -EINVAL;
+    }
+
+    *payload_out = NULL;
+    *payload_len_out = 0;
+
+    if (afp_version == NULL || uam_name == NULL || username == NULL
+            || directory_domain == NULL
+            || (userauthinfo_len != 0 && userauthinfo == NULL)) {
+        return -EINVAL;
+    }
+
+    version_len = strnlen(afp_version, (size_t)UINT8_MAX + 1U);
+    uam_len = strnlen(uam_name, (size_t)UINT8_MAX + 1U);
+
+    if (version_len > UINT8_MAX || uam_len > UINT8_MAX) {
+        return -EOVERFLOW;
+    }
+
+    ret = afp_validate_username(username, &username_len);
+
+    if (ret != 0) {
+        return ret;
+    }
+
+    ret = afp_validate_utf8_name(directory_domain,
+                                 AFP_MAX_UTF8_NAME_CHARS, &domain_len);
+
+    if (ret != 0) {
+        return ret;
+    }
+
+    prefix_len = fixed_len
+                 + 1U + version_len
+                 + 1U + uam_len
+                 + 1U + sizeof(uint32_t) + sizeof(uint16_t) + username_len
+                 + 1U + sizeof(uint32_t) + sizeof(uint16_t) + domain_len;
+    path_pad = prefix_len & 1U;
+
+    if (userauthinfo_len > (size_t)INT_MAX - sizeof(struct dsi_header)
+            || prefix_len + path_pad
+            > (size_t)INT_MAX - sizeof(struct dsi_header) - userauthinfo_len) {
+        return -EOVERFLOW;
+    }
+
+    payload_len = prefix_len + path_pad + userauthinfo_len;
+    payload = calloc(1, payload_len);
+
+    if (payload == NULL) {
+        return -ENOMEM;
+    }
+
+    p = payload;
+    *p++ = afpLoginExt;
+    *p++ = 0;
+    write_uint16_be(&p, 0);
+    write_pascal_string(&p, afp_version, version_len);
+    write_pascal_string(&p, uam_name, uam_len);
+    *p++ = kFPUTF8Name;
+    write_afp_name(&p, username, username_len);
+    *p++ = kFPUTF8Name;
+    write_afp_name(&p, directory_domain, domain_len);
+
+    if (path_pad != 0) {
+        *p++ = 0;
+    }
+
+    if (userauthinfo_len != 0) {
+        memcpy(p, userauthinfo, userauthinfo_len);
+    }
+
+    *payload_out = payload;
+    *payload_len_out = payload_len;
+    return 0;
+}
+
+void afp_loginext_payload_free(uint8_t *payload, size_t payload_len)
+{
+    if (payload != NULL) {
+        explicit_bzero(payload, payload_len);
+        free(payload);
+    }
+}
+
+static int afp_login_build_payload(const char *afp_version,
+                                   const char *uam_name,
+                                   const char *username,
+                                   int pad_before_authinfo,
+                                   const void *userauthinfo,
+                                   size_t userauthinfo_len,
+                                   uint8_t **payload_out,
+                                   size_t *payload_len_out)
+{
+    char legacy_username[UINT8_MAX + 1U];
+    size_t version_len;
+    size_t uam_len;
+    size_t username_len = 0;
+    size_t prefix_len;
+    size_t username_pad;
+    size_t payload_len;
+    uint8_t *payload;
+    uint8_t *p;
+    int ret;
+
+    if (payload_out == NULL || payload_len_out == NULL) {
+        return -EINVAL;
+    }
+
+    *payload_out = NULL;
+    *payload_len_out = 0;
+
+    if (afp_version == NULL || uam_name == NULL
+            || (userauthinfo_len != 0 && userauthinfo == NULL)) {
+        return -EINVAL;
+    }
+
+    version_len = strnlen(afp_version, (size_t)UINT8_MAX + 1U);
+    uam_len = strnlen(uam_name, (size_t)UINT8_MAX + 1U);
+
+    if (version_len > UINT8_MAX || uam_len > UINT8_MAX) {
+        return -EOVERFLOW;
+    }
+
+    if (username != NULL) {
+        ret = afp_validate_utf8_name(username, AFP_LEGACY_MAX_USERNAME_BYTES,
+                                     NULL);
+
+        if (ret != 0) {
+            return ret;
+        }
+
+        if (*username != '\0') {
+            if (convert_utf8_to_mac_roman(username, strlen(username),
+                                          legacy_username,
+                                          sizeof(legacy_username)) != 0) {
+                return -EILSEQ;
+            }
+
+            username_len = strlen(legacy_username);
+        }
+    }
+
+    prefix_len = 1U + 1U + version_len + 1U + uam_len;
+
+    if (username != NULL) {
+        prefix_len += 1U + username_len;
+    }
+
+    username_pad = pad_before_authinfo && (prefix_len & 1U);
+
+    if (userauthinfo_len > (size_t)INT_MAX - sizeof(struct dsi_header)
+            || prefix_len + username_pad
+            > (size_t)INT_MAX - sizeof(struct dsi_header) - userauthinfo_len) {
+        return -EOVERFLOW;
+    }
+
+    payload_len = prefix_len + username_pad + userauthinfo_len;
+    payload = calloc(1, payload_len);
+
+    if (payload == NULL) {
+        return -ENOMEM;
+    }
+
+    p = payload;
+    *p++ = afpLogin;
+    write_pascal_string(&p, afp_version, version_len);
+    write_pascal_string(&p, uam_name, uam_len);
+
+    if (username != NULL) {
+        write_pascal_string(&p, legacy_username, username_len);
+    }
+
+    p += username_pad;
+
+    if (userauthinfo_len != 0) {
+        memcpy(p, userauthinfo, userauthinfo_len);
+    }
+
+    *payload_out = payload;
+    *payload_len_out = payload_len;
+    return 0;
+}
+
+int afp_login_initial_build_payload(int afp_version_number,
+                                    const char *afp_version,
+                                    const char *uam_name,
+                                    const char *username,
+                                    int pad_before_authinfo,
+                                    const void *userauthinfo,
+                                    size_t userauthinfo_len,
+                                    uint8_t **payload_out,
+                                    size_t *payload_len_out)
+{
+    if (afp_version_number >= 30) {
+        return afp_loginext_build_payload(afp_version, uam_name,
+                                          username != NULL ? username : "",
+                                          "", userauthinfo,
+                                          userauthinfo_len, payload_out,
+                                          payload_len_out);
+    }
+
+    return afp_login_build_payload(afp_version, uam_name, username,
+                                   pad_before_authinfo, userauthinfo,
+                                   userauthinfo_len, payload_out,
+                                   payload_len_out);
+}
 
 int afp_logout(struct afp_server *server, unsigned char wait)
 {
@@ -126,120 +390,62 @@ int afp_changepassword_reply(struct afp_server *server _U_,
     return 0;
 }
 
-int afp_login(struct afp_server *server, const char * ua_name,
-              char *userauthinfo, unsigned int userauthinfo_len,
-              struct afp_rx_buffer *rx)
+int afp_login_initial(struct afp_server *server, const char *ua_name,
+                      const char *username, int pad_before_authinfo,
+                      const void *userauthinfo,
+                      unsigned int userauthinfo_len,
+                      struct afp_rx_buffer *rx)
 {
-    char *msg;
-    char *p;
+    uint8_t *payload = NULL;
+    uint8_t command;
+    size_t payload_len = 0;
+    char *msg = NULL;
+    size_t msg_len;
     int ret;
-    struct {
-        struct dsi_header header __attribute__((__packed__));
-        uint8_t command;
-    }  __attribute__((__packed__)) * request;
-    unsigned int len =
-        sizeof(*request) /* DSI Header */
-        + (unsigned int)strnlen(server->using_version->av_name, UINT8_MAX) + 1
-        + (unsigned int)strnlen(ua_name, UINT8_MAX) + 1
-        + userauthinfo_len;
-    msg = malloc(len);
-
-    if (!msg) {
-        log_for_client(NULL, AFPFSD, LOG_ERR,
-                       "afp_login: Failed to allocate message buffer");
-        return -1;
-    }
-
-    request = (void *) msg;
-    p = msg + (sizeof(*request));
     struct dsi_header hdr;
-    afpc_dsi_setup_header(server, &hdr, DSI_DSICommand);
-    memcpy(&request->header, &hdr, sizeof(struct dsi_header));
-    request->command = afpLogin;
-    p += copy_to_pascal(p, server->using_version->av_name) +1;
-    p += copy_to_pascal(p, ua_name) +1;
-    memcpy(p, userauthinfo, userauthinfo_len);
-    ret = afpc_dsi_send(server, msg, len, DSI_LOGIN_TIMEOUT,
-                        afpLogin, (void *)rx);
-    free(msg);
-    return ret;
-}
 
+    if (server == NULL || server->using_version == NULL
+            || server->using_version->av_name == NULL) {
+        return -EINVAL;
+    }
 
-int afp_loginext(struct afp_server *server, const char *ua_name,
-                 const char *username,
-                 char *userauthinfo, unsigned int userauthinfo_len,
-                 struct afp_rx_buffer *rx)
-{
-    char *msg;
-    char *p;
-    int ret;
-    struct {
-        struct dsi_header header __attribute__((__packed__));
-        uint8_t command;
-        uint8_t pad;
-        uint16_t flags;
-    }  __attribute__((__packed__)) * request;
-    unsigned int user_len = (unsigned int)strnlen(username, AFP_MAX_USERNAME_LEN);
-    /* Compute offset from start of AFP payload to end of Pathname,
-     * to determine if a pad byte is needed for even alignment. */
-    unsigned int ver_pascal_len = (unsigned int)strnlen(
-                                      server->using_version->av_name, UINT8_MAX) + 1;
-    unsigned int uam_pascal_len = (unsigned int)strnlen(ua_name, UINT8_MAX) + 1;
-    unsigned int pre_authinfo_len =
-        1 + 1 + 2            /* command + pad + flags */
-        + ver_pascal_len      /* Version (Pascal string) */
-        + uam_pascal_len      /* UAM (Pascal string) */
-        + 1 + 2 + user_len   /* Username: type(1) + len(2) + data */
-        + 1 + 2;             /* Pathname: type(1) + len(2), empty */
-    unsigned int path_pad = (pre_authinfo_len & 1) ? 1 : 0;
-    unsigned int len =
-        sizeof(*request)
-        + ver_pascal_len
-        + uam_pascal_len
-        + 1 + 2 + user_len
-        + 1 + 2
-        + path_pad
-        + userauthinfo_len;
-    msg = malloc(len);
+    ret = afp_login_initial_build_payload(server->using_version->av_number,
+                                          server->using_version->av_name,
+                                          ua_name, username,
+                                          pad_before_authinfo, userauthinfo,
+                                          userauthinfo_len, &payload,
+                                          &payload_len);
 
-    if (!msg) {
+    if (ret != 0) {
+        if (ret == -ENOMEM) {
+            log_for_client(NULL, AFPFSD, LOG_ERR,
+                           "afp_login_initial: Failed to allocate payload buffer");
+        } else {
+            log_for_client(NULL, AFPFSD, LOG_ERR,
+                           "afp_login_initial: Rejected request data (%d)", ret);
+        }
+
+        return ret;
+    }
+
+    msg_len = sizeof(hdr) + payload_len;
+    msg = malloc(msg_len);
+
+    if (msg == NULL) {
         log_for_client(NULL, AFPFSD, LOG_ERR,
-                       "afp_loginext: Failed to allocate message buffer");
-        return -1;
+                       "afp_login_initial: Failed to allocate message buffer");
+        afp_loginext_payload_free(payload, payload_len);
+        return -ENOMEM;
     }
 
-    memset(msg, 0, len);
-    request = (void *)msg;
-    p = msg + sizeof(*request);
-    struct dsi_header hdr;
     afpc_dsi_setup_header(server, &hdr, DSI_DSICommand);
-    memcpy(&request->header, &hdr, sizeof(struct dsi_header));
-    request->command = afpLoginExt;
-    request->pad = 0;
-    request->flags = 0;
-    p += copy_to_pascal(p, server->using_version->av_name) + 1;
-    p += copy_to_pascal(p, ua_name) + 1;
-    /* Username: Type-3 UTF-8 encoding */
-    *p++ = 3; /* type = UTF-8 */
-    *(uint16_t *)p = htons((uint16_t)user_len);
-    p += 2;
-    memcpy(p, username, user_len);
-    p += user_len;
-    /* Pathname: Type-3, empty */
-    *p++ = 3;
-    *(uint16_t *)p = 0;
-    p += 2;
-
-    /* Pad to even boundary if needed */
-    if (path_pad) {
-        *p++ = 0;
-    }
-
-    /* UserAuthInfo */
-    memcpy(p, userauthinfo, userauthinfo_len);
-    ret = afpc_dsi_send(server, msg, len, DSI_LOGIN_TIMEOUT,
-                        afpLoginExt, (void *)rx);
+    memcpy(msg, &hdr, sizeof(hdr));
+    memcpy(msg + sizeof(hdr), payload, payload_len);
+    command = payload[0];
+    afp_loginext_payload_free(payload, payload_len);
+    ret = afpc_dsi_send(server, msg, (int)msg_len, DSI_LOGIN_TIMEOUT,
+                        command, (void *)rx);
+    explicit_bzero(msg, msg_len);
     free(msg);
     return ret;
 }

--- a/lib/proto_login.h
+++ b/lib/proto_login.h
@@ -1,0 +1,46 @@
+#ifndef NETATALK_CLIENT_PROTO_LOGIN_H
+#define NETATALK_CLIENT_PROTO_LOGIN_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+/*
+ * Build the payload for the first login request.  AFP 3.x selects
+ * FPLoginExt; older versions select FPLogin.  username is omitted from a
+ * legacy FPLogin when it is NULL (the guest UAM), and is encoded as the
+ * empty FPLoginExt UserName in that case.
+ *
+ * pad_before_authinfo requests the even-byte boundary required by UAMs
+ * whose opaque data follows their auth name.  It also preserves the padded
+ * username-only form used by DHX2.
+ */
+int afp_login_initial_build_payload(int afp_version_number,
+                                    const char *afp_version,
+                                    const char *uam_name,
+                                    const char *username,
+                                    int pad_before_authinfo,
+                                    const void *userauthinfo,
+                                    size_t userauthinfo_len,
+                                    uint8_t **payload_out,
+                                    size_t *payload_len_out);
+
+/*
+ * Build an AFP FPLoginExt payload without sending it.  The caller owns the
+ * returned buffer and must release it with afp_loginext_payload_free(), since
+ * it contains a copy of UserAuthInfo.
+ *
+ * directory_domain is encoded as a type-3 AFPName.  Pass the empty string for
+ * the default directory domain.
+ */
+int afp_loginext_build_payload(const char *afp_version,
+                               const char *uam_name,
+                               const char *username,
+                               const char *directory_domain,
+                               const void *userauthinfo,
+                               size_t userauthinfo_len,
+                               uint8_t **payload_out,
+                               size_t *payload_len_out);
+
+void afp_loginext_payload_free(uint8_t *payload, size_t payload_len);
+
+#endif

--- a/lib/server.c
+++ b/lib/server.c
@@ -35,8 +35,20 @@ struct afp_server *afp_server_complete_connection(
     char mesg[MAX_ERROR_LEN];
     unsigned int len = 0;
     memset(loginmsg, 0, AFP_LOGINMESG_LEN);
+
+    if (afp_validate_username(username, NULL) != 0) {
+        errno = EINVAL;
+        goto error;
+    }
+
     server->requested_version = requested_version;
-    strlcpy(server->username, username, sizeof(server->username));
+
+    if (strlcpy(server->username, username, sizeof(server->username))
+            >= sizeof(server->username)) {
+        errno = ENAMETOOLONG;
+        goto error;
+    }
+
     strlcpy(server->password, password, sizeof(server->password));
     add_fd_and_signal(server->fd);
 

--- a/lib/transport.c
+++ b/lib/transport.c
@@ -27,6 +27,7 @@
 #include "dsi.h"
 #include "dsi_protocol.h"
 #include "uam_registry.h"
+#include "utils.h"
 
 #define AFPC_AFP_ERROR_BASE (-5000)
 #define AFPC_DEFAULT_RAW_TIMEOUT 20
@@ -177,6 +178,12 @@ int afpc_transport_connect(const struct afpc_transport_options *options,
 
     error = copy_option(request.url.username,
                         sizeof(request.url.username), options->username);
+
+    if (error != 0) {
+        return error;
+    }
+
+    error = afp_validate_username(request.url.username, NULL);
 
     if (error != 0) {
         return error;

--- a/lib/uams.c
+++ b/lib/uams.c
@@ -183,7 +183,8 @@ static int noauth_login(
     char *passwd _U_
 )
 {
-    return afp_login(server, "No User Authent", NULL, 0, NULL);
+    return afp_login_initial(server, "No User Authent", NULL, 0,
+                             NULL, 0, NULL);
 }
 
 int afp_dologin(struct afp_server *server,
@@ -195,6 +196,12 @@ int afp_dologin(struct afp_server *server,
         log_for_client(NULL, AFPFSD, LOG_WARNING,
                        "afp_dologin -- Unknown UAM");
         return -1;
+    }
+
+    if (uam == UAM_SRP && server->using_version->av_number < 30) {
+        log_for_client(NULL, AFPFSD, LOG_WARNING,
+                       "SRP requires AFP 3.x FPLoginExt");
+        return kFPCallNotSupported;
     }
 
     return u->do_server_login(server, username, passwd);
@@ -217,6 +224,13 @@ int afp_dopasswd(struct afp_server *server,
                        "afp_dopasswd -- UAM %s does not support password change",
                        u->name);
         return kFPCallNotSupported;
+    }
+
+    if (server->using_version->av_number < 30
+            && afp_validate_legacy_username(username, NULL) != 0) {
+        log_for_client(NULL, AFPFSD, LOG_WARNING,
+                       "Username exceeds the legacy AFP 2.x limit");
+        return -1;
     }
 
     return u->do_server_passwd(server, username, oldpasswd, newpasswd);

--- a/lib/uams_clrtxt.c
+++ b/lib/uams_clrtxt.c
@@ -46,44 +46,13 @@
 int cleartxt_login(struct afp_server *server, char *username,
                    char *passwd)
 {
-    char *p, *ai = NULL;
-    int len, ret;
-    /* Pack the username and password into the authinfo struct. */
-    len = 1 + (int)strnlen(username, AFP_MAX_USERNAME_LEN) + 1 + 8;
-    ai = calloc(1, len);
-    p = ai;
-
-    if (ai == NULL) {
-        goto cleartxt_fail;
-    }
-
-    p += copy_to_pascal(p, username) + 1;
-
-    if ((long)p & 0x1) {
-        len--;
-    } else {
-        p++;
-    }
-
+    unsigned char password[8] = { 0 };
+    int ret;
     size_t passwd_len = strnlen(passwd, 8);
-
-    if (passwd_len > 8) {
-        passwd_len = 8;
-    }
-
-    memcpy(p, passwd, passwd_len);
-
-    if (passwd_len < 8) {
-        memset(p + passwd_len, 0, 8 - passwd_len);
-    }
-
-    /* Send the login request on to the server. */
-    ret = afp_login(server, "Cleartxt Passwrd", ai, len, NULL);
-    goto cleartxt_cleanup;
-cleartxt_fail:
-    ret = -1;
-cleartxt_cleanup:
-    free(ai);
+    memcpy(password, passwd, passwd_len);
+    ret = afp_login_initial(server, "Cleartxt Passwrd", username, 1,
+                            password, sizeof(password), NULL);
+    explicit_bzero(password, sizeof(password));
     return ret;
 }
 

--- a/lib/uams_dhx.c
+++ b/lib/uams_dhx.c
@@ -96,29 +96,14 @@ int dhx_login(struct afp_server *server, char *username, char *passwd)
     /* Ma = g^Ra mod p <- This is our "public" key, which we exchange
      * with the remote server to help make K, the session key. */
     gcry_mpi_powm(Ma, g, Ra, p);
-    /* The first authinfo block contains the username and Ma.  Ma must start
-     * at an even AFP-packet offset, so calculate the username padding from
-     * the serialized FPLogin prefix rather than the heap address. */
-    ai_len = 1 + (int)strnlen(username, AFP_MAX_USERNAME_LEN);
-
-    if ((1 + 1 + (int)strnlen(server->using_version->av_name, UINT8_MAX) +
-            1 + (int)strlen("DHCAST128") + ai_len) & 1) {
-        ai_len++;
-    }
-
-    ai_len += Ma_len;
+    /* Username encoding and packet-relative alignment are owned by the
+     * command-aware initial-login serializer.  The UAM supplies only Ma. */
+    ai_len = Ma_len;
     ai = calloc(1, ai_len);
     d = ai;
 
     if (ai == NULL) {
         goto dhx_noctx_fail;
-    }
-
-    d += copy_to_pascal(ai, username) + 1;
-
-    if ((1 + 1 + (int)strnlen(server->using_version->av_name, UINT8_MAX) +
-            1 + (int)strlen("DHCAST128") + (d - ai)) & 1) {
-        d++;
     }
 
     /* Extract Ma to send to the server for the exchange. */
@@ -139,8 +124,8 @@ int dhx_login(struct afp_server *server, char *username, char *passwd)
     }
 
     rbuf.size = 0;
-    /* Send the first FPLogin request, and see what happens. */
-    ret = afp_login(server, "DHCAST128", ai, ai_len, &rbuf);
+    ret = afp_login_initial(server, "DHCAST128", username, 1,
+                            ai, ai_len, &rbuf);
     free(ai);
     ai = NULL;
 

--- a/lib/uams_dhx2.c
+++ b/lib/uams_dhx2.c
@@ -53,21 +53,6 @@ int dhx2_login(struct afp_server *server, char *username, char *passwd)
     Ma = gcry_mpi_new(0);
     K = gcry_mpi_new(0);
     new_nonce = gcry_mpi_new(0);
-    /* The DHX2 Pascal username must end on an even AFP-packet boundary. */
-    ai_len = (int)strnlen(username, AFP_MAX_USERNAME_LEN) + 1;
-
-    if ((1 + 1 + (int)strnlen(server->using_version->av_name, UINT8_MAX) +
-            1 + (int)strlen("DHX2") + ai_len) & 1) {
-        ai_len++;
-    }
-
-    ai = calloc(1, ai_len);
-
-    if (ai == NULL) {
-        goto dhx2_noctx_fail;
-    }
-
-    copy_to_pascal(ai, username);
     /* Reply block will contain:
      *   Transaction ID (2 bytes, MSB)
      *   g (4 bytes, MSB)
@@ -86,9 +71,8 @@ int dhx2_login(struct afp_server *server, char *username, char *passwd)
 
     rbuf.size = 0;
     /* Send the initial request in the login sequence. */
-    ret = afp_login(server, "DHX2", ai, ai_len, &rbuf);
-    free(ai);
-    ai = NULL;
+    ret = afp_login_initial(server, "DHX2", username, 1,
+                            NULL, 0, &rbuf);
 
     if (ret != kFPAuthContinue) {
         goto dhx2_noctx_cleanup;

--- a/lib/uams_randnum.c
+++ b/lib/uams_randnum.c
@@ -212,16 +212,16 @@ int randnum_login(struct afp_server *server, char *username,
         assert("libgcrypt initialization failed");
     }
 
-    char *ai = NULL, *p;
+    char *p;
     unsigned char key_buffer[8];
-    int ai_len, ret;
+    int ret;
     const int randnum_len = 8;
     gcry_cipher_hd_t ctx;
     gcry_error_t ctxerror;
     struct afp_rx_buffer rbuf;
     unsigned short ID;
     log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                   "Starting Randnum Exchange authentication for user '%s'", username);
+                   "Starting Randnum Exchange authentication");
     rbuf.maxsize = sizeof(ID) + randnum_len;
     rbuf.data = calloc(1, rbuf.maxsize);
     p = rbuf.data;
@@ -233,22 +233,10 @@ int randnum_login(struct afp_server *server, char *username,
     }
 
     rbuf.size = 0;
-    ai_len = 1 + (int)strnlen(username, AFP_MAX_USERNAME_LEN);
-    ai = calloc(1, ai_len);
-
-    if (ai == NULL) {
-        log_for_client(NULL, AFPFSD, LOG_ERR,
-                       "Randnum: Failed to allocate authinfo buffer");
-        goto randnum_noctx_fail;
-    }
-
-    copy_to_pascal(ai, username);
-    /* Send the initial FPLogin request to the server. */
-    ret = afp_login(server, "Randnum Exchange", ai, ai_len, &rbuf);
-    free(ai);
-    ai = NULL;
+    ret = afp_login_initial(server, "Randnum Exchange", username, 0,
+                            NULL, 0, &rbuf);
     log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                   "Randnum: FPLogin returned %d (expected %d for kFPAuthContinue), rbuf.size=%u",
+                   "Randnum: initial login returned %d (expected %d for kFPAuthContinue), rbuf.size=%u",
                    ret, kFPAuthContinue, rbuf.size);
 
     if (ret != kFPAuthContinue) {
@@ -325,15 +313,14 @@ randnum_noctx_cleanup:
 
     if (ret == kFPNoErr) {
         log_for_client(NULL, AFPFSD, LOG_INFO,
-                       "Randnum Exchange authentication succeeded for user '%s'", username);
+                       "Randnum Exchange authentication succeeded");
     } else {
         log_for_client(NULL, AFPFSD, LOG_WARNING,
-                       "Randnum Exchange authentication failed for user '%s' with code %d",
-                       username, ret);
+                       "Randnum Exchange authentication failed with code %d",
+                       ret);
     }
 
     free(rbuf.data);
-    free(ai);
     return ret;
 }
 
@@ -387,7 +374,7 @@ int randnum2_login(struct afp_server *server, char *username,
     struct afp_rx_buffer rbuf;
     unsigned short ID;
     log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                   "Starting 2-Way Randnum Exchange authentication for user '%s'", username);
+                   "Starting 2-Way Randnum Exchange authentication");
     rbuf.maxsize = sizeof(ID) + 8;
     rbuf.data = calloc(1, rbuf.maxsize);
     p = rbuf.data;
@@ -399,22 +386,10 @@ int randnum2_login(struct afp_server *server, char *username,
     }
 
     rbuf.size = 0;
-    ai_len = 1 + (int)strnlen(username, AFP_MAX_USERNAME_LEN);
-    ai = calloc(1, ai_len);
-
-    if (ai == NULL) {
-        log_for_client(NULL, AFPFSD, LOG_ERR,
-                       "Randnum2: Failed to allocate authinfo buffer");
-        goto randnum2_noctx_fail;
-    }
-
-    copy_to_pascal(ai, username);
-    /* Send the initial FPLogin request to the server. */
-    ret = afp_login(server, "2-Way Randnum Exchange", ai, ai_len, &rbuf);
-    free(ai);
-    ai = NULL;
+    ret = afp_login_initial(server, "2-Way Randnum Exchange", username, 0,
+                            NULL, 0, &rbuf);
     log_for_client(NULL, AFPFSD, LOG_DEBUG,
-                   "Randnum2: FPLogin returned %d (expected %d for kFPAuthContinue), rbuf.size=%u",
+                   "Randnum2: initial login returned %d (expected %d for kFPAuthContinue), rbuf.size=%u",
                    ret, kFPAuthContinue, rbuf.size);
 
     if (ret != kFPAuthContinue) {
@@ -566,11 +541,11 @@ randnum2_noctx_cleanup:
 
     if (ret == kFPNoErr) {
         log_for_client(NULL, AFPFSD, LOG_INFO,
-                       "2-Way Randnum Exchange authentication succeeded for user '%s'", username);
+                       "2-Way Randnum Exchange authentication succeeded");
     } else {
         log_for_client(NULL, AFPFSD, LOG_WARNING,
-                       "2-Way Randnum Exchange authentication failed for user '%s' with code %d",
-                       username, ret);
+                       "2-Way Randnum Exchange authentication failed with code %d",
+                       ret);
     }
 
     free(rbuf.data);

--- a/lib/uams_srp.c
+++ b/lib/uams_srp.c
@@ -144,6 +144,13 @@ int srp_login(struct afp_server *server, char *username, char *passwd)
     gcry_mpi_t x = NULL, v = NULL, k = NULL, u = NULL;
     gcry_mpi_t S = NULL, kv = NULL, tmp = NULL;
 
+    if (server == NULL || server->using_version == NULL
+            || server->using_version->av_number < 30) {
+        log_for_client(NULL, AFPFSD, LOG_WARNING,
+                       "SRP requires AFP 3.x FPLoginExt");
+        return kFPCallNotSupported;
+    }
+
     if (!gcry_check_version(UAM_NEED_LIBGCRYPT_VERSION)) {
         log_for_client(NULL, AFPFSD, LOG_ERR,
                        "SRP: libgcrypt version check failed");
@@ -170,8 +177,8 @@ int srp_login(struct afp_server *server, char *username, char *passwd)
     }
 
     rbuf.size = 0;
-    ret = afp_loginext(server, "SRP", username,
-                       (char *)init_marker, sizeof(init_marker), &rbuf);
+    ret = afp_login_initial(server, "SRP", username, 0,
+                            init_marker, sizeof(init_marker), &rbuf);
 
     if (ret != kFPAuthContinue) {
         if (ret == SRP_AUTH_FAILURE) {

--- a/lib/utils.c
+++ b/lib/utils.c
@@ -65,6 +65,131 @@ int afp_parse_version(const char *text, int *version_out)
     return 0;
 }
 
+int afp_validate_utf8_name(const char *name, size_t max_characters,
+                           size_t *byte_len_out)
+{
+    const uint8_t *p;
+    const uint8_t *end;
+    size_t byte_len;
+    size_t characters = 0;
+
+    if (name == NULL) {
+        return -EINVAL;
+    }
+
+    byte_len = strnlen(name, AFPC_MAX_NAME_BYTES);
+
+    if (byte_len == AFPC_MAX_NAME_BYTES || byte_len > UINT16_MAX) {
+        return -ENAMETOOLONG;
+    }
+
+    p = (const uint8_t *)name;
+    end = p + byte_len;
+
+    while (p < end) {
+        size_t sequence_len;
+        size_t remaining = (size_t)(end - p);
+
+        if (*p <= 0x7f) {
+            sequence_len = 1;
+        } else if (*p >= 0xc2 && *p <= 0xdf) {
+            sequence_len = 2;
+
+            if (remaining < sequence_len || (p[1] & 0xc0) != 0x80) {
+                return -EILSEQ;
+            }
+        } else if (*p == 0xe0) {
+            sequence_len = 3;
+
+            if (remaining < sequence_len || p[1] < 0xa0 || p[1] > 0xbf
+                    || (p[2] & 0xc0) != 0x80) {
+                return -EILSEQ;
+            }
+        } else if ((*p >= 0xe1 && *p <= 0xec)
+                   || (*p >= 0xee && *p <= 0xef)) {
+            sequence_len = 3;
+
+            if (remaining < sequence_len || (p[1] & 0xc0) != 0x80
+                    || (p[2] & 0xc0) != 0x80) {
+                return -EILSEQ;
+            }
+        } else if (*p == 0xed) {
+            sequence_len = 3;
+
+            if (remaining < sequence_len || p[1] < 0x80 || p[1] > 0x9f
+                    || (p[2] & 0xc0) != 0x80) {
+                return -EILSEQ;
+            }
+        } else if (*p == 0xf0) {
+            sequence_len = 4;
+
+            if (remaining < sequence_len || p[1] < 0x90 || p[1] > 0xbf
+                    || (p[2] & 0xc0) != 0x80 || (p[3] & 0xc0) != 0x80) {
+                return -EILSEQ;
+            }
+        } else if (*p >= 0xf1 && *p <= 0xf3) {
+            sequence_len = 4;
+
+            if (remaining < sequence_len || (p[1] & 0xc0) != 0x80
+                    || (p[2] & 0xc0) != 0x80 || (p[3] & 0xc0) != 0x80) {
+                return -EILSEQ;
+            }
+        } else if (*p == 0xf4) {
+            sequence_len = 4;
+
+            if (remaining < sequence_len || p[1] < 0x80 || p[1] > 0x8f
+                    || (p[2] & 0xc0) != 0x80 || (p[3] & 0xc0) != 0x80) {
+                return -EILSEQ;
+            }
+        } else {
+            return -EILSEQ;
+        }
+
+        characters++;
+
+        if (characters > max_characters) {
+            return -ENAMETOOLONG;
+        }
+
+        p += sequence_len;
+    }
+
+    if (byte_len_out != NULL) {
+        *byte_len_out = byte_len;
+    }
+
+    return 0;
+}
+
+int afp_validate_username(const char *username, size_t *byte_len_out)
+{
+    return afp_validate_utf8_name(username, AFPC_MAX_USERNAME_CHARS,
+                                  byte_len_out);
+}
+
+int afp_validate_legacy_username(const char *username,
+                                 size_t *byte_len_out)
+{
+    size_t byte_len;
+
+    if (username == NULL) {
+        return -EINVAL;
+    }
+
+    byte_len = strnlen(username, AFPC_MAX_USERNAME_LEN);
+
+    if (byte_len == AFPC_MAX_USERNAME_LEN
+            || byte_len > AFP_LEGACY_MAX_USERNAME_BYTES) {
+        return -ENAMETOOLONG;
+    }
+
+    if (byte_len_out != NULL) {
+        *byte_len_out = byte_len;
+    }
+
+    return 0;
+}
+
 unsigned short utf8_to_string(char * dest, char * buf, unsigned short maxlen)
 {
     return copy_from_pascal_two(dest, buf + 4, maxlen);
@@ -240,7 +365,7 @@ void copy_path(
         }
 
         header_unicode->type = encoding;
-        header_unicode->hint = htonl(0x08000103);
+        header_unicode->hint = htonl(AFP_TEXT_ENCODING_UTF8);
         header_unicode->unicode = htons((uint16_t)len);
         memcpy(dest + sizeof(struct afp_path_header_unicode), pathname, len);
         break;

--- a/lib/utils.h
+++ b/lib/utils.h
@@ -54,6 +54,19 @@ void sanitize_text(const char *text, char *sanitized, size_t size);
 /* Parse an AFP version such as "3.1" or "31" into its numeric form. */
 int afp_parse_version(const char *text, int *version_out);
 
+/* Validate a NUL-terminated AFP 3.x username and optionally return its UTF-8
+ * byte length. */
+int afp_validate_username(const char *username, size_t *byte_len_out);
+
+/* Validate a username for the one-byte-length FPLogin representation.  AFP
+ * 2.x names are byte strings, so this deliberately does not impose UTF-8. */
+int afp_validate_legacy_username(const char *username,
+                                 size_t *byte_len_out);
+
+/* Internal validator shared by AFPName serializers. */
+int afp_validate_utf8_name(const char *name, size_t max_characters,
+                           size_t *byte_len_out);
+
 /* Log level conversion functions */
 const char *log_level_to_string(int level);
 int string_to_log_level(const char *str, int *level_out);

--- a/test/meson.build
+++ b/test/meson.build
@@ -223,6 +223,23 @@ test(
     verbose: true,
 )
 
+login_packets_test = executable(
+    'test_login_packets',
+    sources: ['test_login_packets.c'],
+    include_directories: incdir,
+    link_with: libafpclient,
+    dependencies: root_dependencies,
+    c_args: cflags,
+)
+
+test(
+    'AFP login packet construction',
+    login_packets_test,
+    args: ['--tap'],
+    protocol: 'tap',
+    verbose: true,
+)
+
 log_test = executable(
     'test_log',
     sources: ['test_log.c'],

--- a/test/test_filename_validation.c
+++ b/test/test_filename_validation.c
@@ -69,6 +69,8 @@ int main(int argc, char **argv)
     char legacy_long_source[UINT8_MAX + 2U];
     char legacy_long_name[UINT8_MAX + 2U];
     char *long_url;
+    char *username_url;
+    char too_many_username_chars[AFPC_MAX_USERNAME_CHARS + 2U];
     struct afpc_url parsed_url;
     struct afpc_path owned_path = { 0 };
     struct afpc_path copied_path = { 0 };
@@ -87,9 +89,12 @@ int main(int argc, char **argv)
     supplementary_name_255 = supplementary_utf8_name(AFP_MAX_UTF8_NAME_CHARS);
     converted_supplementary_name = malloc(AFPC_MAX_NAME_BYTES + 1U);
     long_url = malloc(sizeof("afp://server/volume/") + long_path_len);
+    username_url = malloc(sizeof("afp://@server")
+                          + AFPC_MAX_USERNAME_BYTES);
     CHECK(name_255 != NULL && name_256 != NULL && supplementary_name_255 != NULL
           && converted_supplementary_name != NULL);
     CHECK(long_url != NULL);
+    CHECK(username_url != NULL);
     CHECK(afpc_path_set(&owned_path, "/parent", AFPC_MAX_UTF8_PATH_BYTES) == 0);
     CHECK(afpc_path_join(&copied_path, owned_path.data, "child",
                          AFPC_MAX_UTF8_PATH_BYTES) == 0);
@@ -131,10 +136,6 @@ int main(int argc, char **argv)
     CHECK((unsigned char)utf8_path[6] == 3);
     CHECK((unsigned char)legacy_path[0] == kFPLongName);
     CHECK((unsigned char)legacy_path[1] == 3);
-    free(name_255);
-    free(name_256);
-    free(supplementary_name_255);
-    free(converted_supplementary_name);
 
     if (long_url) {
         strcpy(long_url, "afp://server/volume/");
@@ -146,7 +147,38 @@ int main(int argc, char **argv)
         afpc_path_clear(&parsed_url.path);
     }
 
+    if (username_url && supplementary_name_255) {
+        size_t username_len = strlen(supplementary_name_255 + 1);
+        memcpy(username_url, "afp://", strlen("afp://"));
+        memcpy(username_url + strlen("afp://"), supplementary_name_255 + 1,
+               username_len);
+        strcpy(username_url + strlen("afp://") + username_len, "@server");
+        afp_default_url(&parsed_url);
+        CHECK(afp_parse_url_quiet(&parsed_url, username_url) == 0);
+        CHECK(memcmp(parsed_url.username, supplementary_name_255 + 1,
+                     username_len + 1U) == 0);
+        afpc_path_clear(&parsed_url.path);
+    }
+
+    memset(too_many_username_chars, 'u',
+           sizeof(too_many_username_chars) - 1U);
+    too_many_username_chars[sizeof(too_many_username_chars) - 1U] = '\0';
+
+    if (username_url) {
+        snprintf(username_url,
+                 sizeof("afp://@server") + AFPC_MAX_USERNAME_BYTES,
+                 "afp://%s@server", too_many_username_chars);
+        afp_default_url(&parsed_url);
+        CHECK(afp_parse_url_quiet(&parsed_url, username_url) != 0);
+        afpc_path_clear(&parsed_url.path);
+    }
+
     free(long_url);
+    free(username_url);
+    free(name_255);
+    free(name_256);
+    free(supplementary_name_255);
+    free(converted_supplementary_name);
     afpc_path_clear(&owned_path);
     afpc_path_clear(&copied_path);
     return test_tap_finish();

--- a/test/test_login_packets.c
+++ b/test/test_login_packets.c
@@ -1,0 +1,325 @@
+#include <errno.h>
+#include <limits.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "lib/proto_login.h"
+#include "lib/utils.h"
+#include "tap.h"
+
+static void check_payload(const char *username,
+                          const char *directory_domain,
+                          const uint8_t *authinfo,
+                          size_t authinfo_len,
+                          const uint8_t *expected,
+                          size_t expected_len)
+{
+    uint8_t *payload = NULL;
+    size_t payload_len = 0;
+    CHECK(afp_loginext_build_payload("AFP3.4", "SRP", username,
+                                     directory_domain, authinfo, authinfo_len,
+                                     &payload, &payload_len) == 0);
+    CHECK(payload != NULL);
+    CHECK(payload_len == expected_len);
+    CHECK(memcmp(payload, expected, expected_len) == 0);
+    afp_loginext_payload_free(payload, payload_len);
+}
+
+static void check_rejected(const char *afp_version,
+                           const char *uam_name,
+                           const char *username,
+                           const char *directory_domain,
+                           const void *authinfo,
+                           size_t authinfo_len,
+                           int expected_error)
+{
+    uint8_t marker = 0;
+    uint8_t *payload = &marker;
+    size_t payload_len = 99;
+    CHECK(afp_loginext_build_payload(afp_version, uam_name, username,
+                                     directory_domain, authinfo, authinfo_len,
+                                     &payload, &payload_len) == expected_error);
+    CHECK(payload == NULL);
+    CHECK(payload_len == 0);
+}
+
+static void check_initial(int version_number, const char *version,
+                          const char *uam, const char *username, int pad,
+                          const uint8_t *authinfo, size_t authinfo_len,
+                          const uint8_t *expected, size_t expected_len)
+{
+    uint8_t *payload = NULL;
+    size_t payload_len = 0;
+    CHECK(afp_login_initial_build_payload(version_number, version, uam,
+                                          username, pad, authinfo,
+                                          authinfo_len, &payload,
+                                          &payload_len) == 0);
+    CHECK(payload != NULL);
+    CHECK(payload_len == expected_len);
+
+    for (size_t i = 0; i < expected_len; i++) {
+        if (payload[i] != expected[i]) {
+            fprintf(stderr, "selected payload mismatch at %zu: got %02x, expected %02x\n",
+                    i, payload[i], expected[i]);
+            break;
+        }
+    }
+
+    CHECK(memcmp(payload, expected, expected_len) == 0);
+    afp_loginext_payload_free(payload, payload_len);
+}
+
+int main(int argc, char **argv)
+{
+    static const uint8_t ascii_authinfo[] = { 0xaa, 0xbb };
+    static const uint8_t ascii_expected[] = {
+        0x3f, 0x00, 0x00, 0x00,
+        0x06, 'A', 'F', 'P', '3', '.', '4',
+        0x03, 'S', 'R', 'P',
+        0x03, 0x08, 0x00, 0x01, 0x03, 0x00, 0x03, 'b', 'o', 'b',
+        0x03, 0x08, 0x00, 0x01, 0x03, 0x00, 0x00,
+        0xaa, 0xbb,
+    };
+    static const uint8_t unicode_authinfo[] = { 0xcc };
+    static const uint8_t unicode_expected[] = {
+        0x3f, 0x00, 0x00, 0x00,
+        0x06, 'A', 'F', 'P', '3', '.', '4',
+        0x03, 'S', 'R', 'P',
+        0x03, 0x08, 0x00, 0x01, 0x03, 0x00, 0x02, 0xc3, 0xa9,
+        0x03, 0x08, 0x00, 0x01, 0x03, 0x00, 0x00,
+        0x00,
+        0xcc,
+    };
+    static const uint8_t domain_expected[] = {
+        0x3f, 0x00, 0x00, 0x00,
+        0x06, 'A', 'F', 'P', '3', '.', '4',
+        0x03, 'S', 'R', 'P',
+        0x03, 0x08, 0x00, 0x01, 0x03, 0x00, 0x01, 'a',
+        0x03, 0x08, 0x00, 0x01, 0x03, 0x00, 0x03, 0xe5, 0x9f, 0x9f,
+        0x00,
+    };
+    static const uint8_t password[] = {
+        'p', 'w', 0, 0, 0, 0, 0, 0,
+    };
+    static const uint8_t ma[] = {
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+        0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+    };
+    static const uint8_t srp_marker[] = { 0x00, 0x01 };
+    static const uint8_t guest_legacy[] = {
+        0x12, 0x06, 'A', 'F', 'P', '2', '.', '2',
+        0x0f, 'N', 'o', ' ', 'U', 's', 'e', 'r', ' ',
+        'A', 'u', 't', 'h', 'e', 'n', 't',
+    };
+    static const uint8_t guest_ext[] = {
+        0x3f, 0, 0, 0, 0x06, 'A', 'F', 'P', '3', '.', '4',
+        0x0f, 'N', 'o', ' ', 'U', 's', 'e', 'r', ' ',
+        'A', 'u', 't', 'h', 'e', 'n', 't',
+        0x03, 0x08, 0x00, 0x01, 0x03, 0x00, 0x00,
+        0x03, 0x08, 0x00, 0x01, 0x03, 0x00, 0x00, 0x00,
+    };
+    static const uint8_t clear_legacy[] = {
+        0x12, 0x06, 'A', 'F', 'P', '2', '.', '2',
+        0x10, 'C', 'l', 'e', 'a', 'r', 't', 'x', 't', ' ',
+        'P', 'a', 's', 's', 'w', 'r', 'd',
+        0x03, 'b', 'o', 'b', 0x00,
+        'p', 'w', 0, 0, 0, 0, 0, 0,
+    };
+    static const uint8_t clear_legacy_macroman[] = {
+        0x12, 0x06, 'A', 'F', 'P', '2', '.', '2',
+        0x10, 'C', 'l', 'e', 'a', 'r', 't', 'x', 't', ' ',
+        'P', 'a', 's', 's', 'w', 'r', 'd',
+        0x01, 0x8e, 0x00,
+        'p', 'w', 0, 0, 0, 0, 0, 0,
+    };
+    static const uint8_t clear_ext[] = {
+        0x3f, 0, 0, 0, 0x06, 'A', 'F', 'P', '3', '.', '4',
+        0x10, 'C', 'l', 'e', 'a', 'r', 't', 'x', 't', ' ',
+        'P', 'a', 's', 's', 'w', 'r', 'd',
+        0x03, 0x08, 0x00, 0x01, 0x03, 0x00, 0x03, 'b', 'o', 'b',
+        0x03, 0x08, 0x00, 0x01, 0x03, 0x00, 0x00, 0x00,
+        'p', 'w', 0, 0, 0, 0, 0, 0,
+    };
+    static const uint8_t clear_ext_unicode[] = {
+        0x3f, 0, 0, 0, 0x06, 'A', 'F', 'P', '3', '.', '4',
+        0x10, 'C', 'l', 'e', 'a', 'r', 't', 'x', 't', ' ',
+        'P', 'a', 's', 's', 'w', 'r', 'd',
+        0x03, 0x08, 0x00, 0x01, 0x03, 0x00, 0x02, 0xc3, 0xa9,
+        0x03, 0x08, 0x00, 0x01, 0x03, 0x00, 0x00,
+        'p', 'w', 0, 0, 0, 0, 0, 0,
+    };
+    static const uint8_t rand_legacy[] = {
+        0x12, 0x06, 'A', 'F', 'P', '2', '.', '2',
+        0x10, 'R', 'a', 'n', 'd', 'n', 'u', 'm', ' ',
+        'E', 'x', 'c', 'h', 'a', 'n', 'g', 'e',
+        0x03, 'b', 'o', 'b',
+    };
+    static const uint8_t rand_ext[] = {
+        0x3f, 0, 0, 0, 0x06, 'A', 'F', 'P', '3', '.', '4',
+        0x10, 'R', 'a', 'n', 'd', 'n', 'u', 'm', ' ',
+        'E', 'x', 'c', 'h', 'a', 'n', 'g', 'e',
+        0x03, 0x08, 0x00, 0x01, 0x03, 0x00, 0x03, 'b', 'o', 'b',
+        0x03, 0x08, 0x00, 0x01, 0x03, 0x00, 0x00, 0x00,
+    };
+    static const uint8_t rand2_legacy[] = {
+        0x12, 0x06, 'A', 'F', 'P', '2', '.', '2',
+        0x16, '2', '-', 'W', 'a', 'y', ' ', 'R', 'a', 'n', 'd', 'n', 'u',
+        'm', ' ', 'E', 'x', 'c', 'h', 'a', 'n', 'g', 'e',
+        0x03, 'b', 'o', 'b',
+    };
+    static const uint8_t rand2_ext[] = {
+        0x3f, 0, 0, 0, 0x06, 'A', 'F', 'P', '3', '.', '4',
+        0x16, '2', '-', 'W', 'a', 'y', ' ', 'R', 'a', 'n', 'd', 'n', 'u',
+        'm', ' ', 'E', 'x', 'c', 'h', 'a', 'n', 'g', 'e',
+        0x03, 0x08, 0x00, 0x01, 0x03, 0x00, 0x03, 'b', 'o', 'b',
+        0x03, 0x08, 0x00, 0x01, 0x03, 0x00, 0x00, 0x00,
+    };
+    static const uint8_t dhx_legacy[] = {
+        0x12, 0x06, 'A', 'F', 'P', '2', '.', '2',
+        0x09, 'D', 'H', 'C', 'A', 'S', 'T', '1', '2', '8',
+        0x03, 'b', 'o', 'b',
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+        0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+    };
+    static const uint8_t dhx_ext[] = {
+        0x3f, 0, 0, 0, 0x06, 'A', 'F', 'P', '3', '.', '4',
+        0x09, 'D', 'H', 'C', 'A', 'S', 'T', '1', '2', '8',
+        0x03, 0x08, 0x00, 0x01, 0x03, 0x00, 0x03, 'b', 'o', 'b',
+        0x03, 0x08, 0x00, 0x01, 0x03, 0x00, 0x00,
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+        0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+    };
+    static const uint8_t dhx2_legacy[] = {
+        0x12, 0x06, 'A', 'F', 'P', '2', '.', '2',
+        0x04, 'D', 'H', 'X', '2', 0x03, 'b', 'o', 'b', 0x00,
+    };
+    static const uint8_t dhx2_ext[] = {
+        0x3f, 0, 0, 0, 0x06, 'A', 'F', 'P', '3', '.', '4',
+        0x04, 'D', 'H', 'X', '2',
+        0x03, 0x08, 0x00, 0x01, 0x03, 0x00, 0x03, 'b', 'o', 'b',
+        0x03, 0x08, 0x00, 0x01, 0x03, 0x00, 0x00, 0x00,
+    };
+    static const uint8_t srp_ext[] = {
+        0x3f, 0, 0, 0, 0x06, 'A', 'F', 'P', '3', '.', '4',
+        0x03, 'S', 'R', 'P',
+        0x03, 0x08, 0x00, 0x01, 0x03, 0x00, 0x03, 'b', 'o', 'b',
+        0x03, 0x08, 0x00, 0x01, 0x03, 0x00, 0x00,
+        0x00, 0x01,
+    };
+    char too_many_characters[257];
+    char too_long_pascal[257];
+    char max_username[(255U * 4U) + 1U];
+    char legacy_max[AFP_LEGACY_MAX_USERNAME_BYTES + 1U];
+    char legacy_too_long[AFP_LEGACY_MAX_USERNAME_BYTES + 2U];
+    char max_username_url[sizeof("afp://@server")
+                          + AFPC_MAX_USERNAME_BYTES];
+    struct afpc_url parsed_url;
+    uint8_t *payload = NULL;
+    size_t payload_len = 0;
+    uint8_t auth_marker = 0;
+    test_tap_init(argc, argv);
+    check_initial(22, "AFP2.2", "No User Authent", NULL, 0, NULL, 0,
+                  guest_legacy, sizeof(guest_legacy));
+    check_initial(34, "AFP3.4", "No User Authent", NULL, 0, NULL, 0,
+                  guest_ext, sizeof(guest_ext));
+    check_initial(22, "AFP2.2", "Cleartxt Passwrd", "bob", 1,
+                  password, sizeof(password), clear_legacy,
+                  sizeof(clear_legacy));
+    check_initial(22, "AFP2.2", "Cleartxt Passwrd", "\xc3\xa9", 1,
+                  password, sizeof(password), clear_legacy_macroman,
+                  sizeof(clear_legacy_macroman));
+    check_initial(34, "AFP3.4", "Cleartxt Passwrd", "bob", 1,
+                  password, sizeof(password), clear_ext, sizeof(clear_ext));
+    check_initial(34, "AFP3.4", "Cleartxt Passwrd", "\xc3\xa9", 1,
+                  password, sizeof(password), clear_ext_unicode,
+                  sizeof(clear_ext_unicode));
+    check_initial(22, "AFP2.2", "Randnum Exchange", "bob", 0,
+                  NULL, 0, rand_legacy, sizeof(rand_legacy));
+    check_initial(34, "AFP3.4", "Randnum Exchange", "bob", 0,
+                  NULL, 0, rand_ext, sizeof(rand_ext));
+    check_initial(22, "AFP2.2", "2-Way Randnum Exchange", "bob", 0,
+                  NULL, 0, rand2_legacy, sizeof(rand2_legacy));
+    check_initial(34, "AFP3.4", "2-Way Randnum Exchange", "bob", 0,
+                  NULL, 0, rand2_ext, sizeof(rand2_ext));
+    check_initial(22, "AFP2.2", "DHCAST128", "bob", 1,
+                  ma, sizeof(ma), dhx_legacy, sizeof(dhx_legacy));
+    check_initial(34, "AFP3.4", "DHCAST128", "bob", 1,
+                  ma, sizeof(ma), dhx_ext, sizeof(dhx_ext));
+    check_initial(22, "AFP2.2", "DHX2", "bob", 1,
+                  NULL, 0, dhx2_legacy, sizeof(dhx2_legacy));
+    check_initial(34, "AFP3.4", "DHX2", "bob", 1,
+                  NULL, 0, dhx2_ext, sizeof(dhx2_ext));
+    check_initial(34, "AFP3.4", "SRP", "bob", 0,
+                  srp_marker, sizeof(srp_marker), srp_ext, sizeof(srp_ext));
+    /* Empty type-3 domain ends even: UserAuthInfo follows immediately. */
+    check_payload("bob", "", ascii_authinfo, sizeof(ascii_authinfo),
+                  ascii_expected, sizeof(ascii_expected));
+    /* The two-byte UTF-8 name makes the domain end odd: one pad is present. */
+    check_payload("\xc3\xa9", "", unicode_authinfo,
+                  sizeof(unicode_authinfo), unicode_expected,
+                  sizeof(unicode_expected));
+    check_payload("a", "\xe5\x9f\x9f", NULL, 0,
+                  domain_expected, sizeof(domain_expected));
+
+    for (size_t i = 0; i < 255U; i++) {
+        max_username[(i * 4U) + 0U] = (char)0xf0;
+        max_username[(i * 4U) + 1U] = (char)0xa0;
+        max_username[(i * 4U) + 2U] = (char)0x80;
+        max_username[(i * 4U) + 3U] = (char)0x80;
+    }
+
+    max_username[255U * 4U] = '\0';
+    CHECK(sizeof(((struct afpc_url *)0)->username)
+          == AFPC_MAX_USERNAME_LEN);
+    CHECK(afp_validate_username(max_username, NULL) == 0);
+    CHECK(snprintf(max_username_url, sizeof(max_username_url),
+                   "afp://%s@server", max_username)
+          < (int)sizeof(max_username_url));
+    afp_default_url(&parsed_url);
+    CHECK(afp_parse_url_quiet(&parsed_url, max_username_url) == 0);
+    CHECK(memcmp(parsed_url.username, max_username,
+                 sizeof(max_username)) == 0);
+    CHECK(afp_loginext_build_payload("AFP3.4", "SRP", max_username, "",
+                                     NULL, 0, &payload, &payload_len) == 0);
+    CHECK(payload_len == 1050U);
+    CHECK(payload[20] == 0x03 && payload[21] == 0xfc);
+    afp_loginext_payload_free(payload, payload_len);
+    payload = NULL;
+    payload_len = 0;
+    CHECK(afp_loginext_build_payload("AFP3.4", "SRP",
+                                     parsed_url.username, "", NULL, 0,
+                                     &payload, &payload_len) == 0);
+    CHECK(payload_len == 1050U);
+    afp_loginext_payload_free(payload, payload_len);
+    afpc_path_clear(&parsed_url.path);
+    memset(legacy_max, 'l', sizeof(legacy_max) - 1U);
+    legacy_max[sizeof(legacy_max) - 1U] = '\0';
+    memset(legacy_too_long, 'l', sizeof(legacy_too_long) - 1U);
+    legacy_too_long[sizeof(legacy_too_long) - 1U] = '\0';
+    CHECK(afp_validate_legacy_username(legacy_max, NULL) == 0);
+    CHECK(afp_validate_legacy_username(legacy_too_long, NULL)
+          == -ENAMETOOLONG);
+    memset(too_many_characters, 'x', sizeof(too_many_characters) - 1U);
+    too_many_characters[sizeof(too_many_characters) - 1U] = '\0';
+    memset(too_long_pascal, 'y', sizeof(too_long_pascal) - 1U);
+    too_long_pascal[sizeof(too_long_pascal) - 1U] = '\0';
+    check_rejected("AFP3.4", "SRP", "\xc0\xaf", "", NULL, 0, -EILSEQ);
+    check_rejected("AFP3.4", "SRP", "\xed\xa0\x80", "", NULL, 0,
+                   -EILSEQ);
+    check_rejected("AFP3.4", "SRP", "\xf4\x90\x80\x80", "", NULL, 0,
+                   -EILSEQ);
+    check_rejected("AFP3.4", "SRP", "\xe2\x82", "", NULL, 0, -EILSEQ);
+    check_rejected("AFP3.4", "SRP", too_many_characters, "", NULL, 0,
+                   -ENAMETOOLONG);
+    check_rejected("AFP3.4", "SRP", "user", too_many_characters, NULL, 0,
+                   -ENAMETOOLONG);
+    check_rejected(too_long_pascal, "SRP", "user", "", NULL, 0,
+                   -EOVERFLOW);
+    check_rejected("AFP3.4", too_long_pascal, "user", "", NULL, 0,
+                   -EOVERFLOW);
+    check_rejected("AFP3.4", "SRP", "user", "", NULL, 1, -EINVAL);
+    check_rejected("AFP3.4", "SRP", "user", "", &auth_marker,
+                   (size_t)INT_MAX, -EOVERFLOW);
+    return test_tap_finish();
+}


### PR DESCRIPTION
Select FPLoginExt for every AFP 3.x initial UAM exchange while preserving FPLogin for AFP 2.x and FPLoginCont for continuation exchanges. Serialize AFPName usernames correctly, validate their limits, and cover the resulting packets with byte-exact tests.